### PR TITLE
[PLAT-10357] Move global `appVersion`, `appVersionCode` and `appBundleVersion` to sub commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Add support for installing the CLI via NPM - [40](https://github.com/bugsnag/bug
 
 Move global `appVersion`, `appVersionCode` and `appBundleVersion` flags to sub commands for `dart` and `create-build` - [41](https://github.com/bugsnag/bugsnag-cli/pull/41)
 
-Correct `buildUUID` name in server requests - [41](https://github.com/bugsnag/bugsnag-cli/pull/41)
+Correct `buildUUID` name in server requests for Android Proguard - [41](https://github.com/bugsnag/bugsnag-cli/pull/41)
 
 ## 1.1.1 (2023-05-25)   
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## 1.2.0 (TBD)
+## 1.2.0 (2023-06-29)
 
 Add support for installing the CLI via NPM - [40](https://github.com/bugsnag/bugsnag-cli/pull/40)
 
 Move global `appVersion`, `appVersionCode` and `appBundleVersion` flags to sub commands for `dart` and `create-build` - [41](https://github.com/bugsnag/bugsnag-cli/pull/41)
+
+Correct `buildUUID` name in server requests - [41](https://github.com/bugsnag/bugsnag-cli/pull/41)
 
 ## 1.1.1 (2023-05-25)   
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Move global `appVersion`, `appVersionCode` and `appBundleVersion` flags to sub c
 
 Correct `buildUUID` name in server requests for Android Proguard - [41](https://github.com/bugsnag/bugsnag-cli/pull/41)
 
+Get values from Android AAB manifest via resource ID - [41](https://github.com/bugsnag/bugsnag-cli/pull/41)
+
 ## 1.1.1 (2023-05-25)   
 
 Fix how we check for the AndroidManifest.xml file for Android AAB - [37](https://github.com/bugsnag/bugsnag-cli/pull/37)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## 1.2.0 (2023-06-13)
+## 1.2.0 (TBD)
 
-Add support for installing the CLI via NPM - [42](https://github.com/bugsnag/bugsnag-cli/pull/41)
+Add support for installing the CLI via NPM - [40](https://github.com/bugsnag/bugsnag-cli/pull/40)
 
-## 1.1.1 (2023-05-25)
+Move global `appVersion`, `appVersionCode` and `appBundleVersion` flags to sub commands for `dart` and `create-build` - [41](https://github.com/bugsnag/bugsnag-cli/pull/41)
+
+## 1.1.1 (2023-05-25)   
 
 Fix how we check for the AndroidManifest.xml file for Android AAB - [37](https://github.com/bugsnag/bugsnag-cli/pull/37)
 

--- a/main.go
+++ b/main.go
@@ -156,9 +156,9 @@ func main() {
 		}
 
 		err := upload.Dart(commands.Upload.DartSymbol.Path,
-			commands.Upload.DartSymbol.Version,
-			commands.Upload.DartSymbol.VersionCode,
-			commands.Upload.DartSymbol.BundleVersion,
+			utils.XorString(commands.Upload.DartSymbol.Version, commands.Upload.DartSymbol.AppVersion),
+			utils.XorString(commands.Upload.DartSymbol.VersionCode, commands.Upload.DartSymbol.AppVersionCode),
+			utils.XorString(commands.Upload.DartSymbol.BundleVersion, commands.Upload.DartSymbol.AppBundleVersion),
 			commands.Upload.DartSymbol.IosAppPath,
 			endpoint,
 			commands.Upload.Timeout,
@@ -221,9 +221,9 @@ func main() {
 			commands.CreateBuild.Provider,
 			commands.CreateBuild.Repository,
 			commands.CreateBuild.Revision,
-			commands.CreateBuild.Version,
-			commands.CreateBuild.VersionCode,
-			commands.CreateBuild.BundleVersion,
+			utils.XorString(commands.CreateBuild.Version, commands.CreateBuild.AppVersion),
+			utils.XorString(commands.CreateBuild.VersionCode, commands.CreateBuild.AppVersionCode),
+			utils.XorString(commands.CreateBuild.BundleVersion, commands.CreateBuild.AppBundleVersion),
 			commands.CreateBuild.Metadata,
 			commands.CreateBuild.Path,
 			endpoint)

--- a/main.go
+++ b/main.go
@@ -17,9 +17,6 @@ func main() {
 		Port              int    `help:"Port number for the upload server" default:"443"`
 		ApiKey            string `help:"(required) Bugsnag integration API key for this application"`
 		FailOnUploadError bool   `help:"Stops the upload when a mapping file fails to upload to Bugsnag successfully" default:"false"`
-		AppVersion        string `help:"The version of the application."`
-		AppVersionCode    string `help:"The version code for the application (Android only)."`
-		AppBundleVersion  string `help:"The bundle version for the application (iOS only)."`
 		Upload            struct {
 
 			// shared options
@@ -159,9 +156,9 @@ func main() {
 		}
 
 		err := upload.Dart(commands.Upload.DartSymbol.Path,
-			commands.AppVersion,
-			commands.AppVersionCode,
-			commands.AppBundleVersion,
+			commands.Upload.DartSymbol.Version,
+			commands.Upload.DartSymbol.VersionCode,
+			commands.Upload.DartSymbol.BundleVersion,
 			commands.Upload.DartSymbol.IosAppPath,
 			endpoint,
 			commands.Upload.Timeout,
@@ -224,9 +221,9 @@ func main() {
 			commands.CreateBuild.Provider,
 			commands.CreateBuild.Repository,
 			commands.CreateBuild.Revision,
-			commands.AppVersion,
-			commands.AppVersionCode,
-			commands.AppBundleVersion,
+			commands.CreateBuild.Version,
+			commands.CreateBuild.VersionCode,
+			commands.CreateBuild.BundleVersion,
 			commands.CreateBuild.Metadata,
 			commands.CreateBuild.Path,
 			endpoint)

--- a/main.go
+++ b/main.go
@@ -156,7 +156,7 @@ func main() {
 		}
 
 		err := upload.Dart(commands.Upload.DartSymbol.Path,
-			utils.XorString(commands.Upload.DartSymbol.Version, commands.Upload.DartSymbol.AppVersion),
+			utils.XorString(commands.Upload.DartSymbol.VersionName, commands.Upload.DartSymbol.AppVersion),
 			utils.XorString(commands.Upload.DartSymbol.VersionCode, commands.Upload.DartSymbol.AppVersionCode),
 			utils.XorString(commands.Upload.DartSymbol.BundleVersion, commands.Upload.DartSymbol.AppBundleVersion),
 			commands.Upload.DartSymbol.IosAppPath,
@@ -221,7 +221,7 @@ func main() {
 			commands.CreateBuild.Provider,
 			commands.CreateBuild.Repository,
 			commands.CreateBuild.Revision,
-			utils.XorString(commands.CreateBuild.Version, commands.CreateBuild.AppVersion),
+			utils.XorString(commands.CreateBuild.VersionName, commands.CreateBuild.AppVersion),
 			utils.XorString(commands.CreateBuild.VersionCode, commands.CreateBuild.AppVersionCode),
 			utils.XorString(commands.CreateBuild.BundleVersion, commands.CreateBuild.AppBundleVersion),
 			commands.CreateBuild.Metadata,

--- a/pkg/android/manifest-reader-aab.go
+++ b/pkg/android/manifest-reader-aab.go
@@ -24,18 +24,18 @@ func ReadAabManifest(path string) (map[string]string, error) {
 	}
 
 	for _, data := range rawAabManifestData.GetElement().GetAttribute() {
-		if data.Name == "versionCode" {
-			aabManifestData["versionCode"] = data.Value
+		if data.ResourceId == 16843291 || data.Name == "versionCode" {
+			aabManifestData["versionCode"] = data.GetValue()
 			continue
 		}
 
 		if data.Name == "package" {
-			aabManifestData["applicationId"] = data.Value
+			aabManifestData["applicationId"] = data.GetValue()
 			continue
 		}
 
-		if data.Name == "versionName" {
-			aabManifestData["versionName"] = data.Value
+		if data.ResourceId == 16843292 || data.Name == "versionName" {
+			aabManifestData["versionName"] = data.GetValue()
 			continue
 		}
 	}

--- a/pkg/build/create.go
+++ b/pkg/build/create.go
@@ -14,13 +14,16 @@ import (
 )
 
 type CreateBuild struct {
-	BuilderName  string            `help:"The name of the entity that triggered the build. Could be a user, system etc."`
-	Metadata     map[string]string `help:"Additional build information"`
-	ReleaseStage string            `help:"The release stage (eg, production, staging) that is being released (if applicable)."`
-	Provider     string            `help:"The name of the source control provider that contains the source code for the build."`
-	Repository   string            `help:"The URL of the repository containing the source code being deployed."`
-	Revision     string            `help:"The source control SHA-1 hash for the code that has been built (short or long hash)"`
-	Path         utils.UploadPaths `arg:"" name:"path" help:"Path to the project directory" type:"path" default:"."`
+	BuilderName   string            `help:"The name of the entity that triggered the build. Could be a user, system etc."`
+	Metadata      map[string]string `help:"Additional build information"`
+	ReleaseStage  string            `help:"The release stage (eg, production, staging) that is being released (if applicable)."`
+	Provider      string            `help:"The name of the source control provider that contains the source code for the build."`
+	Repository    string            `help:"The URL of the repository containing the source code being deployed."`
+	Revision      string            `help:"The source control SHA-1 hash for the code that has been built (short or long hash)"`
+	Path          utils.UploadPaths `arg:"" name:"path" help:"Path to the project directory" type:"path" default:"."`
+	Version       string            `help:"The version of the application."`
+	VersionCode   string            `help:"The version code for the application (Android only)."`
+	BundleVersion string            `help:"The bundle version for the application (iOS only)."`
 }
 
 type Payload struct {
@@ -40,8 +43,8 @@ type SourceControl struct {
 	Revision   string `json:"revision,omitempty"`
 }
 
-func ProcessBuildRequest(apiKey string, builderName string, releaseStage string, provider string, repository string, revision string, appVersion string, appVersionCode string, appBundleVersion string, metadata map[string]string, paths []string, endpoint string) error {
-	if appVersion == "" {
+func ProcessBuildRequest(apiKey string, builderName string, releaseStage string, provider string, repository string, revision string, version string, versionCode string, bundleVersion string, metadata map[string]string, paths []string, endpoint string) error {
+	if version == "" {
 		log.Error("Missing app version, please provide this via the command line options", 1)
 	}
 
@@ -63,9 +66,9 @@ func ProcessBuildRequest(apiKey string, builderName string, releaseStage string,
 			Revision:   repoInfo["revision"],
 		},
 		Metadata:         metadata,
-		AppVersion:       appVersion,
-		AppVersionCode:   appVersionCode,
-		AppBundleVersion: appBundleVersion,
+		AppVersion:       version,
+		AppVersionCode:   versionCode,
+		AppBundleVersion: bundleVersion,
 	}
 
 	buildPayload, err := json.Marshal(payload)

--- a/pkg/build/create.go
+++ b/pkg/build/create.go
@@ -21,8 +21,8 @@ type CreateBuild struct {
 	Repository       string            `help:"The URL of the repository containing the source code being deployed."`
 	Revision         string            `help:"The source control SHA-1 hash for the code that has been built (short or long hash)"`
 	Path             utils.UploadPaths `arg:"" name:"path" help:"Path to the project directory" type:"path" default:"."`
-	Version          string            `help:"The version of the application." xor:"app-version,version"`
-	AppVersion       string            `help:"(deprecated) The version of the application." xor:"app-version,version"`
+	VersionName      string            `help:"The version of the application." xor:"app-version,version-name"`
+	AppVersion       string            `help:"(deprecated) The version of the application." xor:"app-version,version-name"`
 	VersionCode      string            `help:"The version code for the application (Android only)." xor:"app-version-code,version-code"`
 	AppVersionCode   string            `help:"(deprecated) The version code for the application (Android only)." xor:"app-version-code,version-code"`
 	BundleVersion    string            `help:"The bundle version for the application (iOS only)." xor:"app-bundle-version,bundle-version"`

--- a/pkg/build/create.go
+++ b/pkg/build/create.go
@@ -14,16 +14,19 @@ import (
 )
 
 type CreateBuild struct {
-	BuilderName   string            `help:"The name of the entity that triggered the build. Could be a user, system etc."`
-	Metadata      map[string]string `help:"Additional build information"`
-	ReleaseStage  string            `help:"The release stage (eg, production, staging) that is being released (if applicable)."`
-	Provider      string            `help:"The name of the source control provider that contains the source code for the build."`
-	Repository    string            `help:"The URL of the repository containing the source code being deployed."`
-	Revision      string            `help:"The source control SHA-1 hash for the code that has been built (short or long hash)"`
-	Path          utils.UploadPaths `arg:"" name:"path" help:"Path to the project directory" type:"path" default:"."`
-	Version       string            `help:"The version of the application." aliases:"app-version"`
-	VersionCode   string            `help:"The version code for the application (Android only)." aliases:"app-version-code"`
-	BundleVersion string            `help:"The bundle version for the application (iOS only)." aliases:"app-bundle-version"`
+	BuilderName      string            `help:"The name of the entity that triggered the build. Could be a user, system etc."`
+	Metadata         map[string]string `help:"Additional build information"`
+	ReleaseStage     string            `help:"The release stage (eg, production, staging) that is being released (if applicable)."`
+	Provider         string            `help:"The name of the source control provider that contains the source code for the build."`
+	Repository       string            `help:"The URL of the repository containing the source code being deployed."`
+	Revision         string            `help:"The source control SHA-1 hash for the code that has been built (short or long hash)"`
+	Path             utils.UploadPaths `arg:"" name:"path" help:"Path to the project directory" type:"path" default:"."`
+	Version          string            `help:"The version of the application." xor:"app-version,version"`
+	AppVersion       string            `help:"(deprecated) The version of the application." xor:"app-version,version"`
+	VersionCode      string            `help:"The version code for the application (Android only)." xor:"app-version-code,version-code"`
+	AppVersionCode   string            `help:"(deprecated) The version code for the application (Android only)." xor:"app-version-code,version-code"`
+	BundleVersion    string            `help:"The bundle version for the application (iOS only)." xor:"app-bundle-version,bundle-version"`
+	AppBundleVersion string            `help:"(deprecated) The bundle version for the application (iOS only)." xor:"app-bundle-version,bundle-version"`
 }
 
 type Payload struct {

--- a/pkg/build/create.go
+++ b/pkg/build/create.go
@@ -21,9 +21,9 @@ type CreateBuild struct {
 	Repository    string            `help:"The URL of the repository containing the source code being deployed."`
 	Revision      string            `help:"The source control SHA-1 hash for the code that has been built (short or long hash)"`
 	Path          utils.UploadPaths `arg:"" name:"path" help:"Path to the project directory" type:"path" default:"."`
-	Version       string            `help:"The version of the application."`
-	VersionCode   string            `help:"The version code for the application (Android only)."`
-	BundleVersion string            `help:"The bundle version for the application (iOS only)."`
+	Version       string            `help:"The version of the application." aliases:"app-version"`
+	VersionCode   string            `help:"The version code for the application (Android only)." aliases:"app-version-code"`
+	BundleVersion string            `help:"The bundle version for the application (iOS only)." aliases:"app-bundle-version"`
 }
 
 type Payload struct {

--- a/pkg/proto_messages/Resources.pb.go
+++ b/pkg/proto_messages/Resources.pb.go
@@ -25,6 +25,7 @@ import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
+	"strconv"
 	sync "sync"
 )
 
@@ -3147,6 +3148,9 @@ func (x *XmlAttribute) GetName() string {
 
 func (x *XmlAttribute) GetValue() string {
 	if x != nil {
+		if x.Value == "" {
+			return strconv.Itoa(int(x.CompiledItem.GetPrim().GetIntDecimalValue()))
+		}
 		return x.Value
 	}
 	return ""

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -153,7 +153,7 @@ func ProcessAndroidProguard(apiKey string, applicationId string, appManifestPath
 		uploadOptions, err := utils.BuildAndroidProguardUploadOptions(apiKey, applicationId, versionName, versionCode, buildUuid, overwrite)
 
 		if err != nil {
-			return nil
+			return err
 		}
 
 		fileFieldData := make(map[string]string)

--- a/pkg/upload/dart.go
+++ b/pkg/upload/dart.go
@@ -17,11 +17,14 @@ import (
 )
 
 type DartSymbol struct {
-	Path       utils.UploadPaths `arg:"" name:"path" help:"(required) Path to directory or file to upload" type:"path"`
-	IosAppPath string            `help:"(optional) the path to the built iOS app."`
+	Path          utils.UploadPaths `arg:"" name:"path" help:"(required) Path to directory or file to upload" type:"path"`
+	IosAppPath    string            `help:"(optional) the path to the built iOS app."`
+	Version       string            `help:"The version of the application."`
+	VersionCode   string            `help:"The version code for the application (Android only)."`
+	BundleVersion string            `help:"The bundle version for the application (iOS only)."`
 }
 
-func Dart(paths []string, appVersion string, appVersionCode string, appBundleVersion string, iosAppPath string, endpoint string, timeout int, retries int, overwrite bool, apiKey string, failOnUploadError bool) error {
+func Dart(paths []string, version string, versionCode string, bundleVersion string, iosAppPath string, endpoint string, timeout int, retries int, overwrite bool, apiKey string, failOnUploadError bool) error {
 	log.Info("Building file list from path")
 
 	fileList, err := utils.BuildFileList(paths)
@@ -50,7 +53,7 @@ func Dart(paths []string, appVersion string, appVersionCode string, appBundleVer
 			}
 
 			// Build Upload options
-			uploadOptions := utils.BuildDartUploadOptions(apiKey, buildId, "android", overwrite, appVersion, appVersionCode)
+			uploadOptions := utils.BuildDartUploadOptions(apiKey, buildId, "android", overwrite, version, versionCode)
 
 			fileFieldData := make(map[string]string)
 			fileFieldData["symbolFile"] = file
@@ -95,7 +98,7 @@ func Dart(paths []string, appVersion string, appVersionCode string, appBundleVer
 			}
 
 			// Build Upload options
-			uploadOptions := utils.BuildDartUploadOptions(apiKey, buildId, "ios", overwrite, appVersion, appBundleVersion)
+			uploadOptions := utils.BuildDartUploadOptions(apiKey, buildId, "ios", overwrite, version, bundleVersion)
 
 			fileFieldData := make(map[string]string)
 			fileFieldData["symbolFile"] = file

--- a/pkg/upload/dart.go
+++ b/pkg/upload/dart.go
@@ -19,8 +19,8 @@ import (
 type DartSymbol struct {
 	Path             utils.UploadPaths `arg:"" name:"path" help:"(required) Path to directory or file to upload" type:"path"`
 	IosAppPath       string            `help:"(optional) the path to the built iOS app."`
-	Version          string            `help:"The version of the application." xor:"app-version,version"`
-	AppVersion       string            `help:"(deprecated) The version of the application." xor:"app-version,version"`
+	VersionName      string            `help:"The version of the application." xor:"app-version,version-name"`
+	AppVersion       string            `help:"(deprecated) The version of the application." xor:"app-version,version-name"`
 	VersionCode      string            `help:"The version code for the application (Android only)." xor:"app-version-code,version-code"`
 	AppVersionCode   string            `help:"(deprecated) The version code for the application (Android only)." xor:"app-version-code,version-code"`
 	BundleVersion    string            `help:"The bundle version for the application (iOS only)." xor:"app-bundle-version,bundle-version"`

--- a/pkg/upload/dart.go
+++ b/pkg/upload/dart.go
@@ -19,9 +19,9 @@ import (
 type DartSymbol struct {
 	Path          utils.UploadPaths `arg:"" name:"path" help:"(required) Path to directory or file to upload" type:"path"`
 	IosAppPath    string            `help:"(optional) the path to the built iOS app."`
-	Version       string            `help:"The version of the application."`
-	VersionCode   string            `help:"The version code for the application (Android only)."`
-	BundleVersion string            `help:"The bundle version for the application (iOS only)."`
+	Version       string            `help:"The version of the application." aliases:"app-version"`
+	VersionCode   string            `help:"The version code for the application (Android only)." aliases:"app-version-code"`
+	BundleVersion string            `help:"The bundle version for the application (iOS only)." aliases:"app-bundle-version"`
 }
 
 func Dart(paths []string, version string, versionCode string, bundleVersion string, iosAppPath string, endpoint string, timeout int, retries int, overwrite bool, apiKey string, failOnUploadError bool) error {

--- a/pkg/upload/dart.go
+++ b/pkg/upload/dart.go
@@ -17,15 +17,22 @@ import (
 )
 
 type DartSymbol struct {
-	Path          utils.UploadPaths `arg:"" name:"path" help:"(required) Path to directory or file to upload" type:"path"`
-	IosAppPath    string            `help:"(optional) the path to the built iOS app."`
-	Version       string            `help:"The version of the application." aliases:"app-version"`
-	VersionCode   string            `help:"The version code for the application (Android only)." aliases:"app-version-code"`
-	BundleVersion string            `help:"The bundle version for the application (iOS only)." aliases:"app-bundle-version"`
+	Path             utils.UploadPaths `arg:"" name:"path" help:"(required) Path to directory or file to upload" type:"path"`
+	IosAppPath       string            `help:"(optional) the path to the built iOS app."`
+	Version          string            `help:"The version of the application." xor:"app-version,version"`
+	AppVersion       string            `help:"(deprecated) The version of the application." xor:"app-version,version"`
+	VersionCode      string            `help:"The version code for the application (Android only)." xor:"app-version-code,version-code"`
+	AppVersionCode   string            `help:"(deprecated) The version code for the application (Android only)." xor:"app-version-code,version-code"`
+	BundleVersion    string            `help:"The bundle version for the application (iOS only)." xor:"app-bundle-version,bundle-version"`
+	AppBundleVersion string            `help:"(deprecated) The bundle version for the application (iOS only)." xor:"app-bundle-version,bundle-version"`
 }
 
 func Dart(paths []string, version string, versionCode string, bundleVersion string, iosAppPath string, endpoint string, timeout int, retries int, overwrite bool, apiKey string, failOnUploadError bool) error {
 	log.Info("Building file list from path")
+
+	log.Info(version)
+	log.Info(versionCode)
+	log.Info(bundleVersion)
 
 	fileList, err := utils.BuildFileList(paths)
 	numberOfFiles := len(fileList)
@@ -58,7 +65,7 @@ func Dart(paths []string, version string, versionCode string, bundleVersion stri
 			fileFieldData := make(map[string]string)
 			fileFieldData["symbolFile"] = file
 
-			requestStatus := server.ProcessRequest(endpoint, uploadOptions, fileFieldData, timeout)
+			requestStatus := server.ProcessRequest(endpoint+"/dart-symbol", uploadOptions, fileFieldData, timeout)
 
 			if requestStatus != nil {
 				if numberOfFiles > 1 && failOnUploadError {

--- a/pkg/upload/dart.go
+++ b/pkg/upload/dart.go
@@ -30,10 +30,6 @@ type DartSymbol struct {
 func Dart(paths []string, version string, versionCode string, bundleVersion string, iosAppPath string, endpoint string, timeout int, retries int, overwrite bool, apiKey string, failOnUploadError bool) error {
 	log.Info("Building file list from path")
 
-	log.Info(version)
-	log.Info(versionCode)
-	log.Info(bundleVersion)
-
 	fileList, err := utils.BuildFileList(paths)
 	numberOfFiles := len(fileList)
 

--- a/pkg/utils/upload-options.go
+++ b/pkg/utils/upload-options.go
@@ -101,14 +101,14 @@ func BuildAndroidProguardUploadOptions(apiKey string, applicationId string, vers
 	}
 
 	if buildUuid != "" {
-		uploadOptions["buildUuid"] = buildUuid
+		uploadOptions["buildUUID"] = buildUuid
 	}
 
 	if overwrite {
 		uploadOptions["overwrite"] = "true"
 	}
 
-	if uploadOptions["appId"] == "" && uploadOptions["buildUuid"] == "" && uploadOptions["versionName"] == "" && uploadOptions["versionCode"] == "" {
+	if uploadOptions["appId"] == "" && uploadOptions["buildUUID"] == "" && uploadOptions["versionName"] == "" && uploadOptions["versionCode"] == "" {
 		return nil, fmt.Errorf("you must set at least the application ID, version name, version code or build UUID to uniquely identify the build")
 	}
 

--- a/pkg/utils/upload-options.go
+++ b/pkg/utils/upload-options.go
@@ -108,7 +108,7 @@ func BuildAndroidProguardUploadOptions(apiKey string, applicationId string, vers
 		uploadOptions["overwrite"] = "true"
 	}
 
-	if uploadOptions["appId"] == "" && uploadOptions["buildUUID"] == "" && uploadOptions["versionName"] == "" && uploadOptions["versionCode"] == "" {
+	if uploadOptions["appId"] == "" || uploadOptions["buildUUID"] == "" || uploadOptions["versionName"] == "" || uploadOptions["versionCode"] == "" {
 		return nil, fmt.Errorf("you must set at least the application ID, version name, version code or build UUID to uniquely identify the build")
 	}
 
@@ -148,7 +148,7 @@ func BuildReactNativeAndroidUploadOptions(apiKey string, appVersion string, appV
 		uploadOptions["overwrite"] = "true"
 	}
 
-	if uploadOptions["appVersion"] == "" && uploadOptions["appVersionCode"] == "" && uploadOptions["codeBundleId"] == "" {
+	if uploadOptions["appVersion"] == "" || uploadOptions["appVersionCode"] == "" || uploadOptions["codeBundleId"] == "" {
 		return nil, fmt.Errorf("you must set at least the version, version code or code bundle ID to uniquely identify the build")
 	}
 

--- a/pkg/utils/upload-options.go
+++ b/pkg/utils/upload-options.go
@@ -108,7 +108,7 @@ func BuildAndroidProguardUploadOptions(apiKey string, applicationId string, vers
 		uploadOptions["overwrite"] = "true"
 	}
 
-	if uploadOptions["appId"] == "" || uploadOptions["buildUUID"] == "" || uploadOptions["versionName"] == "" || uploadOptions["versionCode"] == "" {
+	if uploadOptions["appId"] == "" && uploadOptions["buildUUID"] == "" && uploadOptions["versionName"] == "" && uploadOptions["versionCode"] == "" {
 		return nil, fmt.Errorf("you must set at least the application ID, version name, version code or build UUID to uniquely identify the build")
 	}
 
@@ -148,7 +148,7 @@ func BuildReactNativeAndroidUploadOptions(apiKey string, appVersion string, appV
 		uploadOptions["overwrite"] = "true"
 	}
 
-	if uploadOptions["appVersion"] == "" || uploadOptions["appVersionCode"] == "" || uploadOptions["codeBundleId"] == "" {
+	if uploadOptions["appVersion"] == "" && uploadOptions["appVersionCode"] == "" && uploadOptions["codeBundleId"] == "" {
 		return nil, fmt.Errorf("you must set at least the version, version code or code bundle ID to uniquely identify the build")
 	}
 

--- a/pkg/utils/validation.go
+++ b/pkg/utils/validation.go
@@ -15,3 +15,11 @@ func (p UploadPaths) Validate() error {
 	}
 	return nil
 }
+
+// xorString checks if one string is not empty and returns a second string if it is
+func XorString(string1 string, string2 string) string {
+	if string1 != "" {
+		return string1
+	}
+	return string2
+}


### PR DESCRIPTION
## Goal

Move global flags:

- `appVersion` to `version`
- `appVersionCode` to `versionCode`
- `appBundleVersion` to `bundleVersion`

in the `create-build` and `upload dart` sub commands

Correct `buildUUID` name in server requests for Android Proguard

Get values from Android AAB manifest via resource ID

## Design

This approach matches the pattern used in all new sub commands.

## Testing

- Android Proguard - Tested manually

<img width="1141" alt="Screenshot 2023-06-29 at 10 33 32" src="https://github.com/bugsnag/bugsnag-cli/assets/46817760/8b7aa945-27b7-47a9-b8a8-c2ed7c20be76">


