### PR TITLE
[PLAT-11399] Update paths used when checking for react native ios bundle maps and Info.plist files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
-gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", tag: 'v8.13.1'
+gem "bugsnag-maze-runner", git: "https://github.com/bugsnag/maze-runner", tag: 'v8.18.0'
 gem 'cocoapods'

--- a/features/react-native-ios/rn0_69.feature
+++ b/features/react-native-ios/rn0_69.feature
@@ -48,3 +48,17 @@ Feature: React Native 0.69 iOS Integration Tests
     And the sourcemap payload field "appBundleVersion" equals "1"
     And the sourcemap payload field "platform" equals "ios"
     And the sourcemap payload field "overwrite" equals "true"
+
+  Scenario: Build, Archive and Upload React Native 0.69 iOS sourcemaps
+    When I make the "features/base-fixtures/rn0_69/ios/archive"
+    And I wait for the build to succeed
+
+    When I run bugsnag-cli with upload react-native-ios --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --dev features/base-fixtures/rn0_69
+    And I wait to receive 1 sourcemaps
+    Then the sourcemap is valid for the React Native Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
+    And the sourcemap payload field "appVersion" equals "1.0"
+    And the sourcemap payload field "appBundleVersion" equals "1"
+    And the sourcemap payload field "platform" equals "ios"
+    And the sourcemap payload field "overwrite" equals "true"

--- a/features/react-native-ios/rn0_70.feature
+++ b/features/react-native-ios/rn0_70.feature
@@ -48,3 +48,17 @@ Feature: React Native 0.70 iOS Integration Tests
     And the sourcemap payload field "appBundleVersion" equals "1"
     And the sourcemap payload field "platform" equals "ios"
     And the sourcemap payload field "overwrite" equals "true"
+
+  Scenario: Build, Archive and Upload React Native 0.70 iOS sourcemaps
+    When I make the "features/base-fixtures/rn0_70/ios/archive"
+    And I wait for the build to succeed
+
+    When I run bugsnag-cli with upload react-native-ios --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --dev features/base-fixtures/rn0_70
+    And I wait to receive 1 sourcemaps
+    Then the sourcemap is valid for the React Native Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
+    And the sourcemap payload field "appVersion" equals "1.0"
+    And the sourcemap payload field "appBundleVersion" equals "1"
+    And the sourcemap payload field "platform" equals "ios"
+    And the sourcemap payload field "overwrite" equals "true"

--- a/features/react-native-ios/rn0_72.feature
+++ b/features/react-native-ios/rn0_72.feature
@@ -48,3 +48,17 @@ Feature: React Native 0.72 iOS Integration Tests
     And the sourcemap payload field "appBundleVersion" equals "1"
     And the sourcemap payload field "platform" equals "ios"
     And the sourcemap payload field "overwrite" equals "true"
+
+  Scenario: Build, Archive and Upload React Native 0.72 iOS sourcemaps
+    When I make the "features/base-fixtures/rn0_72/ios/archive"
+    And I wait for the build to succeed
+
+    When I run bugsnag-cli with upload react-native-ios --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --dev features/base-fixtures/rn0_72
+    And I wait to receive 1 sourcemaps
+    Then the sourcemap is valid for the React Native Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
+    And the sourcemap payload field "appVersion" equals "1.0"
+    And the sourcemap payload field "appBundleVersion" equals "1"
+    And the sourcemap payload field "platform" equals "ios"
+    And the sourcemap payload field "overwrite" equals "true"

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -22,6 +22,7 @@ end
 
 When(/^I run bugsnag-cli with (.*)$/) do |flags|
   @output = `bin/#{arch}-#{os}-#{binary} #{flags} 2>&1`
+  puts @output
 end
 
 Then('I should see the help banner') do

--- a/makefile
+++ b/makefile
@@ -99,6 +99,12 @@ features/base-fixtures/rn0_69/ios:
 	cd $@ && pod install
 	cd $@ && xcodebuild -workspace rn0_69.xcworkspace -scheme rn0_69 -configuration Release -sdk iphoneos build
 
