### PR TITLE
[PLAT-9893] React Native Android auto detection

### DIFF
--- a/main.go
+++ b/main.go
@@ -191,7 +191,7 @@ func main() {
 
 		log.Success("Upload(s) completed")
 
-	case "upload react-native-android":
+	case "upload react-native-android", "upload react-native-android <path>":
 
 		if commands.ApiKey == "" {
 			log.Error("no API key provided", 1)
@@ -200,7 +200,9 @@ func main() {
 		// Build endpoint URI
 		endpoint = endpoint + "/react-native-source-map"
 
-		err := upload.ProcessReactNativeAndroid(commands.AppVersion,
+		err := upload.ProcessReactNativeAndroid(commands.Upload.ReactNativeAndroid.Path,
+			commands.Upload.ReactNativeAndroid.AppManifestPath,
+			commands.AppVersion,
 			commands.AppVersionCode,
 			commands.Upload.ReactNativeAndroid.CodeBundleId,
 			commands.Upload.ReactNativeAndroid.Dev,

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -2,46 +2,117 @@ package upload
 
 import (
 	"fmt"
+	"github.com/bugsnag/bugsnag-cli/pkg/android"
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
 	"github.com/bugsnag/bugsnag-cli/pkg/server"
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
+	"path/filepath"
 )
 
 type ReactNativeAndroid struct {
-	CodeBundleId  string `help:"A unique identifier to identify a code bundle release when using tools like CodePush"`
-	Dev           bool   `help:"Indicates whether the application is a debug or release build"`
-	SourceMapPath string `help:"Path to the source map file" type:"path"`
-	BundlePath    string `help:"Path to the bundle file" type:"path"`
-	ProjectRoot   string `help:"path to remove from the beginning of the filenames in the mapping file" type:"path"`
+	Path            utils.UploadPaths `arg:"" name:"path" help:"(required) Path to directory or file to upload" type:"path" default:"."`
+	AppManifestPath string            `help:"(required) Path to directory or file to upload" type:"path"`
+	CodeBundleId    string            `help:"A unique identifier to identify a code bundle release when using tools like CodePush"`
+	Dev             bool              `help:"Indicates whether the application is a debug or release build"`
+	SourceMapPath   string            `help:"Path to the source map file" type:"path"`
+	BundlePath      string            `help:"Path to the bundle file" type:"path"`
+	ProjectRoot     string            `help:"path to remove from the beginning of the filenames in the mapping file" type:"path"`
 }
 
-func ProcessReactNativeAndroid(appVersion string, appVersionCode string, codeBundleId string, dev bool, sourceMapPath string, bundlePath string, projectRoot string, endpoint string, timeout int, retries int, overwrite bool, apiKey string) error {
+func ProcessReactNativeAndroid(paths []string, appManifestPath string, appVersion string, appVersionCode string, codeBundleId string, dev bool, sourceMapPath string, bundlePath string, projectRoot string, endpoint string, timeout int, retries int, overwrite bool, apiKey string) error {
 
-	if appVersion == "" {
-		return fmt.Errorf("`--app-version` missing from options")
-	}
+	for _, path := range paths {
+		log.Info(path)
 
-	if sourceMapPath == "" {
-		return fmt.Errorf("`--source-map-path` missing from options")
-	}
+		if projectRoot == "" {
+			projectRoot = path
+		}
 
-	if bundlePath == "" {
-		return fmt.Errorf("`--bundle-path` missing from options")
-	}
+		if appManifestPath == "" {
+			log.Info("Locating Android manifest")
 
-	// Check if we have project root
-	if projectRoot == "" {
-		return fmt.Errorf("`--project-root` missing from options")
-	}
+			if utils.FileExists(filepath.Join(path, "android", "app", "build", "intermediates", "merged_manifests")) {
+				appManifestPath = filepath.Join(path, "android", "app", "build", "intermediates", "merged_manifests")
+			} else if utils.FileExists(filepath.Join(path, "app", "build", "intermediates", "merged_manifests")) {
+				appManifestPath = filepath.Join(path, "app", "build", "intermediates", "merged_manifests")
+			} else {
+				return fmt.Errorf("unable to find AndroidManifest.xml. Please specify using `--app-manifest-path` ")
+			}
 
-	// Check if SourceMapPath exists
-	if !utils.FileExists(sourceMapPath) {
-		return fmt.Errorf(sourceMapPath + " does not exist on the system.")
-	}
+			variants, err := android.BuildVariantsList(appManifestPath)
 
-	// Check if bundlePath exists
-	if !utils.FileExists(bundlePath) {
-		return fmt.Errorf(bundlePath + " does not exist on the system.")
+			if err != nil {
+				return err
+			}
+
+			if len(variants) > 1 {
+				return fmt.Errorf("more than one variant found. Please specify using `--app-manifest-path`")
+			}
+
+			appManifestPath = filepath.Join(appManifestPath, variants[0], "AndroidManifest.xml")
+
+		}
+
+		if !utils.FileExists(appManifestPath) {
+			return fmt.Errorf(appManifestPath + " doesn't exist on the system")
+		}
+
+		androidManifestData, err := android.ParseAndroidManifestXML(appManifestPath)
+
+		if err != nil {
+			return err
+		}
+
+		if appVersion == "" {
+			log.Info("Setting app version from " + appManifestPath)
+			appVersion = androidManifestData.VersionName
+		}
+
+		if appVersionCode == "" {
+			log.Info("Setting app version code from " + appManifestPath)
+			appVersionCode = androidManifestData.VersionCode
+		}
+
+		if sourceMapPath == "" {
+			if utils.FileExists(filepath.Join(path, "android", "app", "build", "generated", "sourcemaps", "react")) {
+				sourceMapPath = filepath.Join(path, "android", "app", "build", "generated", "sourcemaps", "react")
+			} else if utils.FileExists(filepath.Join(path, "app", "build", "generated", "sourcemaps", "react")) {
+				sourceMapPath = filepath.Join(path, "app", "build", "generated", "sourcemaps", "react")
+			} else {
+				return fmt.Errorf("unable to find the source map path. Please specify using `--source-map-path`")
+			}
+
+			variants, err := android.BuildVariantsList(sourceMapPath)
+
+			if err != nil {
+				return err
+			}
+
+			if len(variants) > 1 {
+				return fmt.Errorf("more than one variant found. Please specify using `--source-map-path`")
+			}
+
+			sourceMapPath = filepath.Join(sourceMapPath, variants[0], "index.android.bundle.map")
+
+		}
+
+		if !utils.FileExists(sourceMapPath) {
+			return fmt.Errorf(sourceMapPath + " doesn't exist on the system")
+		}
+
+		if bundlePath == "" {
+			if utils.FileExists(filepath.Join(path, "android", "app", "build", "ASSETS", "createBundleReleaseJsAndAssets", "index.android.bundle")) {
+				bundlePath = filepath.Join(path, "android", "app", "build", "ASSETS", "createBundleReleaseJsAndAssets", "index.android.bundle")
+			} else if utils.FileExists(filepath.Join(path, "app", "build", "ASSETS", "createBundleReleaseJsAndAssets", "index.android.bundle")) {
+				bundlePath = filepath.Join(path, "app", "build", "ASSETS", "createBundleReleaseJsAndAssets", "index.android.bundle")
+			} else {
+				return fmt.Errorf("unable to find the bundle path. Please specify using `--bundle-path`")
+			}
+		}
+
+		if !utils.FileExists(bundlePath) {
+			return fmt.Errorf(bundlePath + " doesn't exist on the system")
+		}
 	}
 
 	log.Info("Uploading debug information for React Native Android")


### PR DESCRIPTION
## Goal

Add automatic detection and information parsing to the React Native Android functionality.

example:

`bugsnag-cli upload react-native-android --api-key=YOUR_API_KEY` 

output:
```
[INFO] /Users/josh.edney/repos/bugsnag-cli/test/testdata/react-native
[INFO] Locating Android manifest
[INFO] Setting app version from android/app/build/intermediates/merged_manifests/release/AndroidManifest.xml
[INFO] Setting app version code from android/app/build/intermediates/merged_manifests/release/AndroidManifest.xml
[INFO] Uploading debug information for React Native Android
[SUCCESS] Upload(s) completed
```

## Changeset

- Default path to `./` if one isn't provided.
- Add flag for `app-manifest-path`. Defaults to `android/app/build/intermediates/merged_manifests/release/AndroidManifest.xml` if not set.
- Parse `appVersion` and `appVersionCode` from `AndroidManifest.xml` if not set.
- Search for bundle and source map files in the `path` if not set via flags.

## Testing

Covered by unit tests on CI