### PR TITLE
[PLAT-10654] Add --dry-run flag to upload commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ### Enhancements
  
+- Add `--version` flag to the command to retrieve the version of the installed CLI. [51](https://github.com/bugsnag/bugsnag-cli/pull/51)
 - Remove deprecated CLI options - `appVersion`, `appVersionCode` and `appBundleVersion`. [52](https://github.com/bugsnag/bugsnag-cli/pull/52)
 - Android Build IDs can be calculated automatically for `.aab` files when none are specified in the `AndroidManifest` or on the command-line. [54](https://github.com/bugsnag/bugsnag-cli/pull/54)  
+- Add `--dry-run` flag to all upload commands to validate but not upload source maps. [54](https://github.com/bugsnag/bugsnag-cli/pull/54)
 
 ## 1.2.2 (2023-07-11)
 

--- a/main.go
+++ b/main.go
@@ -165,7 +165,9 @@ func main() {
 			commands.Upload.Retries,
 			commands.Upload.Overwrite,
 			commands.ApiKey,
-			commands.FailOnUploadError)
+			commands.FailOnUploadError,
+			commands.Upload.DryRun,
+		)
 
 		if err != nil {
 			log.Error(err.Error(), 1)

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func main() {
 	}
 
 	if commands.Upload.DryRun {
-		log.Info("Performing dry run - no files will be uploaded")
+		log.Info("Performing dry run - no data will be sent to BugSnag")
 	}
 
 	switch ctx.Command() {
@@ -88,7 +88,9 @@ func main() {
 			commands.Upload.Retries,
 			commands.Upload.Overwrite,
 			commands.ApiKey,
-			commands.FailOnUploadError)
+			commands.FailOnUploadError,
+			commands.Upload.DryRun,
+		)
 
 		if err != nil {
 			log.Error(err.Error(), 1)

--- a/main.go
+++ b/main.go
@@ -96,8 +96,6 @@ func main() {
 			log.Error(err.Error(), 1)
 		}
 
-		log.Success("Upload(s) completed")
-
 	case "upload android-aab <path>":
 
 		err := upload.ProcessAndroidAab(
@@ -119,8 +117,6 @@ func main() {
 		if err != nil {
 			log.Error(err.Error(), 1)
 		}
-
-		log.Success("Upload(s) completed")
 
 	case "upload android-ndk <path>", "upload android-ndk":
 
@@ -146,8 +142,6 @@ func main() {
 			log.Error(err.Error(), 1)
 		}
 
-		log.Success("Upload(s) completed")
-
 	case "upload android-proguard <path>", "upload android-proguard":
 
 		err := upload.ProcessAndroidProguard(
@@ -169,8 +163,6 @@ func main() {
 		if err != nil {
 			log.Error(err.Error(), 1)
 		}
-
-		log.Success("Upload(s) completed")
 
 	case "upload dart <path>":
 
@@ -196,8 +188,6 @@ func main() {
 			log.Error(err.Error(), 1)
 		}
 
-		log.Success("Upload(s) completed")
-
 	case "upload react-native-android", "upload react-native-android <path>":
 
 		err := upload.ProcessReactNativeAndroid(
@@ -222,8 +212,6 @@ func main() {
 		if err != nil {
 			log.Error(err.Error(), 1)
 		}
-
-		log.Success("Upload(s) completed")
 
 	case "create-build", "create-build <path>":
 

--- a/main.go
+++ b/main.go
@@ -68,6 +68,10 @@ func main() {
 		log.Error("Failed to build upload url: "+err.Error(), 1)
 	}
 
+	if commands.Upload.DryRun {
+		log.Info("Performing dry run - no files will be uploaded")
+	}
+
 	switch ctx.Command() {
 
 	case "upload all <path>":

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ type Globals struct {
 	ApiKey            string            `help:"(required) Bugsnag integration API key for this application"`
 	FailOnUploadError bool              `help:"Stops the upload when a mapping file fails to upload to Bugsnag successfully" default:"false"`
 	Version           utils.VersionFlag `name:"version" help:"Print version information and quit"`
+	DryRun            bool              `help:"Validate but do not process"`
 }
 
 // Unique CLI options
@@ -31,7 +32,6 @@ type CLI struct {
 		Overwrite bool `help:"Whether to overwrite any existing symbol file with a matching ID"`
 		Timeout   int  `help:"Number of seconds to wait before failing an upload request" default:"300"`
 		Retries   int  `help:"Number of retry attempts before failing an upload request" default:"0"`
-		DryRun    bool `help:"Validate but do not upload"`
 
 		// required options
 		AndroidAab         upload.AndroidAabMapping      `cmd:"" help:"Process and upload application bundle files for Android"`
@@ -68,7 +68,7 @@ func main() {
 		log.Error("Failed to build upload url: "+err.Error(), 1)
 	}
 
-	if commands.Upload.DryRun {
+	if commands.DryRun {
 		log.Info("Performing dry run - no data will be sent to BugSnag")
 	}
 
@@ -89,7 +89,7 @@ func main() {
 			commands.Upload.Overwrite,
 			commands.ApiKey,
 			commands.FailOnUploadError,
-			commands.Upload.DryRun,
+			commands.DryRun,
 		)
 
 		if err != nil {
@@ -111,7 +111,7 @@ func main() {
 			commands.Upload.Retries,
 			commands.Upload.Timeout,
 			commands.Upload.Overwrite,
-			commands.Upload.DryRun,
+			commands.DryRun,
 		)
 
 		if err != nil {
@@ -135,7 +135,7 @@ func main() {
 			commands.Upload.Retries,
 			commands.Upload.Timeout,
 			commands.Upload.Overwrite,
-			commands.Upload.DryRun,
+			commands.DryRun,
 		)
 
 		if err != nil {
@@ -157,7 +157,7 @@ func main() {
 			commands.Upload.Retries,
 			commands.Upload.Timeout,
 			commands.Upload.Overwrite,
-			commands.Upload.DryRun,
+			commands.DryRun,
 		)
 
 		if err != nil {
@@ -181,7 +181,7 @@ func main() {
 			commands.Upload.Overwrite,
 			commands.ApiKey,
 			commands.FailOnUploadError,
-			commands.Upload.DryRun,
+			commands.DryRun,
 		)
 
 		if err != nil {
@@ -206,7 +206,7 @@ func main() {
 			commands.Upload.Timeout,
 			commands.Upload.Retries,
 			commands.Upload.Overwrite,
-			commands.Upload.DryRun,
+			commands.DryRun,
 		)
 
 		if err != nil {
@@ -239,7 +239,10 @@ func main() {
 			commands.CreateBuild.BundleVersion,
 			commands.CreateBuild.Metadata,
 			commands.CreateBuild.Path,
-			endpoint)
+			endpoint,
+			commands.DryRun,
+		)
+
 		if buildUploadError != nil {
 			log.Error(buildUploadError.Error(), 1)
 		}

--- a/pkg/build/create.go
+++ b/pkg/build/create.go
@@ -104,7 +104,7 @@ func ProcessBuildRequest(apiKey string, builderName string, releaseStage string,
 			return fmt.Errorf("%s : %s", res.Status, string(b))
 		}
 	} else {
-		log.Success("(dryrun) Skipping sending build information to " + endpoint)
+		log.Info("(dryrun) Skipping sending build information to " + endpoint)
 	}
 
 	return nil

--- a/pkg/server/request.go
+++ b/pkg/server/request.go
@@ -94,9 +94,9 @@ func ProcessRequest(endpoint string, uploadOptions map[string]string, fileFieldD
 			return fmt.Errorf("%s : %s", res.Status, string(b))
 		}
 
-		log.Success(fileName + " Processed")
+		log.Success("Uploaded " + fileName)
 	} else {
-		log.Success("(dryrun) " + fileName + " Processed")
+		log.Success("(dryrun) Uploaded " + filepath.Base(fileName))
 	}
 
 	return nil

--- a/pkg/server/request.go
+++ b/pkg/server/request.go
@@ -66,7 +66,7 @@ func SendRequest(request *http.Request, timeout int) (*http.Response, error) {
 }
 
 // ProcessRequest - Builds and sends file requests to the API
-func ProcessRequest(endpoint string, uploadOptions map[string]string, fileFieldData map[string]string, timeout int, dryRun bool) error {
+func ProcessRequest(endpoint string, uploadOptions map[string]string, fileFieldData map[string]string, timeout int, fileName string, dryRun bool) error {
 	req, err := BuildFileRequest(endpoint, uploadOptions, fileFieldData)
 
 	if err != nil {
@@ -93,6 +93,10 @@ func ProcessRequest(endpoint string, uploadOptions map[string]string, fileFieldD
 		if !statusOK {
 			return fmt.Errorf("%s : %s", res.Status, string(b))
 		}
+
+		log.Success(fileName + " Processed")
+	} else {
+		log.Success("(dryrun) " + fileName + " Processed")
 	}
 
 	return nil

--- a/pkg/server/request.go
+++ b/pkg/server/request.go
@@ -96,7 +96,7 @@ func ProcessRequest(endpoint string, uploadOptions map[string]string, fileFieldD
 
 		log.Success("Uploaded " + filepath.Base(fileName))
 	} else {
-		log.Success("(dryrun) Skipping upload of " + filepath.Base(fileName) + " to " + endpoint)
+		log.Info("(dryrun) Skipping upload of " + filepath.Base(fileName) + " to " + endpoint)
 	}
 
 	return nil

--- a/pkg/server/request.go
+++ b/pkg/server/request.go
@@ -74,7 +74,7 @@ func ProcessRequest(endpoint string, uploadOptions map[string]string, fileFieldD
 	}
 
 	if !dryRun {
-		log.Info("Uploading " + fileName + " to " + endpoint)
+		log.Info("Uploading " + filepath.Base(fileName) + " to " + endpoint)
 
 		res, err := SendRequest(req, timeout)
 
@@ -94,7 +94,7 @@ func ProcessRequest(endpoint string, uploadOptions map[string]string, fileFieldD
 			return fmt.Errorf("%s : %s", res.Status, string(b))
 		}
 
-		log.Success("Uploaded " + fileName)
+		log.Success("Uploaded " + filepath.Base(fileName))
 	} else {
 		log.Success("(dryrun) Uploaded " + filepath.Base(fileName))
 	}

--- a/pkg/server/request.go
+++ b/pkg/server/request.go
@@ -96,7 +96,7 @@ func ProcessRequest(endpoint string, uploadOptions map[string]string, fileFieldD
 
 		log.Success("Uploaded " + filepath.Base(fileName))
 	} else {
-		log.Success("(dryrun) Uploaded " + filepath.Base(fileName))
+		log.Success("(dryrun) Skipping upload of " + filepath.Base(fileName) + " to " + endpoint)
 	}
 
 	return nil

--- a/pkg/upload/all.go
+++ b/pkg/upload/all.go
@@ -12,7 +12,7 @@ type DiscoverAndUploadAny struct {
 }
 
 func All(paths []string, options map[string]string, endpoint string, timeout int, retries int, overwrite bool,
-	apiKey string, failOnUploadError bool) error {
+	apiKey string, failOnUploadError bool, dryRun bool) error {
 
 	// Build the file list from the path(s)
 	log.Info("building file list...")
@@ -50,7 +50,7 @@ func All(paths []string, options map[string]string, endpoint string, timeout int
 			fileFieldData["file"] = file
 		}
 
-		requestStatus := server.ProcessRequest(endpoint, uploadOptions, fileFieldData, timeout)
+		requestStatus := server.ProcessRequest(endpoint, uploadOptions, fileFieldData, timeout, dryRun)
 
 		if requestStatus != nil {
 			if numberOfFiles > 1 && failOnUploadError {

--- a/pkg/upload/all.go
+++ b/pkg/upload/all.go
@@ -50,7 +50,7 @@ func All(paths []string, options map[string]string, endpoint string, timeout int
 			fileFieldData["file"] = file
 		}
 
-		requestStatus := server.ProcessRequest(endpoint, uploadOptions, fileFieldData, timeout, dryRun)
+		requestStatus := server.ProcessRequest(endpoint, uploadOptions, fileFieldData, timeout, file, dryRun)
 
 		if requestStatus != nil {
 			if numberOfFiles > 1 && failOnUploadError {

--- a/pkg/upload/android-aab.go
+++ b/pkg/upload/android-aab.go
@@ -33,10 +33,6 @@ func ProcessAndroidAab(apiKey string, applicationId string, buildUuid string, pa
 
 	defer os.RemoveAll(tempDir)
 
-	if dryRun {
-		log.Info("Performing dry run - no files will be uploaded")
-	}
-
 	for _, path := range paths {
 		if filepath.Ext(path) == ".aab" {
 

--- a/pkg/upload/android-aab.go
+++ b/pkg/upload/android-aab.go
@@ -43,8 +43,6 @@ func ProcessAndroidAab(apiKey string, applicationId string, buildUuid string, pa
 			if err != nil {
 				return err
 			}
-
-			log.Success(filepath.Base(path) + " expanded")
 		} else {
 			return fmt.Errorf(path + " is not an AAB file")
 		}

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -33,10 +33,6 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 	var appManifestPathExpected string
 	var objCopyPath string
 
-	if dryRun {
-		log.Info("Performing dry run - no files will be uploaded")
-	}
-
 	for _, path := range paths {
 		if utils.IsDir(path) {
 			mergeNativeLibPath = filepath.Join(path, "app", "build", "intermediates", "merged_native_libs")

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -214,7 +214,7 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 			fileFieldData := make(map[string]string)
 			fileFieldData["soFile"] = file
 
-			err = server.ProcessRequest(endpoint+"/ndk-symbol", uploadOptions, fileFieldData, timeout, dryRun)
+			err = server.ProcessRequest(endpoint+"/ndk-symbol", uploadOptions, fileFieldData, timeout, file, dryRun)
 
 			if err != nil {
 				if numberOfFiles > 1 && failOnUploadError {

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -214,11 +214,7 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 			fileFieldData := make(map[string]string)
 			fileFieldData["soFile"] = file
 
-			if dryRun {
-				err = nil
-			} else {
-				err = server.ProcessRequest(endpoint+"/ndk-symbol", uploadOptions, fileFieldData, timeout)
-			}
+			err = server.ProcessRequest(endpoint+"/ndk-symbol", uploadOptions, fileFieldData, timeout, dryRun)
 
 			if err != nil {
 				if numberOfFiles > 1 && failOnUploadError {

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -159,16 +159,12 @@ func ProcessAndroidProguard(apiKey string, applicationId string, appManifestPath
 		fileFieldData := make(map[string]string)
 		fileFieldData["proguard"] = outputFile
 
-		if dryRun {
-			err = nil
-		} else {
-			err = server.ProcessRequest(endpoint+"/proguard", uploadOptions, fileFieldData, timeout)
+		err = server.ProcessRequest(endpoint+"/proguard", uploadOptions, fileFieldData, timeout, dryRun)
 
-			if err != nil {
-				if strings.Contains(err.Error(), "404 Not Found") {
-					log.Info("Trying " + endpoint)
-					err = server.ProcessRequest(endpoint, uploadOptions, fileFieldData, timeout)
-				}
+		if err != nil {
+			if strings.Contains(err.Error(), "404 Not Found") {
+				log.Info("Trying " + endpoint)
+				err = server.ProcessRequest(endpoint, uploadOptions, fileFieldData, timeout, dryRun)
 			}
 		}
 

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -159,12 +159,12 @@ func ProcessAndroidProguard(apiKey string, applicationId string, appManifestPath
 		fileFieldData := make(map[string]string)
 		fileFieldData["proguard"] = outputFile
 
-		err = server.ProcessRequest(endpoint+"/proguard", uploadOptions, fileFieldData, timeout, dryRun)
+		err = server.ProcessRequest(endpoint+"/proguard", uploadOptions, fileFieldData, timeout, outputFile, dryRun)
 
 		if err != nil {
 			if strings.Contains(err.Error(), "404 Not Found") {
 				log.Info("Trying " + endpoint)
-				err = server.ProcessRequest(endpoint, uploadOptions, fileFieldData, timeout, dryRun)
+				err = server.ProcessRequest(endpoint, uploadOptions, fileFieldData, timeout, outputFile, dryRun)
 			}
 		}
 

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -27,6 +27,10 @@ func ProcessAndroidProguard(apiKey string, applicationId string, appManifestPath
 	var appManifestPathExpected string
 	var err error
 
+	if dryRun {
+		log.Info("Performing dry run - no files will be uploaded")
+	}
+
 	for _, path := range paths {
 		if utils.IsDir(path) {
 

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -27,10 +27,6 @@ func ProcessAndroidProguard(apiKey string, applicationId string, appManifestPath
 	var appManifestPathExpected string
 	var err error
 
-	if dryRun {
-		log.Info("Performing dry run - no files will be uploaded")
-	}
-
 	for _, path := range paths {
 		if utils.IsDir(path) {
 

--- a/pkg/upload/dart.go
+++ b/pkg/upload/dart.go
@@ -59,7 +59,7 @@ func Dart(paths []string, version string, versionCode string, bundleVersion stri
 			fileFieldData := make(map[string]string)
 			fileFieldData["symbolFile"] = file
 
-			requestStatus := server.ProcessRequest(endpoint+"/dart-symbol", uploadOptions, fileFieldData, timeout)
+			requestStatus := server.ProcessRequest(endpoint+"/dart-symbol", uploadOptions, fileFieldData, timeout, dryRun)
 
 			if requestStatus != nil {
 				if numberOfFiles > 1 && failOnUploadError {
@@ -107,7 +107,7 @@ func Dart(paths []string, version string, versionCode string, bundleVersion stri
 			if dryRun {
 				err = nil
 			} else {
-				err = server.ProcessRequest(endpoint+"/dart-symbol", uploadOptions, fileFieldData, timeout)
+				err = server.ProcessRequest(endpoint+"/dart-symbol", uploadOptions, fileFieldData, timeout, dryRun)
 			}
 
 			if err != nil {

--- a/pkg/upload/dart.go
+++ b/pkg/upload/dart.go
@@ -59,7 +59,7 @@ func Dart(paths []string, version string, versionCode string, bundleVersion stri
 			fileFieldData := make(map[string]string)
 			fileFieldData["symbolFile"] = file
 
-			requestStatus := server.ProcessRequest(endpoint+"/dart-symbol", uploadOptions, fileFieldData, timeout, dryRun)
+			requestStatus := server.ProcessRequest(endpoint+"/dart-symbol", uploadOptions, fileFieldData, timeout, file, dryRun)
 
 			if requestStatus != nil {
 				if numberOfFiles > 1 && failOnUploadError {
@@ -107,7 +107,7 @@ func Dart(paths []string, version string, versionCode string, bundleVersion stri
 			if dryRun {
 				err = nil
 			} else {
-				err = server.ProcessRequest(endpoint+"/dart-symbol", uploadOptions, fileFieldData, timeout, dryRun)
+				err = server.ProcessRequest(endpoint+"/dart-symbol", uploadOptions, fileFieldData, timeout, file, dryRun)
 			}
 
 			if err != nil {

--- a/pkg/upload/dart.go
+++ b/pkg/upload/dart.go
@@ -25,10 +25,6 @@ type DartSymbol struct {
 }
 
 func Dart(paths []string, version string, versionCode string, bundleVersion string, iosAppPath string, endpoint string, timeout int, retries int, overwrite bool, apiKey string, failOnUploadError bool, dryRun bool) error {
-	
-	if dryRun {
-		log.Info("Performing dry run - no files will be uploaded")
-	}
 
 	log.Info("Building file list from path")
 

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -33,10 +33,6 @@ func ProcessReactNativeAndroid(apiKey string, appManifestPath string, bundlePath
 	var bundleDirPath string
 	var variantFileFormat string
 
-	if dryRun {
-		log.Info("Performing dry run - no files will be uploaded")
-	}
-
 	for _, path := range paths {
 
 		buildDirPath := filepath.Join(path, "android", "app", "build")

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -167,7 +167,7 @@ func ProcessReactNativeAndroid(apiKey string, appManifestPath string, bundlePath
 		fileFieldData["sourceMap"] = sourceMapPath
 		fileFieldData["bundle"] = bundlePath
 
-		err = server.ProcessRequest(endpoint+"/react-native-source-map", uploadOptions, fileFieldData, timeout, dryRun)
+		err = server.ProcessRequest(endpoint+"/react-native-source-map", uploadOptions, fileFieldData, timeout, sourceMapPath, dryRun)
 
 		if err != nil {
 			return err

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -167,11 +167,7 @@ func ProcessReactNativeAndroid(apiKey string, appManifestPath string, bundlePath
 		fileFieldData["sourceMap"] = sourceMapPath
 		fileFieldData["bundle"] = bundlePath
 
-		if dryRun {
-			err = nil
-		} else {
-			err = server.ProcessRequest(endpoint+"/react-native-source-map", uploadOptions, fileFieldData, timeout)
-		}
+		err = server.ProcessRequest(endpoint+"/react-native-source-map", uploadOptions, fileFieldData, timeout, dryRun)
 
 		if err != nil {
 			return err


### PR DESCRIPTION
## Goal

Validate but not upload source maps for all supported languages.

## Changeset

Add the `--dry-run` flag to all upload commands to process given source maps but not upload them. 
Removed the dry run log message from the `AAB` command to reduce the number of log messages

## Testing

Tested manually, CI tests to be added during testing rework.