### PR TITLE
fix(upload-ndk): remove requirment for version info in NDK

### DIFF
--- a/pkg/utils/upload-options.go
+++ b/pkg/utils/upload-options.go
@@ -75,10 +75,6 @@ func BuildAndroidNDKUploadOptions(apiKey string, applicationId string, versionNa
 		uploadOptions["overwrite"] = "true"
 	}
 
-	if uploadOptions["appId"] == "" && uploadOptions["versionName"] == "" && uploadOptions["versionCode"] == "" {
-		return nil, fmt.Errorf("you must set at least the application ID, version name or version code to uniquely identify the build")
-	}
-
 	return uploadOptions, nil
 }
 


### PR DESCRIPTION
## Goal

#29 was incorrect for NDK - the version, version code and app ID are only cosmetic in the new NDK endpoint as we use a build ID in the .so file itself to uniquely identify the build. Therefore we don't need to error out if one of them is not present.