### PR TITLE
upload-api-root-url cannot contain a port number

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,7 +41,11 @@ func main() {
 	}
 
 	// Build connection URI
-	endpoint := utils.BuildEndpointUrl(commands.UploadAPIRootUrl, commands.Port)
+	endpoint, err := utils.BuildEndpointUrl(commands.UploadAPIRootUrl, commands.Port)
+
+	if err != nil {
+		log.Error("building upload url: "+err.Error(), 1)
+	}
 
 	log.Info("Uploading files to: " + endpoint)
 

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 	endpoint, err := utils.BuildEndpointUrl(commands.UploadAPIRootUrl, commands.Port)
 
 	if err != nil {
-		log.Error("building upload url: "+err.Error(), 1)
+		log.Error("Failed to build upload url: "+err.Error(), 1)
 	}
 
 	log.Info("Uploading files to: " + endpoint)

--- a/pkg/utils/endpoint-url.go
+++ b/pkg/utils/endpoint-url.go
@@ -20,5 +20,5 @@ func BuildEndpointUrl(uri string, port int) (string, error) {
 		return fmt.Sprintf("%s:%d", baseUrl, port), nil
 	}
 
-	return "", nil
+	return baseUrl.String(), nil
 }

--- a/pkg/utils/endpoint-url.go
+++ b/pkg/utils/endpoint-url.go
@@ -9,7 +9,7 @@ func BuildEndpointUrl(uri string, port int) (string, error) {
 	baseUrl, err := url.Parse(uri)
 
 	if err != nil {
-		return "", err
+		return baseUrl.String(), err
 	}
 
 	if baseUrl.Port() != "" {

--- a/pkg/utils/endpoint-url.go
+++ b/pkg/utils/endpoint-url.go
@@ -1,20 +1,24 @@
 package utils
 
-import "fmt"
+import (
+	"fmt"
+	"net/url"
+)
 
-func BuildEndpointUrl(url string, port int) string {
+func BuildEndpointUrl(uri string, port int) (string, error) {
+	baseUrl, err := url.Parse(uri)
 
-	var baseUrl string
+	if err != nil {
+		return "", err
+	}
 
-	if url == "" {
-		baseUrl = "https://upload.bugsnag.com"
-	} else {
-		baseUrl = url
+	if baseUrl.Port() != "" {
+		return baseUrl.String(), nil
 	}
 
 	if port != 0 {
-		return fmt.Sprintf("%s:%d", baseUrl, port)
+		return fmt.Sprintf("%s:%d", baseUrl, port), nil
 	}
 
-	return baseUrl
+	return "", nil
 }

--- a/test/utils/endpoint_test.go
+++ b/test/utils/endpoint_test.go
@@ -9,22 +9,20 @@ import (
 )
 
 func TestEndpointBuilding(t *testing.T) {
-	defaultUrl := "https://upload.bugsnag.com"
-	defaultPort := 443
 
 	t.Log("Testing setting an endpoint with CLI defaults")
-	results, err := utils.BuildEndpointUrl(defaultUrl, defaultPort)
+	results, err := utils.BuildEndpointUrl("https://upload.bugsnag.com", 443)
 	if err != nil {
 		t.Error(err)
 	}
-	assert.Equal(t, fmt.Sprintf("%s:%d", defaultUrl, defaultPort), results, "They should be the same")
+	assert.Equal(t, fmt.Sprintf("%s:%d", "https://upload.bugsnag.com", 443), results, "They should be the same")
 
 	t.Log("Testing setting a port with the CLI default URL")
-	results, err = utils.BuildEndpointUrl(defaultUrl, 8443)
+	results, err = utils.BuildEndpointUrl("https://upload.bugsnag.com", 8443)
 	if err != nil {
 		t.Error(err)
 	}
-	assert.Equal(t, results, defaultUrl + ":8443", "They should be the same")
+	assert.Equal(t, results, "https://upload.bugsnag.com" + ":8443", "They should be the same")
 
 	t.Log("Testing setting an endpoint and port")
 	results, err = utils.BuildEndpointUrl("https://localhost", 8443)
@@ -39,4 +37,11 @@ func TestEndpointBuilding(t *testing.T) {
 		t.Error(err)
 	}
 	assert.Equal(t, results, "https://localhost:1234", "They should be the same")
+
+	t.Log("Testing setting an endpoint with no port")
+	results, err = utils.BuildEndpointUrl("https://localhost", 0)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, results, "https://localhost", "They should be the same")
 }

--- a/test/utils/endpoint_test.go
+++ b/test/utils/endpoint_test.go
@@ -1,6 +1,7 @@
 package utils_testing
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
@@ -8,19 +9,34 @@ import (
 )
 
 func TestEndpointBuilding(t *testing.T) {
-	t.Log("Testing the default endpoint")
-	results := utils.BuildEndpointUrl("", 0)
-	assert.Equal(t, results, "https://upload.bugsnag.com", "They should be the same")
+	defaultUrl := "https://upload.bugsnag.com"
+	defaultPort := 443
 
-	t.Log("Testing setting an endpoint")
-	results = utils.BuildEndpointUrl("https://localhost", 0)
-	assert.Equal(t, results, "https://localhost", "They should be the same")
+	t.Log("Testing setting an endpoint with CLI defaults")
+	results, err := utils.BuildEndpointUrl(defaultUrl, defaultPort)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, fmt.Sprintf("%s:%d", defaultUrl, defaultPort), results, "They should be the same")
 
-	t.Log("Testing setting a port")
-	results = utils.BuildEndpointUrl("", 8443)
-	assert.Equal(t, results, "https://upload.bugsnag.com:8443", "They should be the same")
+	t.Log("Testing setting a port with the CLI default URL")
+	results, err = utils.BuildEndpointUrl(defaultUrl, 8443)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, results, defaultUrl + ":8443", "They should be the same")
 
 	t.Log("Testing setting an endpoint and port")
-	results = utils.BuildEndpointUrl("https://localhost", 8443)
+	results, err = utils.BuildEndpointUrl("https://localhost", 8443)
+	if err != nil {
+		t.Error(err)
+	}
 	assert.Equal(t, results, "https://localhost:8443", "They should be the same")
+
+	t.Log("Testing setting an endpoint with a port and port")
+	results, err = utils.BuildEndpointUrl("https://localhost:1234", 8443)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, results, "https://localhost:1234", "They should be the same")
 }


### PR DESCRIPTION
## 👩 Platform release notes

Update the endpoint building function to allow for ports to be passed through the `--upload-api-root-url` option from the CLI.

Unit tests have also been updated.

## 🔬 Testing

Covered by CI

## 🔒 Security
No impact on security

## 🚀 Deployment
Manual release