+.PHONY: features/base-fixtures/rn0_69/ios/archive
+features/base-fixtures/rn0_69/ios/archive:
+	cd features/base-fixtures/rn0_69/ios/../ && npm i && bundle install
+	cd features/base-fixtures/rn0_69/ios/ && pod install
+	cd features/base-fixtures/rn0_69/ios/ && xcrun xcodebuild -scheme rn0_69 -workspace rn0_69.xcworkspace -configuration Release -archivePath "../rn0_69.xcarchive" -allowProvisioningUpdates archive
+
 .PHONY: features/base-fixtures/rn0_70/android
 features/base-fixtures/rn0_70/android:
 	cd $@/../ && npm i
@@ -110,6 +116,12 @@ features/base-fixtures/rn0_70/ios:
 	cd $@ && pod install
 	cd $@ && xcodebuild -workspace rn0_70.xcworkspace -scheme rn0_70 -configuration Release -sdk iphoneos build
 
+.PHONY: features/base-fixtures/rn0_70/ios/archive
+features/base-fixtures/rn0_70/ios/archive:
+	cd features/base-fixtures/rn0_70/ios/../ && npm i && bundle install
+	cd features/base-fixtures/rn0_70/ios/ && pod install
+	cd features/base-fixtures/rn0_70/ios/ && xcrun xcodebuild -scheme rn0_70 -workspace rn0_70.xcworkspace -configuration Release -archivePath "../rn0_70.xcarchive" -allowProvisioningUpdates archive
+
 .PHONY: features/base-fixtures/rn0_72/android
 features/base-fixtures/rn0_72/android:
 	cd $@/../ && npm i
@@ -120,3 +132,9 @@ features/base-fixtures/rn0_72/ios:
 	cd $@/../ && npm i && bundle install
 	cd $@ && pod install
 	cd $@ && xcodebuild -workspace rn0_72.xcworkspace -scheme rn0_72 -configuration Release -sdk iphoneos build
+
+.PHONY: features/base-fixtures/rn0_72/ios/archive
+features/base-fixtures/rn0_72/ios/archive:
+	cd features/base-fixtures/rn0_72/ios/../ && npm i && bundle install
+	cd features/base-fixtures/rn0_72/ios/ && pod install
+	cd features/base-fixtures/rn0_72/ios/ && xcrun xcodebuild -scheme rn0_72 -workspace rn0_72.xcworkspace -configuration Release -archivePath "../rn0_72.xcarchive" -allowProvisioningUpdates archive

--- a/pkg/ios/xcodebuild-utils.go
+++ b/pkg/ios/xcodebuild-utils.go
@@ -15,6 +15,7 @@ type XcodeBuildSettings struct {
 	ConfigurationBuildDir string `mapstructure:"CONFIGURATION_BUILD_DIR"`
 	InfoPlistPath         string `mapstructure:"INFOPLIST_PATH"`
 	BuiltProductsDir      string `mapstructure:"BUILT_PRODUCTS_DIR"`
+	ProjectTempRoot       string `mapstructure:"PROJECT_TEMP_ROOT"`
 }
 
 // IsSchemeInWorkspace checks if a scheme is in a given workspace

