### PR TITLE
feat(create-build): add path option for project dir

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
+	"os"
+
 	"github.com/alecthomas/kong"
 	"github.com/bugsnag/bugsnag-cli/pkg/build"
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
 	"github.com/bugsnag/bugsnag-cli/pkg/upload"
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
-	"os"
 )
 
 func main() {
@@ -202,7 +203,7 @@ func main() {
 
 		log.Success("Upload(s) completed")
 
-	case "create-build":
+	case "create-build", "create-build <path>":
 
 		if commands.ApiKey == "" {
 			log.Error("no API key provided", 1)
@@ -227,6 +228,7 @@ func main() {
 			commands.AppVersionCode,
 			commands.AppBundleVersion,
 			commands.CreateBuild.Metadata,
+			commands.CreateBuild.Path,
 			endpoint)
 		if buildUploadError != nil {
 			log.Error(buildUploadError.Error(), 1)

--- a/pkg/build/create.go
+++ b/pkg/build/create.go
@@ -20,6 +20,7 @@ type CreateBuild struct {
 	Provider     string            `help:"The name of the source control provider that contains the source code for the build."`
 	Repository   string            `help:"The URL of the repository containing the source code being deployed."`
 	Revision     string            `help:"The source control SHA-1 hash for the code that has been built (short or long hash)"`
+	Path         utils.UploadPaths `arg:"" name:"path" help:"Path to the project directory" type:"path" default:"."`
 }
 
 type Payload struct {
@@ -39,7 +40,7 @@ type SourceControl struct {
 	Revision   string `json:"revision,omitempty"`
 }
 
-func ProcessBuildRequest(apiKey string, builderName string, releaseStage string, provider string, repository string, revision string, appVersion string, appVersionCode string, appBundleVersion string, metadata map[string]string, endpoint string) error {
+func ProcessBuildRequest(apiKey string, builderName string, releaseStage string, provider string, repository string, revision string, appVersion string, appVersionCode string, appBundleVersion string, metadata map[string]string, paths []string, endpoint string) error {
 	if appVersion == "" {
 		log.Error("Missing app version, please provide this via the command line options", 1)
 	}
@@ -50,7 +51,7 @@ func ProcessBuildRequest(apiKey string, builderName string, releaseStage string,
 		log.Error("Failed to set builder name from system. Please provide this via the command line options. "+err.Error(), 1)
 	}
 
-	repoInfo := GetRepoInfo(provider, repository, revision)
+	repoInfo := GetRepoInfo(paths[0], provider, repository, revision)
 
 	payload := Payload{
 		ApiKey:       apiKey,
@@ -102,11 +103,11 @@ func ProcessBuildRequest(apiKey string, builderName string, releaseStage string,
 	return nil
 }
 
-func GetRepoInfo(repoProvider string, repoUrl string, repoHash string) map[string]string {
+func GetRepoInfo(repoPath string, repoProvider string, repoUrl string, repoHash string) map[string]string {
 	repoInfo := make(map[string]string)
 
 	if repoUrl == "" {
-		repoUrl = utils.GetRepoUrl()
+		repoUrl = utils.GetRepoUrl(repoPath)
 	}
 
 	repoInfo["repository"] = repoUrl

--- a/pkg/utils/get-repository-info.go
+++ b/pkg/utils/get-repository-info.go
@@ -6,24 +6,24 @@ import (
 )
 
 // GetRepoUrl - Gets the URl of a git repo.
-func GetRepoUrl() string {
+func GetRepoUrl(repoPath string) string {
 	gitLocation, err := exec.LookPath("git")
 
 	if err != nil {
 		return ""
 	}
 
-	remoteOriginCmd := exec.Command(gitLocation, "config", "--get", "remote.origin.url")
+	remoteOriginCmd := exec.Command(gitLocation, "-C", repoPath, "config", "--get", "remote.origin.url")
 	remoteOriginCmdOutput, err := remoteOriginCmd.CombinedOutput()
 
 	if err != nil {
-		remoteCmd := exec.Command(gitLocation, "remote")
+		remoteCmd := exec.Command(gitLocation, "-C", repoPath, "remote")
 		remoteCmdOutput, err := remoteCmd.CombinedOutput()
 		if err != nil {
 			return ""
 		}
 		remotes := strings.Split(string(remoteCmdOutput), "\n")
-		remoteOriginCmd = exec.Command(gitLocation, "config", "--get", "remote."+remotes[0]+".url")
+		remoteOriginCmd = exec.Command(gitLocation, "-C", repoPath, "config", "--get", "remote."+remotes[0]+".url")
 		remoteOriginCmdOutput, err = remoteOriginCmd.CombinedOutput()
 		if err != nil {
 			return ""

--- a/test/build/create_build_test.go
+++ b/test/build/create_build_test.go
@@ -26,7 +26,7 @@ func TestSetBuilderName(t *testing.T) {
 
 func TestGettingRepoInfo(t *testing.T) {
 	t.Log("Test getting repo info map, only setting the commit hash")
-	results := build.GetRepoInfo("", "git@github.com:bugsnag/bugsnag-cli", "0123456789")
+	results := build.GetRepoInfo("", "", "git@github.com:bugsnag/bugsnag-cli", "0123456789")
 
 	assert.Equal(t, map[string]string{
 		"repository": "git@github.com:bugsnag/bugsnag-cli",
@@ -34,7 +34,7 @@ func TestGettingRepoInfo(t *testing.T) {
 	}, results, "They should be the same")
 
 	t.Log("Test getting repo info map, passing all three variables")
-	results = build.GetRepoInfo("github", "https://notgithub.com/bugsnag/bugsnag-cli", "0123456789")
+	results = build.GetRepoInfo("", "github", "https://notgithub.com/bugsnag/bugsnag-cli", "0123456789")
 	assert.Equal(t, map[string]string{
 		"repository": "https://notgithub.com/bugsnag/bugsnag-cli",
 		"revision":   "0123456789",


### PR DESCRIPTION
## Goal

The `create-build` command previously assumes that the git repo it reads for source control parameters is the current directory (from which the command was executed). However I think it makes sense to allow a path to be passed in to the project and this used as the path for git.

## Testing

Manually tested as existing tests don't cover this yet.