### PR TITLE
[PLAT-10546] Add bundle path support for React Native 0.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## 1.2.1 (2023-06-30)
+## 1.2.1 (2023-07-03)
 
 Allow non-standard variants when not providing the bundle path as a flag to the CLI. [44](https://github.com/bugsnag/bugsnag-cli/pull/44)
+
+Add bundle path support for React Native 0.72. [46](https://github.com/bugsnag/bugsnag-cli/pull/46)
 
 ## 1.2.0 (2023-06-29)
 

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -32,6 +32,7 @@ func ProcessReactNativeAndroid(apiKey string, appManifestPath string, bundlePath
 	var rootDirPath string
 	var variantDirName string
 	var bundleDirPath string
+	var variantFileFormat string
 
 	if dryRun {
 		log.Info("Performing dry run - no files will be uploaded")
@@ -56,14 +57,18 @@ func ProcessReactNativeAndroid(apiKey string, appManifestPath string, bundlePath
 
 		if bundlePath == "" {
 			if utils.IsDir(filepath.Join(buildDirPath, "generated", "assets")) {
-				// RN versions >= 0.72 - generated/assets/createBundle<variant>JsAndAssets/index.android.bundle
+				// RN versions >= 0.72 - generated/assets/<variant>/index.android.bundle
 				bundleDirPath = filepath.Join(buildDirPath, "generated", "assets")
+				variantFileFormat = "createBundle%sJsAndAssets"
 			} else if utils.IsDir(filepath.Join(buildDirPath, "ASSETS")) {
 				// RN versions < 0.72 - ASSETS/createBundle<variant>JsAndAssets/index.android.bundle
 				bundleDirPath = filepath.Join(buildDirPath, "ASSETS")
+				variantFileFormat = "createBundle%sJsAndAssets"
 			} else if utils.IsDir(filepath.Join(buildDirPath, "generated", "assets", "react")) {
 				// RN version < 0.70 - generated/assets/react/<variant>/index.android.bundle
 				bundleDirPath = filepath.Join(buildDirPath, "generated", "assets", "react")
+			} else {
+				return fmt.Errorf("unable to find path containing the index.android.bundle")
 			}
 
 			if bundleDirPath != "" {
@@ -72,14 +77,14 @@ func ProcessReactNativeAndroid(apiKey string, appManifestPath string, bundlePath
 					if err != nil {
 						return err
 					}
-					bundlePath = filepath.Join(bundleDirPath, variantDirName, "index.android.bundle")
 				} else {
-					if filepath.Base(bundleDirPath) == "react" {
-						bundlePath = filepath.Join(bundleDirPath, variant, "index.android.bundle")
+					if variantFileFormat != "" {
+						variantDirName = fmt.Sprintf(variantFileFormat, strings.Title(variant))
 					} else {
-						bundlePath = filepath.Join(bundleDirPath, "createBundle"+strings.Title(variant)+"JsAndAssets", "index.android.bundle")
+						variantDirName = variant
 					}
 				}
+				bundlePath = filepath.Join(bundleDirPath, variantDirName, "index.android.bundle")
 			}
 		}
 

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -53,33 +53,44 @@ func ProcessReactNativeAndroid(apiKey string, appManifestPath string, bundlePath
 		}
 
 		if bundlePath == "" {
+			switch true {
 			// Check the path for RN version <= 0.69 - generated/assets/react/<variant>/index.android.bundle
-			bundleDirPath := filepath.Join(buildDirPath, "generated", "assets", "react")
-
-			if utils.IsDir(bundleDirPath) {
+			case utils.IsDir(filepath.Join(buildDirPath, "generated", "assets", "react")):
+				bundleDirPath := filepath.Join(buildDirPath, "generated", "assets", "react")
 				if variant == "" {
 					variant, err = android.GetVariantDirectory(bundleDirPath)
 					if err != nil {
 						return err
 					}
 				}
-
 				bundlePath = filepath.Join(bundleDirPath, variant, "index.android.bundle")
-			} else {
-				// Check the path for RN versions >= 0.70 - ASSETS/createBundle<variant>JsAndAssets/index.android.bundle
-				bundleDirPath := filepath.Join(buildDirPath, "ASSETS")
 
-				if utils.IsDir(bundleDirPath) {
-					if variant == "" {
-						variantDirName, err := android.GetVariantDirectory(bundleDirPath)
-						if err != nil {
-							return err
-						}
-
-						bundlePath = filepath.Join(bundleDirPath, variantDirName, "index.android.bundle")
-					} else {
-						bundlePath = filepath.Join(bundleDirPath, "createBundle"+strings.Title(variant)+"JsAndAssets", "index.android.bundle")
+			// Check the path for RN versions >= 0.72 - generated/assets/<variant>/index.android.bundle
+			case utils.IsDir(filepath.Join(buildDirPath, "generated", "assets")):
+				bundleDirPath := filepath.Join(buildDirPath, "generated", "assets")
+				if variant == "" {
+					variantDirName, err := android.GetVariantDirectory(bundleDirPath)
+					if err != nil {
+						return err
 					}
+
+					bundlePath = filepath.Join(bundleDirPath, variantDirName, "index.android.bundle")
+				} else {
+					bundlePath = filepath.Join(bundleDirPath, "createBundle"+strings.Title(variant)+"JsAndAssets", "index.android.bundle")
+				}
+
+			// Check the path for RN versions >= 0.70 - ASSETS/createBundle<variant>JsAndAssets/index.android.bundle
+			case utils.IsDir(filepath.Join(buildDirPath, "ASSETS")):
+				bundleDirPath := filepath.Join(buildDirPath, "ASSETS")
+				if variant == "" {
+					variantDirName, err := android.GetVariantDirectory(bundleDirPath)
+					if err != nil {
+						return err
+					}
+
+					bundlePath = filepath.Join(bundleDirPath, variantDirName, "index.android.bundle")
+				} else {
+					bundlePath = filepath.Join(bundleDirPath, "createBundle"+strings.Title(variant)+"JsAndAssets", "index.android.bundle")
 				}
 			}
 		}

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -68,7 +68,7 @@ func ProcessReactNativeAndroid(apiKey string, appManifestPath string, bundlePath
 				// RN version < 0.70 - generated/assets/react/<variant>/index.android.bundle
 				bundleDirPath = filepath.Join(buildDirPath, "generated", "assets", "react")
 			} else {
-				return fmt.Errorf("unable to find path containing the index.android.bundle")
+				return fmt.Errorf("unable to find index.android.bundle in your project, please specify the path using --bundle-path")
 			}
 
 			if bundleDirPath != "" {


### PR DESCRIPTION
## Goal

Add support for the new bundle path used in React Native 0.72

## Design

Implement a switch statement to check the different paths used by React Native  versions for the bundle file.

## Testing

This has been tested locally on RN version 0.69, 0.71 and 0.72