### PR TITLE
Check if AndroidManifest.xml exists for Android Proguard, NDK and AAB

### DIFF
--- a/pkg/upload/android-aab.go
+++ b/pkg/upload/android-aab.go
@@ -58,7 +58,6 @@ func ProcessAndroidAab(apiKey string, applicationId string, buildUuid string, pa
 		aabManifestPathExpected := filepath.Join(tempDir, "base", "manifest", "AndroidManifest.xml")
 		if utils.FileExists(aabManifestPath) {
 			aabManifestPath = aabManifestPathExpected
-			log.Info("Found app manifest at: " + aabManifestPath)
 		} else {
 			log.Warn("AndroidManifest.xml not found in AAB file")
 		}

--- a/pkg/upload/android-aab.go
+++ b/pkg/upload/android-aab.go
@@ -59,21 +59,19 @@ func ProcessAndroidAab(apiKey string, applicationId string, buildUuid string, pa
 		if utils.FileExists(aabManifestPath) {
 			aabManifestPath = aabManifestPathExpected
 			log.Info("Found app manifest at: " + aabManifestPath)
+		} else {
+			log.Warn("AndroidManifest.xml not found in AAB file")
 		}
 	}
 
 	// Check to see if we need to read the manifest file due to missing options
-	if apiKey == "" || applicationId == "" || buildUuid == "" || versionCode == "" || versionName == "" {
+	if aabManifestPath != "" && (apiKey == "" || applicationId == "" || buildUuid == "" || versionCode == "" || versionName == "") {
 
 		log.Info("Reading data from AndroidManifest.xml")
 
-		if utils.FileExists(aabManifestPath) {
-			manifestData, err = android.ReadAabManifest(filepath.Join(aabManifestPath))
+		manifestData, err = android.ReadAabManifest(filepath.Join(aabManifestPath))
 
-			if err != nil {
-				return fmt.Errorf("error reading raw AAB manifest data. " + err.Error())
-			}
-		} else {
+		if err != nil {
 			return fmt.Errorf("unable to read data from " + aabManifestPath + " " + err.Error())
 		}
 

--- a/pkg/upload/android-aab.go
+++ b/pkg/upload/android-aab.go
@@ -2,11 +2,12 @@ package upload
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/bugsnag/bugsnag-cli/pkg/android"
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
-	"os"
-	"path/filepath"
 )
 
 type AndroidAabMapping struct {
@@ -49,11 +50,16 @@ func ProcessAndroidAab(apiKey string, androidNdkRoot string, applicationId strin
 			}
 
 			log.Success(filepath.Base(path) + " expanded")
-
-			aabManifestPath = filepath.Join(tempDir, "base", "manifest", "AndroidManifest.xml")
-
 		} else {
 			return fmt.Errorf(path + " is not an AAB file")
+		}
+	}
+
+	if aabManifestPath == "" {
+		aabManifestPathExpected := filepath.Join(tempDir, "base", "manifest", "AndroidManifest.xml")
+		if utils.FileExists(aabManifestPath) {
+			aabManifestPath = aabManifestPathExpected
+			log.Info("Found app manifest at: " + aabManifestPath)
 		}
 	}
 

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -2,13 +2,14 @@ package upload
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/bugsnag/bugsnag-cli/pkg/android"
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
 	"github.com/bugsnag/bugsnag-cli/pkg/server"
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 type AndroidNdkMapping struct {
@@ -78,8 +79,11 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 			}
 
 			if appManifestPath == "" {
-				//	Get the expected path to the manifest using variant name from the given path
-				appManifestPath = filepath.Join(path, "app", "build", "intermediates", "merged_manifests", variant, "AndroidManifest.xml")
+				appManifestPathExpected := filepath.Join(path, "app", "build", "intermediates", "merged_manifests", variant, "AndroidManifest.xml")
+				if utils.FileExists(appManifestPathExpected) {
+					appManifestPath = appManifestPathExpected
+					log.Info("Found app manifest at: " + appManifestPath)
+				}
 			}
 
 			if projectRoot == "" {
@@ -99,6 +103,10 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 
 						if err == nil {
 							appManifestPath = filepath.Join(mergeNativeLibPath, "..", "merged_manifests", variant, "AndroidManifest.xml")
+
+							if utils.FileExists(appManifestPath) {
+								log.Info("Found app manifest at: " + appManifestPath)
+							}
 						}
 
 						if projectRoot == "" {

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -30,6 +30,7 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 	var mergeNativeLibPath string
 	var err error
 	var workingDir string
+	var appManifestPathExpected string
 
 	if dryRun {
 		log.Info("Performing dry run - no files will be uploaded")
@@ -79,7 +80,7 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 			}
 
 			if appManifestPath == "" {
-				appManifestPathExpected := filepath.Join(path, "app", "build", "intermediates", "merged_manifests", variant, "AndroidManifest.xml")
+				appManifestPathExpected = filepath.Join(path, "app", "build", "intermediates", "merged_manifests", variant, "AndroidManifest.xml")
 				if utils.FileExists(appManifestPathExpected) {
 					appManifestPath = appManifestPathExpected
 					log.Info("Found app manifest at: " + appManifestPath)
@@ -102,9 +103,9 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 						variant, err = android.GetVariant(mergeNativeLibPath)
 
 						if err == nil {
-							appManifestPath = filepath.Join(mergeNativeLibPath, "..", "merged_manifests", variant, "AndroidManifest.xml")
-
-							if utils.FileExists(appManifestPath) {
+							appManifestPathExpected = filepath.Join(mergeNativeLibPath, "..", "merged_manifests", variant, "AndroidManifest.xml")
+							if utils.FileExists(appManifestPathExpected) {
+								appManifestPath = appManifestPathExpected
 								log.Info("Found app manifest at: " + appManifestPath)
 							}
 						}
@@ -123,7 +124,7 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 		}
 
 		// Check to see if we need to read the manifest file due to missing options
-		if apiKey == "" || applicationId == "" || versionCode == "" || versionName == "" {
+		if appManifestPath != "" && (apiKey == "" || applicationId == "" || versionCode == "" || versionName == "") {
 
 			log.Info("Reading data from AndroidManifest.xml")
 			manifestData, err := android.ParseAndroidManifestXML(appManifestPath)

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -33,7 +33,6 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 	var appManifestPathExpected string
 	var objCopyPath string
 
-
 	if dryRun {
 		log.Info("Performing dry run - no files will be uploaded")
 	}


### PR DESCRIPTION
## Goal

Update the checking around the `AndroidManifest.xml` and only set it if the file exists.

## Design

Follows the pattern set out in the React Native Android section

## Testing

Covered by CI and also manual testing.