### PR TITLE
[PLAT-11330] Adjust how we handle multiple file uploads and failures for Android NDK/AAB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 - Ensure that `--ios-app-path` exists when passed as an option via the `upload dart` CLI. [67](https://github.com/bugsnag/bugsnag-cli/pull/67)
+- Ensure that we handle `--fail-on-upload-error` and multiple files correctly for Android AAB and NDK. [68](https://github.com/bugsnag/bugsnag-cli/pull/68)
 
 ## 2.0.0 (2023-10-17)
 

--- a/pkg/android/process-uploads.go
+++ b/pkg/android/process-uploads.go
@@ -29,10 +29,14 @@ func UploadAndroidNdk(fileList []string, apiKey string, applicationId string, ve
 		err = server.ProcessFileRequest(endpoint+"/ndk-symbol", uploadOptions, fileFieldData, timeout, file, dryRun)
 
 		if err != nil {
-			if numberOfFiles > 1 && failOnUploadError {
-				return err
+			if numberOfFiles > 1 {
+				if failOnUploadError {
+					return err
+				} else {
+					log.Warn(err.Error())
+				}
 			} else {
-				log.Warn(err.Error())
+				return err
 			}
 		} else {
 			log.Success("Uploaded " + filepath.Base(file))

--- a/pkg/upload/all.go
+++ b/pkg/upload/all.go
@@ -54,10 +54,14 @@ func All(paths []string, options map[string]string, endpoint string, timeout int
 		requestStatus := server.ProcessFileRequest(endpoint, uploadOptions, fileFieldData, timeout, file, dryRun)
 
 		if requestStatus != nil {
-			if numberOfFiles > 1 && failOnUploadError {
-				return requestStatus
+			if numberOfFiles > 1 {
+				if failOnUploadError {
+					return err
+				} else {
+					log.Warn(err.Error())
+				}
 			} else {
-				log.Warn(requestStatus.Error())
+				return err
 			}
 		} else {
 			log.Success("Uploaded " + filepath.Base(file))

--- a/pkg/upload/android-aab.go
+++ b/pkg/upload/android-aab.go
@@ -2,12 +2,11 @@ package upload
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
-
 	"github.com/bugsnag/bugsnag-cli/pkg/android"
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
+	"os"
+	"path/filepath"
 )
 
 type AndroidAabMapping struct {
@@ -60,12 +59,10 @@ func ProcessAndroidAab(apiKey string, applicationId string, buildUuid string, pa
 		}
 
 		if len(soFileList) > 0 {
-			for _, file := range soFileList {
-				err = ProcessAndroidNDK(manifestData["apiKey"], manifestData["applicationId"], "", "", []string{file}, projectRoot, "", manifestData["versionCode"], manifestData["versionName"], endpoint, failOnUploadError, retries, timeout, overwrite, dryRun)
+			err = ProcessAndroidNDK(manifestData["apiKey"], manifestData["applicationId"], "", "", soFileList, projectRoot, "", manifestData["versionCode"], manifestData["versionName"], endpoint, failOnUploadError, retries, timeout, overwrite, dryRun)
 
-				if err != nil {
-					return err
-				}
+			if err != nil {
+				return err
 			}
 		} else {
 			log.Info("No NDK (.so) files detected for upload.")

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -68,7 +68,7 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 			}
 
 		} else {
-			fileList = []string{path}
+			fileList = append(fileList, path)
 
 			if appManifestPath == "" {
 				if variant == "" {
@@ -94,108 +94,108 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 				}
 			}
 		}
+	}
 
-		if projectRoot != "" {
-			log.Info("Using " + projectRoot + " as the project root")
-		}
+	if projectRoot != "" {
+		log.Info("Using " + projectRoot + " as the project root")
+	}
 
-		// Check to see if we need to read the manifest file due to missing options
-		if appManifestPath != "" && (apiKey == "" || applicationId == "" || versionCode == "" || versionName == "") {
+	// Check to see if we need to read the manifest file due to missing options
+	if appManifestPath != "" && (apiKey == "" || applicationId == "" || versionCode == "" || versionName == "") {
 
-			log.Info("Reading data from AndroidManifest.xml")
-			manifestData, err := android.ParseAndroidManifestXML(appManifestPath)
-
-			if err != nil {
-				return err
-			}
-
-			if apiKey == "" {
-				for key, value := range manifestData.Application.MetaData.Name {
-					if value == "com.bugsnag.android.API_KEY" {
-						apiKey = manifestData.Application.MetaData.Value[key]
-					}
-				}
-
-				if apiKey != "" {
-					log.Info("Using " + apiKey + " as API key from AndroidManifest.xml")
-
-				}
-			}
-
-			if applicationId == "" {
-				applicationId = manifestData.ApplicationId
-
-				if applicationId != "" {
-					log.Info("Using " + applicationId + " as application ID from AndroidManifest.xml")
-				}
-			}
-
-			if versionCode == "" {
-				versionCode = manifestData.VersionCode
-
-				if versionCode != "" {
-					log.Info("Using " + versionCode + " as version code from AndroidManifest.xml")
-				}
-			}
-
-			if versionName == "" {
-				versionName = manifestData.VersionName
-
-				if versionName != "" {
-					log.Info("Using " + versionName + " as version name from AndroidManifest.xml")
-				}
-			}
-		}
-
-		// Process .so files through objcopy to create .sym files, filtering any other file type
-		for _, file := range fileList {
-			if strings.HasSuffix(file, ".so.sym") {
-				symbolFileList = append(symbolFileList, file)
-			} else if filepath.Ext(file) == ".so" {
-				// Check NDK path is set
-				if objCopyPath == "" {
-					androidNdkRoot, err = android.GetAndroidNDKRoot(androidNdkRoot)
-
-					if err != nil {
-						return err
-					}
-
-					objCopyPath, err = android.BuildObjcopyPath(androidNdkRoot)
-
-					if err != nil {
-						return err
-					}
-
-					log.Info("Located objcopy within Android NDK path: " + androidNdkRoot)
-				}
-
-				log.Info("Extracting debug info from " + filepath.Base(file) + " using objcopy")
-
-				if workingDir == "" {
-					workingDir, err = os.MkdirTemp("", "bugsnag-cli-ndk-*")
-
-					if err != nil {
-						return fmt.Errorf("error creating temporary working directory " + err.Error())
-					}
-
-					defer os.RemoveAll(workingDir)
-				}
-
-				outputFile, err := android.Objcopy(objCopyPath, file, workingDir)
-
-				if err != nil {
-					return fmt.Errorf("failed to process file, " + file + " using objcopy : " + err.Error())
-				}
-
-				symbolFileList = append(symbolFileList, outputFile)
-			}
-		}
-
-		err = android.UploadAndroidNdk(symbolFileList, apiKey, applicationId, versionName, versionCode, projectRoot, overwrite, endpoint, timeout, dryRun, failOnUploadError)
+		log.Info("Reading data from AndroidManifest.xml")
+		manifestData, err := android.ParseAndroidManifestXML(appManifestPath)
 
 		if err != nil {
 			return err
 		}
+
+		if apiKey == "" {
+			for key, value := range manifestData.Application.MetaData.Name {
+				if value == "com.bugsnag.android.API_KEY" {
+					apiKey = manifestData.Application.MetaData.Value[key]
+				}
+			}
+
+			if apiKey != "" {
+				log.Info("Using " + apiKey + " as API key from AndroidManifest.xml")
+
+			}
+		}
+
+		if applicationId == "" {
+			applicationId = manifestData.ApplicationId
+
+			if applicationId != "" {
+				log.Info("Using " + applicationId + " as application ID from AndroidManifest.xml")
+			}
+		}
+
+		if versionCode == "" {
+			versionCode = manifestData.VersionCode
+
+			if versionCode != "" {
+				log.Info("Using " + versionCode + " as version code from AndroidManifest.xml")
+			}
+		}
+
+		if versionName == "" {
+			versionName = manifestData.VersionName
+
+			if versionName != "" {
+				log.Info("Using " + versionName + " as version name from AndroidManifest.xml")
+			}
+		}
+	}
+
+	// Process .so files through objcopy to create .sym files, filtering any other file type
+	for _, file := range fileList {
+		if strings.HasSuffix(file, ".so.sym") {
+			symbolFileList = append(symbolFileList, file)
+		} else if filepath.Ext(file) == ".so" {
+			// Check NDK path is set
+			if objCopyPath == "" {
+				androidNdkRoot, err = android.GetAndroidNDKRoot(androidNdkRoot)
+
+				if err != nil {
+					return err
+				}
+
+				objCopyPath, err = android.BuildObjcopyPath(androidNdkRoot)
+
+				if err != nil {
+					return err
+				}
+
+				log.Info("Located objcopy within Android NDK path: " + androidNdkRoot)
+			}
+
+			log.Info("Extracting debug info from " + filepath.Base(file) + " using objcopy")
+
+			if workingDir == "" {
+				workingDir, err = os.MkdirTemp("", "bugsnag-cli-ndk-*")
+
+				if err != nil {
+					return fmt.Errorf("error creating temporary working directory " + err.Error())
+				}
+
+				defer os.RemoveAll(workingDir)
+			}
+
+			outputFile, err := android.Objcopy(objCopyPath, file, workingDir)
+
+			if err != nil {
+				return fmt.Errorf("failed to process file, " + file + " using objcopy : " + err.Error())
+			}
+
+			symbolFileList = append(symbolFileList, outputFile)
+		}
+	}
+
+	err = android.UploadAndroidNdk(symbolFileList, apiKey, applicationId, versionName, versionCode, projectRoot, overwrite, endpoint, timeout, dryRun, failOnUploadError)
+
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/upload/dart.go
+++ b/pkg/upload/dart.go
@@ -64,10 +64,14 @@ func Dart(paths []string, version string, versionCode string, bundleVersion stri
 			requestStatus := server.ProcessFileRequest(endpoint+"/dart-symbol", uploadOptions, fileFieldData, timeout, file, dryRun)
 
 			if requestStatus != nil {
-				if numberOfFiles > 1 && failOnUploadError {
-					return requestStatus
+				if numberOfFiles > 1 {
+					if failOnUploadError {
+						return err
+					} else {
+						log.Warn(err.Error())
+					}
 				} else {
-					log.Warn(requestStatus.Error())
+					return err
 				}
 			} else {
 				log.Success(file)
@@ -113,10 +117,14 @@ func Dart(paths []string, version string, versionCode string, bundleVersion stri
 			}
 
 			if err != nil {
-				if numberOfFiles > 1 && failOnUploadError {
-					return err
+				if numberOfFiles > 1 {
+					if failOnUploadError {
+						return err
+					} else {
+						log.Warn(err.Error())
+					}
 				} else {
-					log.Warn(err.Error())
+					return err
 				}
 			} else {
 				log.Success(file)


### PR DESCRIPTION
## Goal

Ensure that we properly handle failures with multiple file uploads for Android NDK and AAB when passing the `--fail-on-upload-error` CLI flag.

## Changeset

Rather than process each NDK file separately when dealing with an AAB file, we will pass an array of strings so that it can process them as one group enabling us to utilise the `--fail-on-upload-error` flag correctly. 

Adjust how we check if we're dealing with multiple files when checking for `failOnUploadError` to ensure that we still error if we're dealing with a single file.

## Testing

Covered by CI