### PR TITLE
[PLAT-10142] Add NPM package to install Bugsnag CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ Gemfile.lock
 bin/*
 bin/**/**
 .DS_Store
+
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ bin/*
 bin/**/**
 .DS_Store
 
+# NodeJS
 node_modules/
+package-lock.json

--- a/install.js
+++ b/install.js
@@ -100,9 +100,20 @@ const downloadBinaryFromGitHub = async (downloadUrl, outputPath) => {
     }
 };
 
+const writeToPackageJson = (packageJsonPath) => {
+    const packageJson = require(packageJsonPath);
+
+    packageJson.scripts.bugsnagCreateBuild = './node_modules/.bin/bugsnag-cli create-build';
+    packageJson.scripts.bugsnagUpload = './node_modules/.bin/bugsnag-cli upload react-native-android';
+
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+}
+
 const platformMetadata = getPlatformMetadata();
 const repoUrl = removeGitPrefixAndSuffix(repository.url);
 const binaryUrl = `${repoUrl}/releases/download/v${version}/${platformMetadata.ARTIFACT_NAME}`;
 const binaryOutputPath = path.join(__dirname, '..', '.bin', platformMetadata.BINARY_NAME);
+const projectPackageJsonPath = path.join(__dirname, '..', '..', 'package.json');
 
 downloadBinaryFromGitHub(binaryUrl, binaryOutputPath);
+writeToPackageJson(projectPackageJsonPath)

--- a/install.js
+++ b/install.js
@@ -1,0 +1,93 @@
+const axios = require('axios');
+const fs = require('fs');
+const path = require('path');
+const os = require("os");
+const cTable = require("console.table");
+
+
+const {name, repository, version} = require("./package.json");
+
+const error = msg => {
+    console.error(msg);
+    process.exit(1);
+};
+
+const supportedPlatforms = [
+    {
+        TYPE: "windows",
+        ARCHITECTURE: "x86_64",
+        ARTIFACT_NAME: "x86_64-windows-bugsnag-cli.exe",
+        BINARY_NAME: "bugsnag-cli.exe"
+    },
+    {
+        TYPE: "windows",
+        ARCHITECTURE: "i386",
+        ARTIFACT_NAME: "i386-windows-bugsnag-cli.exe",
+        BINARY_NAME: "bugsnag-cli.exe"
+    },
+    {
+        TYPE: "linux",
+        ARCHITECTURE: "x86_64",
+        ARTIFACT_NAME: "x86_64-linux-bugsnag-cli",
+        BINARY_NAME: "bugsnag-cli"
+
+    },
+    {
+        TYPE: "linux",
+        ARCHITECTURE: "i386",
+        ARTIFACT_NAME: "i386-linux-bugsnag-cli",
+        BINARY_NAME: "bugsnag-cli"
+    },
+    {
+        TYPE: "Darwin",
+        ARCHITECTURE: "x86_64",
+        ARTIFACT_NAME: "x86_64-macos-bugsnag-cli",
+        BINARY_NAME: "bugsnag-cli"
+    },
+    {
+        TYPE: "Darwin",
+        ARCHITECTURE: "arm64",
+        ARTIFACT_NAME: "arm64-macos-bugsnag-cli",
+        BINARY_NAME: "bugsnag-cli"
+    }
+];
+
+const getPlatformMetadata = () => {
+    const type = os.type();
+    const architecture = os.arch();
+
+    for (let supportedPlatform of supportedPlatforms) {
+        if (
+            type === supportedPlatform.TYPE &&
+            architecture === supportedPlatform.ARCHITECTURE
+        ) {
+            return supportedPlatform;
+        }
+    }
+
+    error(
+        `Platform with type "${type}" and architecture "${architecture}" is not supported by ${name}.\nYour system must be one of the following:\n\n${cTable.getTable(
+            supportedPlatforms
+        )}`
+    );
+};
+
+async function downloadBinaryFromGitHub(url, outputPath) {
+    try {
+        const response = await axios.get(url, { responseType: 'arraybuffer' });
+        const binaryData = response.data;
+        fs.writeFileSync(outputPath, binaryData, 'binary');
+        fs.chmodSync(outputPath, '755');
+        console.log('Binary downloaded successfully!');
+    } catch (error) {
+        console.error('Error downloading binary:', error.message);
+    }
+}
+
+const platformMetadata = getPlatformMetadata();
+
+const binaryUrl = `${repository.url}/releases/download/${version}/${platformMetadata.ARTIFACT_NAME}`;
+
+const binaryOutputPath = path.join(__dirname, 'node_modules', '.bin', platformMetadata.BINARY_NAME);
+
+downloadBinaryFromGitHub(binaryUrl, binaryOutputPath);

