### PR TITLE
[PLAT-11067] Allow Unity Android symbol uploads without Android AAB file

### DIFF
--- a/main.go
+++ b/main.go
@@ -226,7 +226,6 @@ func main() {
 			commands.Upload.UnityAndroid.ApplicationId,
 			commands.Upload.UnityAndroid.VersionCode,
 			commands.Upload.UnityAndroid.BuildUuid,
-			commands.Upload.UnityAndroid.Arch,
 			commands.Upload.UnityAndroid.VersionName,
 			commands.Upload.UnityAndroid.ProjectRoot,
 			commands.Upload.UnityAndroid.Path,

--- a/main.go
+++ b/main.go
@@ -222,7 +222,7 @@ func main() {
 
 		err := upload.ProcessUnityAndroid(
 			commands.ApiKey,
-			commands.Upload.UnityAndroid.AabPath,
+			string(commands.Upload.UnityAndroid.AabPath),
 			commands.Upload.UnityAndroid.ApplicationId,
 			commands.Upload.UnityAndroid.VersionCode,
 			commands.Upload.UnityAndroid.BuildUuid,

--- a/pkg/android/aab.go
+++ b/pkg/android/aab.go
@@ -26,16 +26,16 @@ func MergeUploadOptionsFromAabManifest(path string, apiKey string, applicationId
 
 		if utils.FileExists(aabManifestPathExpected) {
 			aabManifestPath = aabManifestPathExpected
+
+			log.Info("Reading data from AndroidManifest.xml")
+
+			manifestData, err = ReadAabManifest(filepath.Join(aabManifestPath))
+
+			if err != nil {
+				return aabUploadOptions, fmt.Errorf("unable to read data from " + path + " " + err.Error())
+			}
 		} else {
-			return nil, fmt.Errorf("AndroidManifest.xml not found in AAB file")
-		}
-
-		log.Info("Reading data from AndroidManifest.xml")
-
-		manifestData, err = ReadAabManifest(filepath.Join(aabManifestPath))
-
-		if err != nil {
-			return nil, fmt.Errorf("unable to read data from " + path + " " + err.Error())
+			return aabUploadOptions, fmt.Errorf("AndroidManifest.xml not found in AAB file")
 		}
 
 		if aabUploadOptions["apiKey"] == "" && manifestData["apiKey"] != "" {

--- a/pkg/build/create.go
+++ b/pkg/build/create.go
@@ -19,7 +19,7 @@ type CreateBuild struct {
 	Provider      string            `help:"The name of the source control provider that contains the source code for the build."`
 	Repository    string            `help:"The URL of the repository containing the source code being deployed."`
 	Revision      string            `help:"The source control SHA-1 hash for the code that has been built (short or long hash)"`
-	Path          utils.UploadPaths `arg:"" name:"path" help:"Path to the project directory" type:"path" default:"."`
+	Path          utils.Paths       `arg:"" name:"path" help:"Path to the project directory" type:"path" default:"."`
 	VersionName   string            `help:"The version of the application." xor:"app-version,version-name"`
 	VersionCode   string            `help:"The version code for the application (Android only)." xor:"app-version-code,version-code"`
 	BundleVersion string            `help:"The bundle version for the application (iOS only)." xor:"app-bundle-version,bundle-version"`

--- a/pkg/upload/all.go
+++ b/pkg/upload/all.go
@@ -8,7 +8,7 @@ import (
 )
 
 type DiscoverAndUploadAny struct {
-	Path          utils.UploadPaths `arg:"" name:"path" help:"(required) Path to directory or file to upload" type:"path"`
+	Path          utils.Paths       `arg:"" name:"path" help:"(required) Path to directory or file to upload" type:"path"`
 	UploadOptions map[string]string `help:"Additional arguments to pass to the upload request" mapsep:","`
 }
 

--- a/pkg/upload/android-aab.go
+++ b/pkg/upload/android-aab.go
@@ -11,12 +11,12 @@ import (
 )
 
 type AndroidAabMapping struct {
-	ApplicationId string            `help:"Module application identifier"`
-	BuildUuid     string            `help:"Module Build UUID ('none' to opt-out)"`
-	Path          utils.UploadPaths `arg:"" name:"path" help:"(required) Path to directory or file to upload" type:"path"`
-	ProjectRoot   string            `help:"path to remove from the beginning of the filenames in the mapping file" type:"path"`
-	VersionCode   string            `help:"Module version code"`
-	VersionName   string            `help:"Module version name"`
+	ApplicationId string      `help:"Module application identifier"`
+	BuildUuid     string      `help:"Module Build UUID ('none' to opt-out)"`
+	Path          utils.Paths `arg:"" name:"path" help:"(required) Path to directory or file to upload" type:"path"`
+	ProjectRoot   string      `help:"path to remove from the beginning of the filenames in the mapping file" type:"path"`
+	VersionCode   string      `help:"Module version code"`
+	VersionName   string      `help:"Module version name"`
 }
 
 func ProcessAndroidAab(apiKey string, applicationId string, buildUuid string, paths []string, projectRoot string, versionCode string, versionName string, endpoint string, failOnUploadError bool, retries int, timeout int, overwrite bool, dryRun bool) error {

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -12,14 +12,14 @@ import (
 )
 
 type AndroidNdkMapping struct {
-	ApplicationId  string            `help:"Module application identifier"`
-	AndroidNdkRoot string            `help:"Path to Android NDK installation ($ANDROID_NDK_ROOT)"`
-	AppManifest    string            `help:"Path to app manifest file" type:"path"`
-	Path           utils.UploadPaths `arg:"" name:"path" help:"Path to directory or file to upload" type:"path" default:"."`
-	ProjectRoot    string            `help:"path to remove from the beginning of the filenames in the mapping file" type:"path"`
-	Variant        string            `help:"Build type, like 'debug' or 'release'"`
-	VersionCode    string            `help:"Module version code"`
-	VersionName    string            `help:"Module version name"`
+	ApplicationId  string      `help:"Module application identifier"`
+	AndroidNdkRoot string      `help:"Path to Android NDK installation ($ANDROID_NDK_ROOT)"`
+	AppManifest    string      `help:"Path to app manifest file" type:"path"`
+	Path           utils.Paths `arg:"" name:"path" help:"Path to directory or file to upload" type:"path" default:"."`
+	ProjectRoot    string      `help:"path to remove from the beginning of the filenames in the mapping file" type:"path"`
+	Variant        string      `help:"Build type, like 'debug' or 'release'"`
+	VersionCode    string      `help:"Module version code"`
+	VersionName    string      `help:"Module version name"`
 }
 
 func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot string, appManifestPath string, paths []string, projectRoot string, variant string, versionCode string, versionName string, endpoint string, failOnUploadError bool, retries int, timeout int, overwrite bool, dryRun bool) error {

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -12,13 +12,13 @@ import (
 )
 
 type AndroidProguardMapping struct {
-	ApplicationId string            `help:"Module application identifier"`
-	AppManifest   string            `help:"Path to app manifest file" type:"path"`
-	BuildUuid     string            `help:"Module Build UUID"`
-	Path          utils.UploadPaths `arg:"" name:"path" help:"Path to directory or file to upload" type:"path" default:"."`
-	Variant       string            `help:"Build type, like 'debug' or 'release'"`
-	VersionCode   string            `help:"Module version code"`
-	VersionName   string            `help:"Module version name"`
+	ApplicationId string      `help:"Module application identifier"`
+	AppManifest   string      `help:"Path to app manifest file" type:"path"`
+	BuildUuid     string      `help:"Module Build UUID"`
+	Path          utils.Paths `arg:"" name:"path" help:"Path to directory or file to upload" type:"path" default:"."`
+	Variant       string      `help:"Build type, like 'debug' or 'release'"`
+	VersionCode   string      `help:"Module version code"`
+	VersionName   string      `help:"Module version name"`
 }
 
 func ProcessAndroidProguard(apiKey string, applicationId string, appManifestPath string, buildUuid string, paths []string, variant string, versionCode string, versionName string, endpoint string, retries int, timeout int, overwrite bool, dryRun bool) error {

--- a/pkg/upload/dart.go
+++ b/pkg/upload/dart.go
@@ -17,11 +17,11 @@ import (
 )
 
 type DartSymbolOptions struct {
-	Path          utils.UploadPaths `arg:"" name:"path" help:"(required) Path to directory or file to upload" type:"path"`
-	IosAppPath    string            `help:"(optional) the path to the built iOS app."`
-	VersionName   string            `help:"The version of the application." xor:"app-version,version-name"`
-	VersionCode   string            `help:"The version code for the application (Android only)." xor:"app-version-code,version-code"`
-	BundleVersion string            `help:"The bundle version for the application (iOS only)." xor:"app-bundle-version,bundle-version"`
+	Path          utils.Paths `arg:"" name:"path" help:"(required) Path to directory or file to upload" type:"path"`
+	IosAppPath    string      `help:"(optional) the path to the built iOS app."`
+	VersionName   string      `help:"The version of the application." xor:"app-version,version-name"`
+	VersionCode   string      `help:"The version code for the application (Android only)." xor:"app-version-code,version-code"`
+	BundleVersion string      `help:"The bundle version for the application (iOS only)." xor:"app-bundle-version,bundle-version"`
 }
 
 func Dart(paths []string, version string, versionCode string, bundleVersion string, iosAppPath string, endpoint string, timeout int, retries int, overwrite bool, apiKey string, failOnUploadError bool, dryRun bool) error {

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -12,16 +12,16 @@ import (
 )
 
 type ReactNativeAndroid struct {
-	AppManifest  string            `help:"(required) Path to directory or file to upload" type:"path"`
-	Bundle       string            `help:"Path to the bundle file" type:"path"`
-	CodeBundleId string            `help:"A unique identifier to identify a code bundle release when using tools like CodePush"`
-	Dev          bool              `help:"Indicates whether the application is a debug or release build"`
-	Path         utils.UploadPaths `arg:"" name:"path" help:"Path to directory or file to upload" type:"path" default:"."`
-	ProjectRoot  string            `help:"path to remove from the beginning of the filenames in the mapping file" type:"path"`
-	SourceMap    string            `help:"Path to the source map file" type:"path"`
-	Variant      string            `help:"Build type, like 'debug' or 'release'"`
-	VersionName  string            `help:"The version name of the application."`
-	VersionCode  string            `help:"The version code for the application (Android only)."`
+	AppManifest  string      `help:"(required) Path to directory or file to upload" type:"path"`
+	Bundle       string      `help:"Path to the bundle file" type:"path"`
+	CodeBundleId string      `help:"A unique identifier to identify a code bundle release when using tools like CodePush"`
+	Dev          bool        `help:"Indicates whether the application is a debug or release build"`
+	Path         utils.Paths `arg:"" name:"path" help:"Path to directory or file to upload" type:"path" default:"."`
+	ProjectRoot  string      `help:"path to remove from the beginning of the filenames in the mapping file" type:"path"`
+	SourceMap    string      `help:"Path to the source map file" type:"path"`
+	Variant      string      `help:"Build type, like 'debug' or 'release'"`
+	VersionName  string      `help:"The version name of the application."`
+	VersionCode  string      `help:"The version code for the application (Android only)."`
 }
 
 func ProcessReactNativeAndroid(apiKey string, appManifestPath string, bundlePath string, codeBundleId string, dev bool, paths []string, projectRoot string, variant string, versionName string, versionCode string, sourceMapPath string, endpoint string, timeout int, retries int, overwrite bool, dryRun bool) error {

--- a/pkg/upload/unity-android.go
+++ b/pkg/upload/unity-android.go
@@ -11,13 +11,13 @@ import (
 )
 
 type UnityAndroid struct {
-	AabPath       string            `help:"Path to Android AAB file to upload with your Unity symbols"`
-	ApplicationId string            `help:"Module application identifier"`
-	Path          utils.UploadPaths `arg:"" name:"path" help:"(required) Path to Unity symbols zip file or directory to upload" type:"path"`
-	ProjectRoot   string            `help:"path to remove from the beginning of the filenames in the mapping file" type:"path"`
-	VersionCode   string            `help:"Module version code"`
-	VersionName   string            `help:"Module version name"`
-	BuildUuid     string            `help:"Module Build UUID"`
+	AabPath       utils.Path  `help:"Path to Android AAB file to upload with your Unity symbols"`
+	ApplicationId string      `help:"Module application identifier"`
+	Path          utils.Paths `arg:"" name:"path" help:"(required) Path to Unity symbols zip file or directory to upload" type:"path"`
+	ProjectRoot   string      `help:"path to remove from the beginning of the filenames in the mapping file" type:"path"`
+	VersionCode   string      `help:"Module version code"`
+	VersionName   string      `help:"Module version name"`
+	BuildUuid     string      `help:"Module Build UUID"`
 }
 
 func ProcessUnityAndroid(apiKey string, aabPath string, applicationId string, versionCode string, buildUuid string, versionName string, projectRoot string, paths []string, endpoint string, failOnUploadError bool, retries int, timeout int, overwrite bool, dryRun bool) error {
@@ -51,7 +51,7 @@ func ProcessUnityAndroid(apiKey string, aabPath string, applicationId string, ve
 		}
 	}
 
-	if utils.FileExists(aabPath) {
+	if aabPath != "" {
 		log.Info("Extracting " + filepath.Base(aabPath) + " into a temporary directory")
 
 		aabDir, err := utils.ExtractFile(aabPath, "aab")
@@ -73,8 +73,6 @@ func ProcessUnityAndroid(apiKey string, aabPath string, applicationId string, ve
 		if err != nil {
 			return err
 		}
-	} else {
-		log.Info("No AAB files to process.")
 	}
 
 	log.Info("Extracting " + filepath.Base(zipPath) + " into a temporary directory")

--- a/pkg/utils/validation.go
+++ b/pkg/utils/validation.go
@@ -5,14 +5,23 @@ import (
 	"strings"
 )
 
-type UploadPaths []string
+type Paths []string
+type Path string
 
 // Validate that the path(s) exist
-func (p UploadPaths) Validate() error {
+func (p Paths) Validate() error {
 	for _, path := range p {
 		if _, err := os.Stat(path); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// Validate that the path exist
+func (p Path) Validate() error {
+	if _, err := os.Stat(string(p)); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
## Goal

Allow Unity Android symbols file uploads without needed an Android AAB file.

Example:
`bugsnag-cli upload unity-android --api-key=YOUR_API_KEY`

Output:
```
[INFO] No AAB files detected to process.
[INFO] Extracting Unity2022-1.0-v1-IL2CPP.symbols.zip into a temporary directory
[INFO] Uploading libil2cpp.so to https://upload.bugsnag.com:443/ndk-symbol
[SUCCESS] Uploaded libil2cpp.so
[INFO] Uploading libmain.so to https://upload.bugsnag.com:443/ndk-symbol
[SUCCESS] Uploaded libmain.so
[INFO] Uploading libunity.so to https://upload.bugsnag.com:443/ndk-symbol
[SUCCESS] Uploaded libunity.so
[INFO] Uploading libil2cpp.so to https://upload.bugsnag.com:443/ndk-symbol
[SUCCESS] Uploaded libil2cpp.so
[INFO] Uploading libmain.so to https://upload.bugsnag.com:443/ndk-symbol
[SUCCESS] Uploaded libmain.so
[INFO] Uploading libunity.so to https://upload.bugsnag.com:443/ndk-symbol
[SUCCESS] Uploaded libunity.so
```