### PR TITLE
[PLAT-10452] Remove hardcoded paths for react native bundle path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.1 (2023-06-30)
+
+Allow non-standard variants when not providing the bundle path as a flag to the CLI. [44](https://github.com/bugsnag/bugsnag-cli/pull/44)
+
 ## 1.2.0 (2023-06-29)
 
 Add support for installing the CLI via NPM - [40](https://github.com/bugsnag/bugsnag-cli/pull/40)

--- a/main.go
+++ b/main.go
@@ -184,7 +184,7 @@ func main() {
 			commands.Upload.ReactNativeAndroid.Path,
 			commands.Upload.ReactNativeAndroid.ProjectRoot,
 			commands.Upload.ReactNativeAndroid.Variant,
-			commands.Upload.ReactNativeAndroid.Version,
+			utils.XorString(commands.Upload.ReactNativeAndroid.VersionName, commands.Upload.ReactNativeAndroid.Version),
 			commands.Upload.ReactNativeAndroid.VersionCode,
 			commands.Upload.ReactNativeAndroid.SourceMap,
 			endpoint,

--- a/pkg/android/get-variant.go
+++ b/pkg/android/get-variant.go
@@ -25,7 +25,7 @@ func BuildVariantsList(path string) ([]string, error) {
 	return variants, nil
 }
 
-func GetVariant(path string) (string, error) {
+func GetVariantDirectory(path string) (string, error) {
 	var variants []string
 
 	fileInfo, err := ioutil.ReadDir(path)

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -47,7 +47,7 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 			}
 
 			if variant == "" {
-				variant, err = android.GetVariant(mergeNativeLibPath)
+				variant, err = android.GetVariantDirectory(mergeNativeLibPath)
 
 				if err != nil {
 					return err
@@ -81,7 +81,7 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 					mergeNativeLibPath = filepath.Join(path, "..", "..", "..", "..", "..")
 
 					if filepath.Base(mergeNativeLibPath) == "merged_native_libs" {
-						variant, err = android.GetVariant(mergeNativeLibPath)
+						variant, err = android.GetVariantDirectory(mergeNativeLibPath)
 
 						if err == nil {
 							appManifestPathExpected = filepath.Join(mergeNativeLibPath, "..", "merged_manifests", variant, "AndroidManifest.xml")

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -37,7 +37,7 @@ func ProcessAndroidProguard(apiKey string, applicationId string, appManifestPath
 			}
 
 			if variant == "" {
-				variant, err = android.GetVariant(mappingPath)
+				variant, err = android.GetVariantDirectory(mappingPath)
 
 				if err != nil {
 					return err
@@ -67,7 +67,7 @@ func ProcessAndroidProguard(apiKey string, applicationId string, appManifestPath
 					mergedManifestPath := filepath.Join(path, "..", "..", "..", "..", "intermediates", "merged_manifests")
 
 					if filepath.Base(mergedManifestPath) == "merged_manifests" {
-						variant, err = android.GetVariant(mergedManifestPath)
+						variant, err = android.GetVariantDirectory(mergedManifestPath)
 						if err == nil {
 							appManifestPathExpected = filepath.Join(mergedManifestPath, variant, "AndroidManifest.xml")
 							if utils.FileExists(appManifestPathExpected) {

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -121,39 +121,36 @@ func ProcessReactNativeAndroid(apiKey string, appManifestPath string, bundlePath
 				appManifestPath = appManifestPathExpected
 				log.Info("Found app manifest at: " + appManifestPath)
 			} else {
-				appManifestPath = ""
+				log.Info("No app manifest found at: " + appManifestPathExpected)
 			}
 		}
 
-		if apiKey == "" || versionName == "" || versionCode == "" {
-			if appManifestPath != "" {
-				manifestData, err := android.ParseAndroidManifestXML(appManifestPath)
+		if appManifestPath != "" && (apiKey == "" || versionName == "" || versionCode == "") {
 
-				if err != nil {
-					return err
-				}
+			manifestData, err := android.ParseAndroidManifestXML(appManifestPath)
 
-				if apiKey == "" {
-					for key, value := range manifestData.Application.MetaData.Name {
-						if value == "com.bugsnag.android.API_KEY" {
-							apiKey = manifestData.Application.MetaData.Value[key]
-						}
+			if err != nil {
+				return err
+			}
+
+			if apiKey == "" {
+				for key, value := range manifestData.Application.MetaData.Name {
+					if value == "com.bugsnag.android.API_KEY" {
+						apiKey = manifestData.Application.MetaData.Value[key]
 					}
-
-					log.Info("Using " + apiKey + " as API key from AndroidManifest.xml")
 				}
 
-				if versionName == "" {
-					versionName = manifestData.VersionName
-					log.Info("Using " + versionName + " as version name from AndroidManifest.xml")
-				}
+				log.Info("Using " + apiKey + " as API key from AndroidManifest.xml")
+			}
 
-				if versionCode == "" {
-					versionCode = manifestData.VersionCode
-					log.Info("Using " + versionCode + " as version code from AndroidManifest.xml")
-				}
-			} else {
-				return fmt.Errorf("unable to open AndroidManifest.xml to retrieve missing api key, version name, version code or code bundle ID")
+			if versionName == "" {
+				versionName = manifestData.VersionName
+				log.Info("Using " + versionName + " as version name from AndroidManifest.xml")
+			}
+
+			if versionCode == "" {
+				versionCode = manifestData.VersionCode
+				log.Info("Using " + versionCode + " as version code from AndroidManifest.xml")
 			}
 		}
 

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -53,11 +53,12 @@ func ProcessReactNativeAndroid(apiKey string, appManifestPath string, bundlePath
 		}
 
 		if bundlePath == "" {
+			// Check the path for RN version <= 0.69 - generated/assets/react/<variant>/index.android.bundle
 			bundleDirPath := filepath.Join(buildDirPath, "generated", "assets", "react")
 
 			if utils.IsDir(bundleDirPath) {
 				if variant == "" {
-					variant, err = android.GetVariant(bundleDirPath)
+					variant, err = android.GetVariantDirectory(bundleDirPath)
 					if err != nil {
 						return err
 					}
@@ -65,16 +66,17 @@ func ProcessReactNativeAndroid(apiKey string, appManifestPath string, bundlePath
 
 				bundlePath = filepath.Join(bundleDirPath, variant, "index.android.bundle")
 			} else {
+				// Check the path for RN versions >= 0.70 - ASSETS/createBundle<variant>JsAndAssets/index.android.bundle
 				bundleDirPath := filepath.Join(buildDirPath, "ASSETS")
 
 				if utils.IsDir(bundleDirPath) {
 					if variant == "" {
-						variant, err = android.GetVariant(bundleDirPath)
+						variantDirName, err := android.GetVariantDirectory(bundleDirPath)
 						if err != nil {
 							return err
 						}
 
-						bundlePath = filepath.Join(bundleDirPath, variant, "index.android.bundle")
+						bundlePath = filepath.Join(bundleDirPath, variantDirName, "index.android.bundle")
 					} else {
 						bundlePath = filepath.Join(bundleDirPath, "createBundle"+strings.Title(variant)+"JsAndAssets", "index.android.bundle")
 					}
@@ -90,7 +92,7 @@ func ProcessReactNativeAndroid(apiKey string, appManifestPath string, bundlePath
 			sourceMapDirPath := filepath.Join(buildDirPath, "generated", "sourcemaps", "react")
 
 			if variant == "" {
-				variant, err = android.GetVariant(sourceMapDirPath)
+				variant, err = android.GetVariantDirectory(sourceMapDirPath)
 				if err != nil {
 					return err
 				}
@@ -103,7 +105,7 @@ func ProcessReactNativeAndroid(apiKey string, appManifestPath string, bundlePath
 				sourceMapDirPath := filepath.Join(sourceMapPath, "..", "..")
 
 				if filepath.Base(sourceMapDirPath) == "react" {
-					variant, err = android.GetVariant(sourceMapDirPath)
+					variant, err = android.GetVariantDirectory(sourceMapDirPath)
 					if err != nil {
 						return err
 					}

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -20,6 +20,7 @@ type ReactNativeAndroid struct {
 	ProjectRoot  string            `help:"path to remove from the beginning of the filenames in the mapping file" type:"path"`
 	SourceMap    string            `help:"Path to the source map file" type:"path"`
 	Variant      string            `help:"Build type, like 'debug' or 'release'"`
+	Version      string            `help:"(depricated) The version name of the application."`
 	VersionName  string            `help:"The version name of the application."`
 	VersionCode  string            `help:"The version code for the application (Android only)."`
 }

--- a/pkg/utils/upload-options.go
+++ b/pkg/utils/upload-options.go
@@ -149,7 +149,7 @@ func BuildReactNativeAndroidUploadOptions(apiKey string, appVersion string, appV
 	}
 
 	if uploadOptions["appVersion"] == "" && uploadOptions["appVersionCode"] == "" && uploadOptions["codeBundleId"] == "" {
-		return nil, fmt.Errorf("you must set at least the version, version code or code bundle ID to uniquely identify the build")
+		return nil, fmt.Errorf("you must set at least the version name, version code or code bundle ID to uniquely identify the build")
 	}
 
 	return uploadOptions, nil

--- a/pkg/utils/validation.go
+++ b/pkg/utils/validation.go
@@ -16,7 +16,7 @@ func (p UploadPaths) Validate() error {
 	return nil
 }
 
-// xorString checks if one string is not empty and returns a second string if it is
+// XorString checks if one string is not empty and returns a second string if it is
 func XorString(string1 string, string2 string) string {
 	if string1 != "" {
 		return string1


### PR DESCRIPTION
## Goal

Allow non-standard variants when not providing the bundle path as a flag to the CLI.

Correctly throw an error when trying to retrieve `apiKey`, `versionName` or `versionCode` from a non-existent android manifest file

## Design

Remove the hardcoded bundle path from the react native upload function and auto detect the variant from the folder structure.

## Testing

Tested locally with multiple variants