### PR TITLE
Remove `--android-ndk-root` from Android AAB

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,6 @@ func main() {
 
 		err := upload.ProcessAndroidAab(
 			commands.ApiKey,
-			commands.Upload.AndroidAab.AndroidNdkRoot,
 			commands.Upload.AndroidAab.ApplicationId,
 			commands.Upload.AndroidAab.BuildUuid,
 			commands.Upload.AndroidAab.Path,

--- a/pkg/upload/android-aab.go
+++ b/pkg/upload/android-aab.go
@@ -10,16 +10,15 @@ import (
 )
 
 type AndroidAabMapping struct {
-	ApplicationId  string            `help:"Module application identifier"`
-	AndroidNdkRoot string            `help:"Path to Android NDK installation ($ANDROID_NDK_ROOT)"`
-	BuildUuid      string            `help:"Module Build UUID"`
-	Path           utils.UploadPaths `arg:"" name:"path" help:"(required) Path to directory or file to upload" type:"path"`
-	ProjectRoot    string            `help:"path to remove from the beginning of the filenames in the mapping file" type:"path"`
-	VersionCode    string            `help:"Module version code"`
-	VersionName    string            `help:"Module version name"`
+	ApplicationId string            `help:"Module application identifier"`
+	BuildUuid     string            `help:"Module Build UUID"`
+	Path          utils.UploadPaths `arg:"" name:"path" help:"(required) Path to directory or file to upload" type:"path"`
+	ProjectRoot   string            `help:"path to remove from the beginning of the filenames in the mapping file" type:"path"`
+	VersionCode   string            `help:"Module version code"`
+	VersionName   string            `help:"Module version name"`
 }
 
-func ProcessAndroidAab(apiKey string, androidNdkRoot string, applicationId string, buildUuid string, paths []string, projectRoot string, versionCode string, versionName string, endpoint string, failOnUploadError bool, retries int, timeout int, overwrite bool, dryRun bool) error {
+func ProcessAndroidAab(apiKey string, applicationId string, buildUuid string, paths []string, projectRoot string, versionCode string, versionName string, endpoint string, failOnUploadError bool, retries int, timeout int, overwrite bool, dryRun bool) error {
 
 	var manifestData map[string]string
 	var aabManifestPath string
@@ -104,7 +103,7 @@ func ProcessAndroidAab(apiKey string, androidNdkRoot string, applicationId strin
 
 	if len(fileList) > 0 && err == nil {
 		for _, file := range fileList {
-			err = ProcessAndroidNDK(apiKey, applicationId, androidNdkRoot, "", []string{file}, projectRoot, "", versionCode, versionName, endpoint, failOnUploadError, retries, timeout, overwrite, dryRun)
+			err = ProcessAndroidNDK(apiKey, applicationId, "", "", []string{file}, projectRoot, "", versionCode, versionName, endpoint, failOnUploadError, retries, timeout, overwrite, dryRun)
 
 			if err != nil {
 				return err

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -145,18 +145,13 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 						return err
 					}
 
-					log.Info("Android NDK Path: " + androidNdkRoot)
-
-					// Find objcopy within NDK path
-					log.Info("Locating objcopy within Android NDK path")
-
 					objCopyPath, err = android.BuildObjcopyPath(androidNdkRoot)
 
 					if err != nil {
 						return err
 					}
 
-					log.Info("Objcopy Path: " + objCopyPath)
+					log.Info("Located objcopy within Android NDK path:" + androidNdkRoot)
 				}
 
 				log.Info("Extracting debug info from " + filepath.Base(file) + " using objcopy")

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -151,7 +151,7 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 						return err
 					}
 
-					log.Info("Located objcopy within Android NDK path:" + androidNdkRoot)
+					log.Info("Located objcopy within Android NDK path: " + androidNdkRoot)
 				}
 
 				log.Info("Extracting debug info from " + filepath.Base(file) + " using objcopy")

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -30,6 +30,7 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 	var mergeNativeLibPath string
 	var err error
 	var workingDir string
+	var objCopyPath string
 
 	if dryRun {
 		log.Info("Performing dry run - no files will be uploaded")
@@ -137,24 +138,26 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 				symbolFileList = append(symbolFileList, file)
 			} else if filepath.Ext(file) == ".so" {
 				// Check NDK path is set
-				androidNdkRoot, err = android.GetAndroidNDKRoot(androidNdkRoot)
+				if objCopyPath == "" {
+					androidNdkRoot, err = android.GetAndroidNDKRoot(androidNdkRoot)
 
-				if err != nil {
-					return err
+					if err != nil {
+						return err
+					}
+
+					log.Info("Android NDK Path: " + androidNdkRoot)
+
+					// Find objcopy within NDK path
+					log.Info("Locating objcopy within Android NDK path")
+
+					objCopyPath, err = android.BuildObjcopyPath(androidNdkRoot)
+
+					if err != nil {
+						return err
+					}
+
+					log.Info("Objcopy Path: " + objCopyPath)
 				}
-
-				log.Info("Android NDK Path: " + androidNdkRoot)
-
-				// Find objcopy within NDK path
-				log.Info("Locating objcopy within Android NDK path")
-
-				objCopyPath, err := android.BuildObjcopyPath(androidNdkRoot)
-
-				if err != nil {
-					return err
-				}
-
-				log.Info("Objcopy Path: " + objCopyPath)
 
 				log.Info("Extracting debug info from " + filepath.Base(file) + " using objcopy")
 

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -2,13 +2,14 @@ package upload
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/bugsnag/bugsnag-cli/pkg/android"
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
 	"github.com/bugsnag/bugsnag-cli/pkg/server"
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 type AndroidNdkMapping struct {
@@ -33,26 +34,6 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 	if dryRun {
 		log.Info("Performing dry run - no files will be uploaded")
 	}
-
-	// Check NDK path is set
-	androidNdkRoot, err = android.GetAndroidNDKRoot(androidNdkRoot)
-
-	if err != nil {
-		return err
-	}
-
-	log.Info("Android NDK Path: " + androidNdkRoot)
-
-	// Find objcopy within NDK path
-	log.Info("Locating objcopy within Android NDK path")
-
-	objCopyPath, err := android.BuildObjcopyPath(androidNdkRoot)
-
-	if err != nil {
-		return err
-	}
-
-	log.Info("Objcopy Path: " + objCopyPath)
 
 	for _, path := range paths {
 		if utils.IsDir(path) {
@@ -155,6 +136,25 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 			if strings.HasSuffix(file, ".so.sym") {
 				symbolFileList = append(symbolFileList, file)
 			} else if filepath.Ext(file) == ".so" {
+				// Check NDK path is set
+				androidNdkRoot, err = android.GetAndroidNDKRoot(androidNdkRoot)
+
+				if err != nil {
+					return err
+				}
+
+				log.Info("Android NDK Path: " + androidNdkRoot)
+
+				// Find objcopy within NDK path
+				log.Info("Locating objcopy within Android NDK path")
+
+				objCopyPath, err := android.BuildObjcopyPath(androidNdkRoot)
+
+				if err != nil {
+					return err
+				}
+
+				log.Info("Objcopy Path: " + objCopyPath)
 
 				log.Info("Extracting debug info from " + filepath.Base(file) + " using objcopy")
 

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -137,7 +137,7 @@ func ProcessAndroidProguard(apiKey string, applicationId string, appManifestPath
 		if dryRun {
 			err = nil
 		} else {
-			err = server.ProcessRequest(endpoint+"/proguardd", uploadOptions, fileFieldData, timeout)
+			err = server.ProcessRequest(endpoint+"/proguard", uploadOptions, fileFieldData, timeout)
 
 			if err != nil {
 				if strings.Contains(err.Error(), "404 Not Found") {

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -137,11 +137,13 @@ func ProcessAndroidProguard(apiKey string, applicationId string, appManifestPath
 		if dryRun {
 			err = nil
 		} else {
-			err = server.ProcessRequest(endpoint+"/proguard", uploadOptions, fileFieldData, timeout)
+			err = server.ProcessRequest(endpoint+"/proguardd", uploadOptions, fileFieldData, timeout)
 
-			if strings.Contains(err.Error(), "404 Not Found") {
-				log.Info("Trying " + endpoint)
-				err = server.ProcessRequest(endpoint, uploadOptions, fileFieldData, timeout)
+			if err != nil {
+				if strings.Contains(err.Error(), "404 Not Found") {
+					log.Info("Trying " + endpoint)
+					err = server.ProcessRequest(endpoint, uploadOptions, fileFieldData, timeout)
+				}
 			}
 		}
 


### PR DESCRIPTION
## Goal

Remove the CLI option `--android-ndk-root` from the Android AAB upload section as it's not required due to the symbol files not needing to be passed through `objcopy`.

During testing, I also noticed that we're missing an `if err !=nil ` for checking if we need to fall back during the Android Proguard processing.

## Changeset

Remove `--android-ndk-root` from CLI options for Android AAB
Check if we have an `err` before we attempt to fall back to the default endpoint for Android Proguard

## Testing

Covered By CI