--- a/pkg/upload/react-native-ios.go
+++ b/pkg/upload/react-native-ios.go
@@ -157,7 +157,7 @@ func ProcessReactNativeIos(
 					bundlePath = possibleBundleFilePath
 					log.Info("Found bundle file at: " + bundlePath)
 				} else {
-					possibleBundleFilePath = filepath.Join(buildSettings.ProjectTempRoot, "ArchiveIntermediates/"+scheme+"/BuildProductsPath/Release-iphoneos/main.jsbundle")
+					possibleBundleFilePath = filepath.Join(buildSettings.ProjectTempRoot, "ArchiveIntermediates", scheme, "BuildProductsPath", filepath.Base(buildSettings.BuiltProductsDir), "main.jsbundle")
 					if utils.FileExists(possibleBundleFilePath) {
 						bundlePath = possibleBundleFilePath
 						log.Info("Found bundle file at: " + bundlePath)

--- a/pkg/upload/react-native-ios.go
+++ b/pkg/upload/react-native-ios.go
@@ -132,7 +132,7 @@ func ProcessReactNativeIos(
 					plistPath = plistPathExpected
 					log.Info("Found Info.plist at: " + plistPath)
 				} else {
-					plistPathExpected = filepath.Join(buildSettings.ProjectTempRoot, "ArchiveIntermediates/"+scheme+"/BuildProductsPath/Release-iphoneos/"+scheme+".app/Info.plist")
+					plistPathExpected = filepath.Join(buildSettings.ProjectTempRoot, "ArchiveIntermediates", scheme, "BuildProductsPath", filepath.Base(buildSettings.BuiltProductsDir), buildSettings.InfoPlistPath)				
 					if utils.FileExists(plistPathExpected) {
 						plistPath = plistPathExpected
 						log.Info("Found Info.plist at: " + plistPath)

--- a/pkg/upload/react-native-ios.go
+++ b/pkg/upload/react-native-ios.go
@@ -132,7 +132,13 @@ func ProcessReactNativeIos(
 					plistPath = plistPathExpected
 					log.Info("Found Info.plist at: " + plistPath)
 				} else {
-					log.Info("No Info.plist found at: " + plistPathExpected)
+					plistPathExpected = filepath.Join(buildSettings.ProjectTempRoot, "ArchiveIntermediates/"+scheme+"/BuildProductsPath/Release-iphoneos/"+scheme+".app/Info.plist")
+					if utils.FileExists(plistPathExpected) {
+						plistPath = plistPathExpected
+						log.Info("Found Info.plist at: " + plistPath)
+					} else {
+						log.Info("No Info.plist found at: " + plistPathExpected)
+					}
 				}
 			}
 
@@ -151,7 +157,13 @@ func ProcessReactNativeIos(
 					bundlePath = possibleBundleFilePath
 					log.Info("Found bundle file at: " + bundlePath)
 				} else {
-					log.Info("No bundle file found at: " + possibleBundleFilePath)
+					possibleBundleFilePath = filepath.Join(buildSettings.ProjectTempRoot, "ArchiveIntermediates/"+scheme+"/BuildProductsPath/Release-iphoneos/main.jsbundle")
+					if utils.FileExists(possibleBundleFilePath) {
+						bundlePath = possibleBundleFilePath
+						log.Info("Found bundle file at: " + bundlePath)
+					} else {
+						log.Info("No bundle file found at: " + possibleBundleFilePath)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Goal

Ensure that we are able to find the bundle map and Info.plist file when working with archive over a regular build. This due to the required files being stored in a separate location than what we where previously checking.

e.g.

`/Users/administrator/Library/Developer/Xcode/DerivedData/rn0_69-fuannaoexgewdsfmbpxkkalrdlgw/Build/Products/Release-iphoneos/rn0_69.app/Info.plist`
vs
`/Users/administrator/Library/Developer/Xcode/DerivedData/rn0_69-fuannaoexgewdsfmbpxkkalrdlgw/Build/Intermediates.noindex/ArchiveIntermediates/rn0_69/BuildProductsPath/Release-iphoneos/rn0_69.app/Info.plist`

And 

`/Users/administrator/Library/Developer/Xcode/DerivedData/rn0_69-fuannaoexgewdsfmbpxkkalrdlgw/Build/Products/Release-iphoneos/main.jsbundle` 
vs
`/Users/administrator/Library/Developer/Xcode/DerivedData/rn0_69-fuannaoexgewdsfmbpxkkalrdlgw/Build/Intermediates.noindex/ArchiveIntermediates/rn0_69/BuildProductsPath/Release-iphoneos/main.jsbundle`

## Design

We're following a similar multiple file/path check flow that we use in the Android side.


## Testing

Covered by CI