### PR TITLE
[HOTFIX] Add missing variant to the index.android.bundle path for react native android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.2 (TBD)
 
-Add missing variant to `index.android.bundle` path for React Native versions lower than 0.70. [47](https://github.com/bugsnag/bugsnag-cli/pull/44)
+Add missing variant to `index.android.bundle` path for React Native versions lower than 0.70. [49](https://github.com/bugsnag/bugsnag-cli/pull/49)
 
 ## 1.2.1 (2023-07-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.2 (TBD)
+
+Add missing variant to `index.android.bundle` path for React Native versions lower than 0.70. [47](https://github.com/bugsnag/bugsnag-cli/pull/44)
+
 ## 1.2.1 (2023-07-03)
 
 Allow non-standard variants when not providing the bundle path as a flag to the CLI. [44](https://github.com/bugsnag/bugsnag-cli/pull/44)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.2 (TBD)
 
-Add missing variant to `index.android.bundle` path for React Native versions lower than 0.70. [49](https://github.com/bugsnag/bugsnag-cli/pull/49)
+Adjust `index.android.bundle` path checking for React Native Android to ensure that paths are tested correctly. [49](https://github.com/bugsnag/bugsnag-cli/pull/49)
 
 ## 1.2.1 (2023-07-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Add bundle path support for React Native 0.72. [46](https://github.com/bugsnag/b
 
 ## 1.2.0 (2023-06-29)
 
-Add support for installing the CLI via NPM - [40](https://github.com/bugsnag/bugsnag-cli/pull/40)
+Add support for installing the CLI via NPM - [39](https://github.com/bugsnag/bugsnag-cli/pull/39)
 
 Move global `appVersion`, `appVersionCode` and `appBundleVersion` flags to sub commands for `dart` and `create-build` - [41](https://github.com/bugsnag/bugsnag-cli/pull/41)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/cli",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "BugSnag CLI",
   "main": "install.js",
   "repository": {

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -73,7 +73,7 @@ func ProcessReactNativeAndroid(apiKey string, appManifestPath string, bundlePath
 
 			if bundleDirPath != "" {
 				if variant == "" {
-					variantDirName, err = android.GetVariantDirectory(bundleDirPath)
+					variant, err = android.GetVariantDirectory(bundleDirPath)
 					if err != nil {
 						return err
 					}

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -59,13 +59,13 @@ func ProcessReactNativeAndroid(apiKey string, appManifestPath string, bundlePath
 			if utils.IsDir(filepath.Join(buildDirPath, "generated", "assets", "react")) {
 				// RN version < 0.70 - generated/assets/react/<variant>/index.android.bundle
 				bundleDirPath = filepath.Join(buildDirPath, "generated", "assets", "react")
-			} else if utils.IsDir(filepath.Join(buildDirPath, "generated", "assets")) {
-				// RN versions >= 0.72 - generated/assets/<variant>/index.android.bundle
-				bundleDirPath = filepath.Join(buildDirPath, "generated", "assets")
-				variantFileFormat = "createBundle%sJsAndAssets"
 			} else if utils.IsDir(filepath.Join(buildDirPath, "ASSETS")) {
 				// RN versions < 0.72 - ASSETS/createBundle<variant>JsAndAssets/index.android.bundle
 				bundleDirPath = filepath.Join(buildDirPath, "ASSETS")
+				variantFileFormat = "createBundle%sJsAndAssets"
+			} else if utils.IsDir(filepath.Join(buildDirPath, "generated", "assets")) {
+				// RN versions >= 0.72 - generated/assets/<variant>/index.android.bundle
+				bundleDirPath = filepath.Join(buildDirPath, "generated", "assets")
 				variantFileFormat = "createBundle%sJsAndAssets"
 			} else {
 				return fmt.Errorf("unable to find index.android.bundle in your project, please specify the path using --bundle-path")

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -56,7 +56,10 @@ func ProcessReactNativeAndroid(apiKey string, appManifestPath string, bundlePath
 		}
 
 		if bundlePath == "" {
-			if utils.IsDir(filepath.Join(buildDirPath, "generated", "assets")) {
+			if utils.IsDir(filepath.Join(buildDirPath, "generated", "assets", "react")) {
+				// RN version < 0.70 - generated/assets/react/<variant>/index.android.bundle
+				bundleDirPath = filepath.Join(buildDirPath, "generated", "assets", "react")
+			} else if utils.IsDir(filepath.Join(buildDirPath, "generated", "assets")) {
 				// RN versions >= 0.72 - generated/assets/<variant>/index.android.bundle
 				bundleDirPath = filepath.Join(buildDirPath, "generated", "assets")
 				variantFileFormat = "createBundle%sJsAndAssets"
@@ -64,16 +67,13 @@ func ProcessReactNativeAndroid(apiKey string, appManifestPath string, bundlePath
 				// RN versions < 0.72 - ASSETS/createBundle<variant>JsAndAssets/index.android.bundle
 				bundleDirPath = filepath.Join(buildDirPath, "ASSETS")
 				variantFileFormat = "createBundle%sJsAndAssets"
-			} else if utils.IsDir(filepath.Join(buildDirPath, "generated", "assets", "react")) {
-				// RN version < 0.70 - generated/assets/react/<variant>/index.android.bundle
-				bundleDirPath = filepath.Join(buildDirPath, "generated", "assets", "react")
 			} else {
 				return fmt.Errorf("unable to find index.android.bundle in your project, please specify the path using --bundle-path")
 			}
 
 			if bundleDirPath != "" {
 				if variant == "" {
-					variant, err = android.GetVariantDirectory(bundleDirPath)
+					variantDirName, err = android.GetVariantDirectory(bundleDirPath)
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
## Goal

Ensure source map uploads for React Native Android versions lower than 0.70 can find and upload the correct `index.android.bundle` file.

## Design

Adjust `index.android.bundle` path checking for React Native Android to ensure that paths are tested in the correct order.

## Changeset

Test for `buildDirPath, "generated", "assets", "react"` before testing for `buildDirPath, "generated", "assets"`

## Testing

Tested locally on React Native versions 0.60, 0.69 and 0.72