### PR TITLE
Fix FileListBuilding function

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,21 +59,10 @@ func main() {
 	// Build a file list form given path(s)
 	log.Info("building file list...")
 
-	var fileList []string
+	fileList, err := utils.BuildFileList(commands.Upload.Path)
 
-	for _, path := range commands.Upload.Path {
-		if utils.IsDir(path) {
-			log.Info("searching " + " for files...")
-			files, err := utils.FilePathWalkDir(path)
-			if err != nil {
-				log.Error("error getting files from dir", 1)
-			}
-			for _, s := range files {
-				fileList = append(fileList, s)
-			}
-		} else {
-			fileList = append(fileList, path)
-		}
+	if err != nil {
+		log.Error(" error building file list", 1)
 	}
 
 	log.Info("File list built..")

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -1,31 +1,12 @@
 package utils
 
 import (
-	"io/fs"
+	"github.com/bugsnag/bugsnag-cli/pkg/log"
 	"os"
 	"path/filepath"
 )
 
-func walk(s string, d fs.DirEntry, err error) (string, error) {
-	if err != nil {
-		return "", err
-	}
-	if ! d.IsDir() {
-		println(s)
-		return s, nil
-	}
-	return "", nil
-}
-
-//FindFilesInDir - Finds files in a given directory
-func FindFilesInDir(directory string) ([]string, error) {
-	files, err := FilePathWalkDir(directory)
-	if err != nil {
-		return nil, err
-	}
-	return files, nil
-}
-
+// FilePathWalkDir - finds files within a given directory
 func FilePathWalkDir(root string) ([]string, error) {
 	var files []string
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
@@ -37,10 +18,31 @@ func FilePathWalkDir(root string) ([]string, error) {
 	return files, err
 }
 
-
 // IsDir - Checks if a provided path is a directory or not
 func IsDir(path string) bool{
 	pathInfo, err := os.Stat(path)
 
-	return err != nil && pathInfo.IsDir()
+	return err == nil && pathInfo.IsDir()
+}
+
+// BuildFileList - Builds a list of files from a given path(s)
+func BuildFileList(paths []string) ([]string, error) {
+	var fileList []string
+
+	for _, path := range paths {
+		if IsDir(path) {
+			log.Info("searching " + path + " for files...")
+			files, err := FilePathWalkDir(path)
+			if err != nil {
+				return nil, err
+			}
+			for _, s := range files {
+				fileList = append(fileList, s)
+			}
+		} else {
+			fileList = append(fileList, path)
+		}
+	}
+
+	return fileList, nil
 }


### PR DESCRIPTION
There was an issue with the `isDir` function returning `false` even if the path(s) was a directory. I've fixed this by adjusting the return part of the function. I've also moved the file list building to the `utils` package to keep things clean.