--- a/install.js
+++ b/install.js
@@ -1,54 +1,58 @@
 const axios = require('axios');
 const fs = require('fs');
 const path = require('path');
-const os = require("os");
-const cTable = require("console.table");
+const os = require('os');
 
+const { name, repository, version } = require('./package.json');
 
-const {name, repository, version} = require("./package.json");
-
-const error = msg => {
+const handleError = (msg) => {
     console.error(msg);
     process.exit(1);
 };
 
+// Remove the git prefix and suffix from the repository URL
+const removeGitPrefixAndSuffix = (input) => {
+    let result = input.replace(/^git\+/, '');
+    result = result.replace(/\.git$/, '');
+    return result;
+};
+
 const supportedPlatforms = [
     {
-        TYPE: "windows",
-        ARCHITECTURE: "x86_64",
-        ARTIFACT_NAME: "x86_64-windows-bugsnag-cli.exe",
-        BINARY_NAME: "bugsnag-cli.exe"
+        TYPE: 'windows',
+        ARCHITECTURE: 'x86_64',
+        ARTIFACT_NAME: 'x86_64-windows-bugsnag-cli.exe',
+        BINARY_NAME: 'bugsnag-cli.exe'
     },
     {
-        TYPE: "windows",
-        ARCHITECTURE: "i386",
-        ARTIFACT_NAME: "i386-windows-bugsnag-cli.exe",
-        BINARY_NAME: "bugsnag-cli.exe"
+        TYPE: 'windows',
+        ARCHITECTURE: 'i386',
+        ARTIFACT_NAME: 'i386-windows-bugsnag-cli.exe',
+        BINARY_NAME: 'bugsnag-cli.exe'
     },
     {
-        TYPE: "linux",
-        ARCHITECTURE: "x86_64",
-        ARTIFACT_NAME: "x86_64-linux-bugsnag-cli",
-        BINARY_NAME: "bugsnag-cli"
-
+        TYPE: 'linux',
+        ARCHITECTURE: 'x86_64',
+        ARTIFACT_NAME: 'x86_64-linux-bugsnag-cli',
+        BINARY_NAME: 'bugsnag-cli'
     },
     {
-        TYPE: "linux",
-        ARCHITECTURE: "i386",
-        ARTIFACT_NAME: "i386-linux-bugsnag-cli",
-        BINARY_NAME: "bugsnag-cli"
+        TYPE: 'linux',
+        ARCHITECTURE: 'i386',
+        ARTIFACT_NAME: 'i386-linux-bugsnag-cli',
+        BINARY_NAME: 'bugsnag-cli'
     },
     {
-        TYPE: "Darwin",
-        ARCHITECTURE: "x86_64",
-        ARTIFACT_NAME: "x86_64-macos-bugsnag-cli",
-        BINARY_NAME: "bugsnag-cli"
+        TYPE: 'Darwin',
+        ARCHITECTURE: 'x86_64',
+        ARTIFACT_NAME: 'x86_64-macos-bugsnag-cli',
+        BINARY_NAME: 'bugsnag-cli'
     },
     {
-        TYPE: "Darwin",
-        ARCHITECTURE: "arm64",
-        ARTIFACT_NAME: "arm64-macos-bugsnag-cli",
-        BINARY_NAME: "bugsnag-cli"
+        TYPE: 'Darwin',
+        ARCHITECTURE: 'arm64',
+        ARTIFACT_NAME: 'arm64-macos-bugsnag-cli',
+        BINARY_NAME: 'bugsnag-cli'
     }
 ];
 
@@ -56,38 +60,49 @@ const getPlatformMetadata = () => {
     const type = os.type();
     const architecture = os.arch();
 
-    for (let supportedPlatform of supportedPlatforms) {
-        if (
-            type === supportedPlatform.TYPE &&
-            architecture === supportedPlatform.ARCHITECTURE
-        ) {
+    for (const supportedPlatform of supportedPlatforms) {
+        if (type === supportedPlatform.TYPE && architecture === supportedPlatform.ARCHITECTURE) {
             return supportedPlatform;
         }
     }
 
-    error(
-        `Platform with type "${type}" and architecture "${architecture}" is not supported by ${name}.\nYour system must be one of the following:\n\n${cTable.getTable(
-            supportedPlatforms
+    const supportedPlatformsTable = supportedPlatforms.map((platform) => {
+        return {
+            Type: platform.TYPE,
+            Architecture: platform.ARCHITECTURE,
+            Artifact: platform.ARTIFACT_NAME
+        };
+    });
+
+    handleError(
+        `Platform with type "${type}" and architecture "${architecture}" is not supported by ${name}.\nYour system must be one of the following:\n\n${JSON.stringify(
+            supportedPlatformsTable,
+            null,
+            2
         )}`
     );
 };
 
-async function downloadBinaryFromGitHub(url, outputPath) {
+const downloadBinaryFromGitHub = async (downloadUrl, outputPath) => {
     try {
-        const response = await axios.get(url, { responseType: 'arraybuffer' });
+        const binDir = path.resolve(__dirname, '..', '.bin');
+        if (!fs.existsSync(binDir)) {
+            fs.mkdirSync(binDir, { recursive: true });
+        }
+
+        const response = await axios.get(downloadUrl, { responseType: 'arraybuffer' });
         const binaryData = response.data;
         fs.writeFileSync(outputPath, binaryData, 'binary');
         fs.chmodSync(outputPath, '755');
         console.log('Binary downloaded successfully!');
-    } catch (error) {
-        console.error('Error downloading binary:', error.message);
+    } catch (err) {
+        console.error('Error downloading binary:', err.message);
     }
-}
+};
 
 const platformMetadata = getPlatformMetadata();
-
-const binaryUrl = `${repository.url}/releases/download/${version}/${platformMetadata.ARTIFACT_NAME}`;
-
-const binaryOutputPath = path.join(__dirname, 'node_modules', '.bin', platformMetadata.BINARY_NAME);
+const repoUrl = removeGitPrefixAndSuffix(repository.url);
+const binaryUrl = `${repoUrl}/releases/download/v${version}/${platformMetadata.ARTIFACT_NAME}`;
+const binaryOutputPath = path.join(__dirname, '..', '.bin', platformMetadata.BINARY_NAME);
 
 downloadBinaryFromGitHub(binaryUrl, binaryOutputPath);

--- a/package.json
+++ b/package.json
@@ -22,8 +22,5 @@
   ],
   "scripts": {
     "postinstall": "node install.js"
-  },
-  "bin": {
-    "bugsnag-cli": "./node_modules/.bin/bugsnag-cli"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "bugsnag-cli",
-  "version": "v1.1.1",
+  "version": "1.1.1",
   "description": "BugSnag CLI",
   "main": "install.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bugsnag/bugsnag-cli.git"
+    "url": "https://github.com/bugsnag/bugsnag-cli"
   },
   "author": "BugSnag",
   "license": "ISC",
@@ -14,6 +14,16 @@
   },
   "homepage": "https://github.com/bugsnag/bugsnag-cli#readme",
   "dependencies": {
+    "axios": "^1.4.0",
     "console.table": "^0.10.0"
+  },
+  "files": [
+    "install.js"
+  ],
+  "scripts": {
+    "postinstall": "node install.js"
+  },
+  "bin": {
+    "bugsnag-cli": "./node_modules/.bin/bugsnag-cli"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "bugsnag-cli",
+  "version": "1.1.1",
+  "description": "BugSnag CLI",
+  "main": "install.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bugsnag/bugsnag-cli.git"
+  },
+  "author": "BugSnag",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/bugsnag/bugsnag-cli/issues"
+  },
+  "homepage": "https://github.com/bugsnag/bugsnag-cli#readme",
+  "dependencies": {
+    "console.table": "^0.10.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bugsnag-cli",
-  "version": "1.1.1",
+  "version": "v1.1.1",
   "description": "BugSnag CLI",
   "main": "install.js",
   "repository": {


### PR DESCRIPTION
## Goal

The goal for this PR is to add the `install.js` script to handle the downloading and installing for the correct version of the Bugsnag CLI which will be published as a package to the NPM repository. I've currently got the package in the root of the repo as its only a small file and shouldn't really need anything else adding to it but we may want to move it to its own subfolder for ease of navigation.

Add scripts to the projects `package.json` 

- `bugsnagUpload` - `bugsnag-cli upload react-native-cli` - `npm run bugsnagUpload -- --api-key=YOUR_API_KEY`
- `bugsnagCreateBuild` - `bugsnag-cli create-build` - `npm run bugsnagCreateBuild -- --api-key=YOUR_API_KEY`

## Changeset

Add the foundation for the NPM package so that we can publish it via NPMJS and install the Bugsnag CLI via NPM

## Testing

Tested locally using `verdaccio` 

```
npm install bugsnag-cli --save --registry http://localhost:4873

> bugsnag-cli@1.1.1 postinstall node_modules/bugsnag-cli
> node install.js

Binary downloaded successfully!
npm WARN my-npm-package@1.0.0 No description
npm WARN my-npm-package@1.0.0 No repository field.

+ bugsnag-cli@1.1.1
updated 1 package and audited 15 packages in 5.315s
found 0 vulnerabilities
```