### PR TITLE
remove adding commands to the package.json when installing via NPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.2.2 (TBD)
 
+Do not modify the projects package.json when installing the CLI via NPM. [50](https://github.com/bugsnag/bugsnag-cli/pull/50)
+
 Adjust `index.android.bundle` path checking for React Native Android to ensure that paths are tested correctly. [49](https://github.com/bugsnag/bugsnag-cli/pull/49)
 
 ## 1.2.1 (2023-07-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.2.2 (TBD)
+## 1.2.2 (2023-07-11)
 
 Do not modify the projects package.json when installing the CLI via NPM. [50](https://github.com/bugsnag/bugsnag-cli/pull/50)
 

--- a/install.js
+++ b/install.js
@@ -100,41 +100,9 @@ const downloadBinaryFromGitHub = async (downloadUrl, outputPath) => {
     }
 };
 
-const writeToPackageJson = (packageJsonPath) => {
-    fs.readFile(packageJsonPath, 'utf8', (err, data) => {
-        if (err) {
-            console.error(`Error reading package.json: ${err}`);
-            return;
-        }
-
-        try {
-            const packageJson = JSON.parse(data);
-
-            packageJson.scripts = {
-                ...packageJson.scripts,
-                "bugsnag:create-build": "./node_modules/.bin/bugsnag-cli create-build",
-                "bugsnag:upload-android": "./node_modules/.bin/bugsnag-cli upload react-native-android"
-            };
-
-            const updatedPackageJson = JSON.stringify(packageJson, null, 2);
-
-            fs.writeFile(packageJsonPath, updatedPackageJson, 'utf8', (err) => {
-                if (err) {
-                    console.error(`Error writing package.json: ${err}`);
-                    return;
-                }
-            });
-        } catch (err) {
-            console.error(`Error parsing package.json: ${err}`);
-        }
-    })
-}
-
 const platformMetadata = getPlatformMetadata();
 const repoUrl = removeGitPrefixAndSuffix(repository.url);
 const binaryUrl = `${repoUrl}/releases/download/v${version}/${platformMetadata.ARTIFACT_NAME}`;
 const binaryOutputPath = path.join(process.cwd(),'..','..','.bin', platformMetadata.BINARY_NAME);
-const projectPackageJsonPath = path.join(process.cwd(),'..','..', '..','package.json');
 
 downloadBinaryFromGitHub(binaryUrl, binaryOutputPath);
-writeToPackageJson(projectPackageJsonPath)


### PR DESCRIPTION
## Goal

Do not modify the projects `package.json` when installing the CLI via NPM.

## Changeset

Remove the `writeToPackageJson` from `install.js` so that we do not write to a projects `package.json` when installing via NPM.

## Testing

Tested locally