### PR TITLE
Validate we have app/build ID or version code/name before uploading and error out if we do not

### DIFF
--- a/pkg/upload/android-aab.go
+++ b/pkg/upload/android-aab.go
@@ -2,11 +2,12 @@ package upload
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/bugsnag/bugsnag-cli/pkg/android"
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
-	"os"
-	"path/filepath"
 )
 
 type AndroidAabMapping struct {
@@ -83,7 +84,11 @@ func ProcessAndroidAab(apiKey string, applicationId string, buildUuid string, pa
 
 		if buildUuid == "" {
 			buildUuid = manifestData["buildUuid"]
-			log.Info("Using " + buildUuid + " as build UUID from AndroidManifest.xml")
+			if buildUuid == "" {
+				log.Warn("No BUILD_UUID found in AndroidManifest.xml, defaulting to none")
+			} else {
+				log.Info("Using " + buildUuid + " as build UUID from AndroidManifest.xml")
+			}
 		}
 
 		if versionCode == "" {

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -2,12 +2,13 @@ package upload
 
 import (
 	"fmt"
+	"path/filepath"
+	"strings"
+
 	"github.com/bugsnag/bugsnag-cli/pkg/android"
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
 	"github.com/bugsnag/bugsnag-cli/pkg/server"
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
-	"path/filepath"
-	"strings"
 )
 
 type AndroidProguardMapping struct {
@@ -99,9 +100,13 @@ func ProcessAndroidProguard(apiKey string, applicationId string, appManifestPath
 				for i := range manifestData.Application.MetaData.Name {
 					if manifestData.Application.MetaData.Name[i] == "com.bugsnag.android.BUILD_UUID" {
 						buildUuid = manifestData.Application.MetaData.Value[i]
+						if buildUuid == "" {
+							log.Warn("No BUILD_UUID found in AndroidManifest.xml, defaulting to none")
+						} else {
+							log.Info("Using " + buildUuid + " as build UUID from AndroidManifest.xml")
+						}
 					}
 				}
-				log.Info("Using " + buildUuid + " as build UUID from AndroidManifest.xml")
 			}
 
 			if versionCode == "" {

--- a/pkg/utils/upload-options.go
+++ b/pkg/utils/upload-options.go
@@ -59,8 +59,6 @@ func BuildAndroidNDKUploadOptions(apiKey string, applicationId string, versionNa
 
 	if versionCode != "" {
 		uploadOptions["versionCode"] = versionCode
-	} else {
-		return nil, fmt.Errorf("missing version code, please specify using `--version-code`")
 	}
 
 	if versionName != "" {
@@ -77,6 +75,10 @@ func BuildAndroidNDKUploadOptions(apiKey string, applicationId string, versionNa
 
 	if overwrite {
 		uploadOptions["overwrite"] = "true"
+	}
+
+	if uploadOptions["versionName"] == "" && uploadOptions["versionCode"] == "" {
+		return nil, fmt.Errorf("missing version code or version name, please specify using `--version-code` or `--version-name`")
 	}
 
 	return uploadOptions, nil
@@ -100,8 +102,6 @@ func BuildAndroidProguardUploadOptions(apiKey string, applicationId string, vers
 
 	if versionCode != "" {
 		uploadOptions["versionCode"] = versionCode
-	} else {
-		return nil, fmt.Errorf("missing version code, please specify using `--version-code`")
 	}
 
 	if versionName != "" {
@@ -114,6 +114,10 @@ func BuildAndroidProguardUploadOptions(apiKey string, applicationId string, vers
 
 	if overwrite {
 		uploadOptions["overwrite"] = "true"
+	}
+
+	if uploadOptions["buildUuid"] == "" && uploadOptions["versionName"] == "" && uploadOptions["versionCode"] == "" {
+		return nil, fmt.Errorf("missing build uuid, version code or version name, please specify using `--build-uuid`, `--version-code` or `--version-name`")
 	}
 
 	return uploadOptions, nil

--- a/pkg/utils/upload-options.go
+++ b/pkg/utils/upload-options.go
@@ -53,8 +53,6 @@ func BuildAndroidNDKUploadOptions(apiKey string, applicationId string, versionNa
 
 	if applicationId != "" {
 		uploadOptions["appId"] = applicationId
-	} else {
-		return nil, fmt.Errorf("missing application id, please specify using `--application-id`")
 	}
 
 	if versionCode != "" {
@@ -78,7 +76,7 @@ func BuildAndroidNDKUploadOptions(apiKey string, applicationId string, versionNa
 	}
 
 	if uploadOptions["versionName"] == "" && uploadOptions["versionCode"] == "" {
-		return nil, fmt.Errorf("missing version code or version name, please specify using `--version-code` or `--version-name`")
+		return nil, fmt.Errorf("missing application ID, version code or version name, please specify using `--application-id`, `--version-code` or `--version-name`")
 	}
 
 	return uploadOptions, nil
@@ -96,8 +94,6 @@ func BuildAndroidProguardUploadOptions(apiKey string, applicationId string, vers
 
 	if applicationId != "" {
 		uploadOptions["appId"] = applicationId
-	} else {
-		return nil, fmt.Errorf("missing application id, please specify using `--application-id`")
 	}
 
 	if versionCode != "" {
@@ -117,7 +113,7 @@ func BuildAndroidProguardUploadOptions(apiKey string, applicationId string, vers
 	}
 
 	if uploadOptions["buildUuid"] == "" && uploadOptions["versionName"] == "" && uploadOptions["versionCode"] == "" {
-		return nil, fmt.Errorf("missing build uuid, version code or version name, please specify using `--build-uuid`, `--version-code` or `--version-name`")
+		return nil, fmt.Errorf("missing application ID, build uuid, version code or version name, please specify using `--application-id`, `--build-uuid`, `--version-code` or `--version-name`")
 	}
 
 	return uploadOptions, nil


### PR DESCRIPTION
## Goal

Validate that we have either `applicationId`, `buildUuid`, `versionCode` or `versionName` before we attempt to upload to the API and error out if we do not.