### PR TITLE
[HOTFIX] Ensure `--retries` is handled correctly during uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Ensure that `--ios-app-path` exists when passed as an option via the `upload dart` CLI. [67](https://github.com/bugsnag/bugsnag-cli/pull/67)
 - Ensure that we handle `--fail-on-upload-error` and multiple files correctly for Android AAB and NDK. [68](https://github.com/bugsnag/bugsnag-cli/pull/68)
+- Ensure that uploads are retried when passing the `--retries=x` argument to the CLI. [70](https://github.com/bugsnag/bugsnag-cli/pull/70)
 
 ## 2.0.0 (2023-10-17)
 

--- a/main.go
+++ b/main.go
@@ -258,7 +258,7 @@ func main() {
 			log.Error("Failed to build upload url: "+err.Error(), 1)
 		}
 
-		err = build.ProcessCreateBuild(CreateBuildOptions, endpoint, commands.DryRun, commands.CreateBuild.Timeout)
+		err = build.ProcessCreateBuild(CreateBuildOptions, endpoint, commands.DryRun, commands.CreateBuild.Timeout, commands.CreateBuild.Retries)
 
 		if err != nil {
 			log.Error(err.Error(), 1)

--- a/pkg/android/process-uploads.go
+++ b/pkg/android/process-uploads.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 )
 
-func UploadAndroidNdk(fileList []string, apiKey string, applicationId string, versionName string, versionCode string, projectRoot string, overwrite bool, endpoint string, timeout int, dryRun bool, failOnUploadError bool) error {
+func UploadAndroidNdk(fileList []string, apiKey string, applicationId string, versionName string, versionCode string, projectRoot string, overwrite bool, endpoint string, timeout int, retries int, dryRun bool, failOnUploadError bool) error {
 	fileFieldData := make(map[string]string)
 
 	numberOfFiles := len(fileList)
@@ -26,7 +26,7 @@ func UploadAndroidNdk(fileList []string, apiKey string, applicationId string, ve
 
 		fileFieldData["soFile"] = file
 
-		err = server.ProcessFileRequest(endpoint+"/ndk-symbol", uploadOptions, fileFieldData, timeout, file, dryRun)
+		err = server.ProcessFileRequest(endpoint+"/ndk-symbol", uploadOptions, fileFieldData, timeout, retries, file, dryRun)
 
 		if err != nil {
 			if numberOfFiles > 1 {

--- a/pkg/build/process-create-build.go
+++ b/pkg/build/process-create-build.go
@@ -30,7 +30,7 @@ type Payload struct {
 //
 // Returns:
 //   - error: An error if any step of the build processing fails. Nil if the process is successful.
-func ProcessCreateBuild(buildOptions CreateBuildInfo, endpoint string, dryRun bool, timeout int) error {
+func ProcessCreateBuild(buildOptions CreateBuildInfo, endpoint string, dryRun bool, timeout int, retries int) error {
 	buildPayload, err := json.Marshal(buildOptions)
 	if err != nil {
 		return fmt.Errorf("Failed to create build information payload: " + err.Error())
@@ -39,7 +39,7 @@ func ProcessCreateBuild(buildOptions CreateBuildInfo, endpoint string, dryRun bo
 	prettyBuildPayload, _ := utils.PrettyPrintJson(string(buildPayload))
 	log.Info("Build information:\n" + prettyBuildPayload)
 
-	err = server.ProcessBuildRequest(endpoint, buildPayload, timeout, dryRun)
+	err = server.ProcessBuildRequest(endpoint, buildPayload, timeout, retries, dryRun)
 	if err != nil {
 		return err
 	}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -65,6 +65,7 @@ type CreateBuild struct {
 	VersionName       string            `help:"The version of the application." xor:"app-version,version-name"`
 	AutoAssignRelease bool              `help:"Whether to automatically associate this build with any new error events and sessions that are received for the releaseStage"`
 	Timeout           int               `help:"Number of seconds to wait before failing an upload request" default:"300"`
+	Retries           int               `help:"Number of retry attempts before failing an upload request" default:"0"`
 	AndroidBuildOptions
 	IosBuildOptions
 }

--- a/pkg/server/request.go
+++ b/pkg/server/request.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -144,18 +143,25 @@ func ProcessBuildRequest(endpoint string, payload []byte, timeout int, retries i
 //   - error: An error indicating the reason for failure or nil if the request is successful.
 func processRequest(request *http.Request, timeout int, retryCount int) error {
 	var err error
-	for i := 0; i <= retryCount; i++ {
+	i := 0
+	for {
 		err = sendRequest(request, timeout)
 		if err == nil {
 			return nil
 		}
 
-		log.Warn("Attempt " + strconv.Itoa(i+1) + " %d failed. Retrying...")
+		log.Warn("Request Failed, Retrying...")
+		i++
+
+		if i >= retryCount {
+			break
+		}
+
 		time.Sleep(time.Second)
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed after %d attempts", retryCount)
+		return fmt.Errorf("failed after %d attempts. "+err.Error(), retryCount)
 	}
 
 	return nil

--- a/pkg/server/request.go
+++ b/pkg/server/request.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -81,7 +82,7 @@ func buildFileRequest(url string, fieldData map[string]string, fileFieldData map
 //
 // Returns:
 //   - error: An error if any step of the file processing fails. Nil if the process is successful.
-func ProcessFileRequest(endpoint string, uploadOptions map[string]string, fileFieldData map[string]string, timeout int, fileName string, dryRun bool) error {
+func ProcessFileRequest(endpoint string, uploadOptions map[string]string, fileFieldData map[string]string, timeout int, retries int, fileName string, dryRun bool) error {
 	req, err := buildFileRequest(endpoint, uploadOptions, fileFieldData)
 	if err != nil {
 		return fmt.Errorf("error building file request: %w", err)
@@ -90,7 +91,7 @@ func ProcessFileRequest(endpoint string, uploadOptions map[string]string, fileFi
 	if !dryRun {
 		log.Info("Uploading " + filepath.Base(fileName) + " to " + endpoint)
 
-		err := sendRequest(req, timeout)
+		err := processRequest(req, timeout, retries)
 		if err != nil {
 			return err
 		}
@@ -112,14 +113,14 @@ func ProcessFileRequest(endpoint string, uploadOptions map[string]string, fileFi
 //
 // Returns:
 //   - error: An error if any step of the build processing fails. Nil if the process is successful.
-func ProcessBuildRequest(endpoint string, payload []byte, timeout int, dryRun bool) error {
+func ProcessBuildRequest(endpoint string, payload []byte, timeout int, retries int, dryRun bool) error {
 	req, _ := http.NewRequest("POST", endpoint, bytes.NewBuffer(payload))
 	req.Header.Add("Content-Type", "application/json")
 
 	if !dryRun {
 		log.Info("Sending build information to " + endpoint)
 
-		err := sendRequest(req, timeout)
+		err := processRequest(req, timeout, retries)
 		if err != nil {
 			return err
 		}
@@ -128,6 +129,31 @@ func ProcessBuildRequest(endpoint string, payload []byte, timeout int, dryRun bo
 	}
 
 	return nil
+}
+
+// processRequest sends an HTTP request using sendRequest function with retry logic.
+// It attempts to send the request multiple times, specified by retryCount parameter,
+// and waits for a short duration between each attempt.
+// If all attempts fail, it returns an error indicating the failure after the specified number of attempts.
+// Parameters:
+//   - request: The HTTP request to be sent.
+//   - timeout: Timeout duration for the HTTP request in seconds.
+//   - retryCount: Number of times to retry the request in case of failure.
+//
+// Returns:
+//   - error: An error indicating the reason for failure or nil if the request is successful.
+func processRequest(request *http.Request, timeout int, retryCount int) error {
+	for i := 0; i < retryCount; i++ {
+		err := sendRequest(request, timeout)
+		if err == nil {
+			return nil
+		}
+
+		log.Warn("Attempt " + strconv.Itoa(i+1) + " %d failed. Retrying...")
+		time.Sleep(time.Second)
+	}
+
+	return fmt.Errorf("failed after %d attempts", retryCount)
 }
 
 // sendRequest sends an HTTP request using the provided request object and timeout.
@@ -153,7 +179,7 @@ func sendRequest(request *http.Request, timeout int) error {
 	if err != nil {
 		return fmt.Errorf("error reading body from response: %w", err)
 	}
-	
+
 	contentType := response.Header.Get("Content-Type")
 
 	if strings.Contains(contentType, "application/json") {

--- a/pkg/server/request.go
+++ b/pkg/server/request.go
@@ -144,13 +144,11 @@ func ProcessBuildRequest(endpoint string, payload []byte, timeout int, retries i
 //   - error: An error indicating the reason for failure or nil if the request is successful.
 func processRequest(request *http.Request, timeout int, retryCount int) error {
 	var err error
-	for i := 0; i < retryCount; i++ {
+	for i := 0; i <= retryCount; i++ {
 		err = sendRequest(request, timeout)
 		if err == nil {
 			return nil
 		}
-
-		fmt.Println(err)
 
 		log.Warn("Attempt " + strconv.Itoa(i+1) + " %d failed. Retrying...")
 		time.Sleep(time.Second)

--- a/pkg/server/request.go
+++ b/pkg/server/request.go
@@ -143,17 +143,24 @@ func ProcessBuildRequest(endpoint string, payload []byte, timeout int, retries i
 // Returns:
 //   - error: An error indicating the reason for failure or nil if the request is successful.
 func processRequest(request *http.Request, timeout int, retryCount int) error {
+	var err error
 	for i := 0; i < retryCount; i++ {
-		err := sendRequest(request, timeout)
+		err = sendRequest(request, timeout)
 		if err == nil {
 			return nil
 		}
+
+		fmt.Println(err)
 
 		log.Warn("Attempt " + strconv.Itoa(i+1) + " %d failed. Retrying...")
 		time.Sleep(time.Second)
 	}
 
-	return fmt.Errorf("failed after %d attempts", retryCount)
+	if err != nil {
+		return fmt.Errorf("failed after %d attempts", retryCount)
+	}
+
+	return nil
 }
 
 // sendRequest sends an HTTP request using the provided request object and timeout.

--- a/pkg/upload/all.go
+++ b/pkg/upload/all.go
@@ -51,7 +51,7 @@ func All(paths []string, options map[string]string, endpoint string, timeout int
 			fileFieldData["file"] = file
 		}
 
-		requestStatus := server.ProcessFileRequest(endpoint, uploadOptions, fileFieldData, timeout, file, dryRun)
+		requestStatus := server.ProcessFileRequest(endpoint, uploadOptions, fileFieldData, timeout, retries, file, dryRun)
 
 		if requestStatus != nil {
 			if numberOfFiles > 1 {

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -192,7 +192,7 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 		}
 	}
 
-	err = android.UploadAndroidNdk(symbolFileList, apiKey, applicationId, versionName, versionCode, projectRoot, overwrite, endpoint, timeout, dryRun, failOnUploadError)
+	err = android.UploadAndroidNdk(symbolFileList, apiKey, applicationId, versionName, versionCode, projectRoot, overwrite, endpoint, timeout, retries, dryRun, failOnUploadError)
 
 	if err != nil {
 		return err

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -189,12 +189,12 @@ func ProcessAndroidProguard(
 		fileFieldData := make(map[string]string)
 		fileFieldData["proguard"] = outputFile
 
-		err = server.ProcessFileRequest(endpoint+"/proguard", uploadOptions, fileFieldData, timeout, outputFile, dryRun)
+		err = server.ProcessFileRequest(endpoint+"/proguard", uploadOptions, fileFieldData, timeout, retries, outputFile, dryRun)
 
 		if err != nil {
 			if strings.Contains(err.Error(), "404 Not Found") {
 				log.Info("Trying " + endpoint)
-				err = server.ProcessFileRequest(endpoint, uploadOptions, fileFieldData, timeout, outputFile, dryRun)
+				err = server.ProcessFileRequest(endpoint, uploadOptions, fileFieldData, timeout, retries, outputFile, dryRun)
 			}
 		}
 

--- a/pkg/upload/dart.go
+++ b/pkg/upload/dart.go
@@ -61,7 +61,7 @@ func Dart(paths []string, version string, versionCode string, bundleVersion stri
 			fileFieldData := make(map[string]string)
 			fileFieldData["symbolFile"] = file
 
-			requestStatus := server.ProcessFileRequest(endpoint+"/dart-symbol", uploadOptions, fileFieldData, timeout, file, dryRun)
+			requestStatus := server.ProcessFileRequest(endpoint+"/dart-symbol", uploadOptions, fileFieldData, timeout, retries, file, dryRun)
 
 			if requestStatus != nil {
 				if numberOfFiles > 1 {
@@ -113,7 +113,7 @@ func Dart(paths []string, version string, versionCode string, bundleVersion stri
 			if dryRun {
 				err = nil
 			} else {
-				err = server.ProcessFileRequest(endpoint+"/dart-symbol", uploadOptions, fileFieldData, timeout, file, dryRun)
+				err = server.ProcessFileRequest(endpoint+"/dart-symbol", uploadOptions, fileFieldData, timeout, retries, file, dryRun)
 			}
 
 			if err != nil {

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -169,7 +169,7 @@ func ProcessReactNativeAndroid(apiKey string, appManifestPath string, bundlePath
 		fileFieldData["sourceMap"] = sourceMapPath
 		fileFieldData["bundle"] = bundlePath
 
-		err = server.ProcessFileRequest(endpoint+"/react-native-source-map", uploadOptions, fileFieldData, timeout, sourceMapPath, dryRun)
+		err = server.ProcessFileRequest(endpoint+"/react-native-source-map", uploadOptions, fileFieldData, timeout, retries, sourceMapPath, dryRun)
 
 		if err != nil {
 			return err

--- a/pkg/upload/react-native-ios.go
+++ b/pkg/upload/react-native-ios.go
@@ -225,7 +225,7 @@ func ProcessReactNativeIos(
 	fileFieldData["sourceMap"] = sourceMapPath
 	fileFieldData["bundle"] = bundlePath
 
-	err = server.ProcessFileRequest(endpoint+"/react-native-source-map", uploadOptions, fileFieldData, timeout, sourceMapPath, dryRun)
+	err = server.ProcessFileRequest(endpoint+"/react-native-source-map", uploadOptions, fileFieldData, timeout, retries, sourceMapPath, dryRun)
 
 	if err != nil {
 		return err

--- a/pkg/upload/unity-android.go
+++ b/pkg/upload/unity-android.go
@@ -109,7 +109,7 @@ func ProcessUnityAndroid(apiKey string, aabPath string, applicationId string, ve
 		}
 	}
 
-	err = android.UploadAndroidNdk(symbolFileList, manifestData["apiKey"], manifestData["applicationId"], manifestData["versionName"], manifestData["versionCode"], projectRoot, overwrite, endpoint, timeout, dryRun, failOnUploadError)
+	err = android.UploadAndroidNdk(symbolFileList, manifestData["apiKey"], manifestData["applicationId"], manifestData["versionName"], manifestData["versionCode"], projectRoot, overwrite, endpoint, timeout, retries, dryRun, failOnUploadError)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
## Goal

Ensure that when using the `--retries` argument on the CLI that if the upload fails the upload is retried the number of times equal to the value passed to the CLI argument. 

## Changeset

Add a new function to house and process the retry logic for sending requests to the upload endpoint.

## Testing

Covered by CI