### PR TITLE
[PLAT-10966] Install script version handling

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -80,7 +80,36 @@ file_not_grpowned() {
   [[ " $(id -G "${USER}") " != *" $(get_group "$1") "* ]]
 }
 
-BUGSNAG_CLI_GIT_REMOTE="https://api.github.com/repos/bugsnag/bugsnag-cli/releases/latest"
+display_help() {
+  echo ""
+  cat <<EOS
+  Usage: ./$0
+
+  Flags:
+    --help                          Display help and usage information
+    --version=<VERSION_NUMBER>      Specify the version to install
+EOS
+}
+
+VERSION="1.2.2"
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --version=*)
+      VERSION="${1#*=}"
+      ;;
+    --help)
+      display_help
+      exit 0
+      ;;
+    *)
+      ohai "Invalid argument: $1"
+      display_help
+      exit 1
+      ;;
+  esac
+  shift
+done
 
 # USER isn't always set so provide a fall back for the installer and subprocesses.
 if [[ -z "${USER-}" ]]; then
@@ -136,18 +165,7 @@ ohai "Downloading and installing Bugsnag CLI..."
 (
   cd "${BUGSNAG_CLI_PREFIX}" >/dev/null || return
 
-  DOWNLOAD_URL=$(curl -sS ${BUGSNAG_CLI_GIT_REMOTE} |
-    grep "${UNAME_MACHINE}-${OS_NAME}-bugsnag-cli*" |
-    grep "browser_download_url" |
-    cut -d : -f 2,3 |
-    tr -d \" |
-    xargs)
-
-  if [[ ! -n ${DOWNLOAD_URL} ]]; then
-    abort "Failed to get download URL from ${BUGSNAG_CLI_GIT_REMOTE}"
-  fi
-
-  execute "curl" "-#" "-L" "${DOWNLOAD_URL}" "-o" "${BUGSNAG_CLI_PREFIX}/bin/bugsnag-cli"
+  execute "curl" "-#" "-L" "https://github.com/bugsnag/bugsnag-cli/releases/download/v${VERSION}/${UNAME_MACHINE}-${OS_NAME}-bugsnag-cli" "-o" "${BUGSNAG_CLI_PREFIX}/bin/bugsnag-cli"
 
   execute "chmod" "ug=rwx" "${BUGSNAG_CLI_PREFIX}/bin/bugsnag-cli"
 

--- a/install.sh
+++ b/install.sh
@@ -91,12 +91,12 @@ display_help() {
 EOS
 }
 
-VERSION="1.2.2"
+VERSION="2.0.0"
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     --version=*)
-      VERSION="${1#*=}"
+      VERSION=${1#*=}
       ;;
     --help)
       display_help

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -15,3 +15,4 @@ echo Bumping the version number to $VERSION
 sed -i '' "s/package_version = \".*\"/package_version = \"$VERSION\"/" main.go
 sed -i '' "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" package.json
 sed -i '' "s/## TBD/## $VERSION ($(date '+%Y-%m-%d'))/" CHANGELOG.md
+sed -i '' "s/VERSION=\".*\"/VERSION=\"$VERSION\"/" install.sh


### PR DESCRIPTION
## Goal

Bypass the rate limiting of the Github API when installing via the `install.sh` script and allow users to specify the version they wish to install via a command line flag.

Example:

`./install.sh --version=1.2.2`

Output:

```
==> This script will install:
/Users/josh.edney/.local/bugsnag/bin/bugsnag-cli
==> Downloading and installing Bugsnag CLI...
############################################## 100.0%
==> Installation successful!
```

## Changeset

Instead of using the github API to search for the latest release of the CLI we set the latest version using the `bump.sh` script within the `install.sh` script. We have also added an option to allow users to specify the version they wish to install using a `--version=x.x.x` flag

## Testing

Tested locally but we could add this to the CI run if we wanted. Currently the CLI used is built from source.