### PR TITLE
[PLAT-11305] Validate paths when passed to the Dart upload option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
-## 2.1.0 (2023-11-28)
+## 2.1.0 (TBD)
 
 ### Enhancements
 
 Add support for:
 - React Native source maps for iOS [online docs (TBD)]()
+
+### Fixes
+
+- Ensure that `--ios-app-path` exists when passed as an option via the `upload dart` CLI. [67](https://github.com/bugsnag/bugsnag-cli/pull/67)
 
 ## 2.0.0 (2023-10-17)
 

--- a/main.go
+++ b/main.go
@@ -179,7 +179,7 @@ func main() {
 			commands.Upload.DartSymbol.VersionName,
 			commands.Upload.DartSymbol.VersionCode,
 			commands.Upload.DartSymbol.BundleVersion,
-			commands.Upload.DartSymbol.IosAppPath,
+			string(commands.Upload.DartSymbol.IosAppPath),
 			endpoint,
 			commands.Upload.Timeout,
 			commands.Upload.Retries,

--- a/pkg/upload/dart.go
+++ b/pkg/upload/dart.go
@@ -20,7 +20,7 @@ var iosSymbolFileRegex = regexp.MustCompile("ios-([^;]*).symbols")
 
 type DartSymbolOptions struct {
 	Path          utils.Paths `arg:"" name:"path" help:"(required) Path to directory or file to upload" type:"path"`
-	IosAppPath    utils.Path  `help:"(optional) the path to the built iOS app."`
+	IosAppPath    utils.Path  `help:"(optional) the path to the built iOS app." type:"path"`
 	VersionName   string      `help:"The version of the application." xor:"app-version,version-name"`
 	VersionCode   string      `help:"The version code for the application (Android only)." xor:"app-version-code,version-code"`
 	BundleVersion string      `help:"The bundle version for the application (iOS only)." xor:"app-bundle-version,bundle-version"`

--- a/pkg/upload/dart.go
+++ b/pkg/upload/dart.go
@@ -20,7 +20,7 @@ var iosSymbolFileRegex = regexp.MustCompile("ios-([^;]*).symbols")
 
 type DartSymbolOptions struct {
 	Path          utils.Paths `arg:"" name:"path" help:"(required) Path to directory or file to upload" type:"path"`
-	IosAppPath    string      `help:"(optional) the path to the built iOS app."`
+	IosAppPath    utils.Path  `help:"(optional) the path to the built iOS app."`
 	VersionName   string      `help:"The version of the application." xor:"app-version,version-name"`
 	VersionCode   string      `help:"The version code for the application (Android only)." xor:"app-version-code,version-code"`
 	BundleVersion string      `help:"The bundle version for the application (iOS only)." xor:"app-bundle-version,bundle-version"`


### PR DESCRIPTION
## Goal

Ensure that the paths that are passed to the Dart upload option exist before attempting to use them.

Example error message when file doesn't exist:
`bugsnag-cli: error: --ios-app-path: stat /path/to/no/where: no such file or directory`

## Changeset

Use the `utils.Path` type for the `--ios-app-path` CLI option to validate whether the file exists or not.

## Testing

Covered by CI