### PR TITLE
Unsupported Curl Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # 1.0.0 TBD
 
+## Fixes
+- Remove unsupported curl options [11](https://github.com/bugsnag/bugsnag-cli/pull/11)
+- Fix using port within endpoint url CLI option [10](https://github.com/bugsnag/bugsnag-cli/pull/10)
 ## Enhancements 
 - Add dart symbol file support [6](https://github.com/bugsnag/bugsnag-cli/pull/6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,4 @@
 # 1.0.0 TBD
 
-## Fixes
-- Remove unsupported curl options [11](https://github.com/bugsnag/bugsnag-cli/pull/11)
-- Fix using port within endpoint url CLI option [10](https://github.com/bugsnag/bugsnag-cli/pull/10)
 ## Enhancements 
 - Add dart symbol file support [6](https://github.com/bugsnag/bugsnag-cli/pull/6)

--- a/install.sh
+++ b/install.sh
@@ -144,7 +144,7 @@ ohai "Downloading and installing Bugsnag CLI..."
     xargs)
 
   if [[ ! -n ${DOWNLOAD_URL} ]]; then
-    abort "Failed to get download url"
+    abort "Failed to get download URL from ${BUGSNAG_CLI_GIT_REMOTE}"
   fi
 
   execute "curl" "-#" "-L" "${DOWNLOAD_URL}" "-o" "${BUGSNAG_CLI_PREFIX}/bin/bugsnag-cli"

--- a/install.sh
+++ b/install.sh
@@ -136,12 +136,16 @@ ohai "Downloading and installing Bugsnag CLI..."
 (
   cd "${BUGSNAG_CLI_PREFIX}" >/dev/null || return
 
-  DOWNLOAD_URL=$(curl -sS --no-progress-meter ${BUGSNAG_CLI_GIT_REMOTE} |
+  DOWNLOAD_URL=$(curl -sS ${BUGSNAG_CLI_GIT_REMOTE} |
     grep "${UNAME_MACHINE}-${OS_NAME}-bugsnag-cli*" |
     grep "browser_download_url" |
     cut -d : -f 2,3 |
     tr -d \" |
     xargs)
+
+  if [[ ! -n ${DOWNLOAD_URL} ]]; then
+    abort "Failed to get download url"
+  fi
 
   execute "curl" "-#" "-L" "${DOWNLOAD_URL}" "-o" "${BUGSNAG_CLI_PREFIX}/bin/bugsnag-cli"
 


### PR DESCRIPTION
## 👩 Platform release notes

Update the install script so that curl command doesn't fail when using older versions of curl.

## 🔬 Testing

Covered by CI/ Manual testing

## 🔒 Security
No impact on security

## 🚀 Deployment
Manual release