### PR TITLE
[PLAT-11638] Add fallback endpoint for DSYM uploads

### DIFF
--- a/pkg/ios/dsym-utils.go
+++ b/pkg/ios/dsym-utils.go
@@ -42,7 +42,7 @@ func FindDsymsInPath(path string, ignoreEmptyDsym, ignoreMissingDwarf bool) ([]*
 			tempDir, err = utils.ExtractFile(path, "dsym")
 
 			if err != nil {
-				log.Error("Could not unzip " + fileName + " to a temporary directory, skipping", 1)
+				log.Error("Could not unzip "+fileName+" to a temporary directory, skipping", 1)
 
 			} else {
 				log.Info("Unzipped " + fileName + " to " + tempDir + " for uploading")
@@ -91,7 +91,7 @@ func FindDsymsInPath(path string, ignoreEmptyDsym, ignoreMissingDwarf bool) ([]*
 					if ignoreEmptyDsym {
 						log.Warn("Skipping empty file: " + file.Name())
 					} else {
-						log.Error("Skipping empty file: " + file.Name(), 0)
+						log.Error("Skipping empty file: "+file.Name(), 0)
 					}
 				}
 			}

--- a/pkg/ios/dsym-utils.go
+++ b/pkg/ios/dsym-utils.go
@@ -42,7 +42,7 @@ func FindDsymsInPath(path string, ignoreEmptyDsym, ignoreMissingDwarf bool) ([]*
 			tempDir, err = utils.ExtractFile(path, "dsym")
 
 			if err != nil {
-				log.Error("Could not unzip "+fileName+" to a temporary directory, skipping", 1)
+				log.Error("Could not unzip " + fileName + " to a temporary directory, skipping", 1)
 
 			} else {
 				log.Info("Unzipped " + fileName + " to " + tempDir + " for uploading")

--- a/pkg/upload/dsym.go
+++ b/pkg/upload/dsym.go
@@ -190,7 +190,7 @@ func ProcessDsym(
 			if err != nil {
 				if strings.Contains(err.Error(), "404 Not Found") {
 					log.Info("Trying " + endpoint)
-					err = server.ProcessFileRequest(endpoint, uploadOptions, fileFieldData, timeout, retries, outputFile, dryRun)
+					err = server.ProcessFileRequest(endpoint, uploadOptions, fileFieldData, timeout, retries, dsym.UUID, dryRun)
 				}
 			}
 

--- a/pkg/upload/dsym.go
+++ b/pkg/upload/dsym.go
@@ -189,13 +189,16 @@ func ProcessDsym(
 
 			if err != nil {
 				if strings.Contains(err.Error(), "404 Not Found") {
-					log.Info("Trying " + endpoint)
 					err = server.ProcessFileRequest(endpoint, uploadOptions, fileFieldData, timeout, retries, dsym.UUID, dryRun)
 				}
 			}
 
 			if err != nil {
-				return err
+				if failOnUpload {
+					return err
+				} else {
+					log.Warn(err.Error())
+				}
 			} else {
 				log.Success("Uploaded dSYM: " + dsym.Name)
 			}

--- a/pkg/upload/dsym.go
+++ b/pkg/upload/dsym.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/bugsnag/bugsnag-cli/pkg/ios"
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
@@ -187,15 +188,17 @@ func ProcessDsym(
 			err = server.ProcessFileRequest(endpoint+"/dsym", uploadOptions, fileFieldData, timeout, retries, dsym.UUID, dryRun)
 
 			if err != nil {
-				if failOnUpload {
-					return err
-				} else {
-					log.Warn(err.Error())
+				if strings.Contains(err.Error(), "404 Not Found") {
+					log.Info("Trying " + endpoint)
+					err = server.ProcessFileRequest(endpoint, uploadOptions, fileFieldData, timeout, retries, outputFile, dryRun)
 				}
+			}
+
+			if err != nil {
+				return err
 			} else {
 				log.Success("Uploaded dSYM: " + dsym.Name)
 			}
-
 		}
 	}
 

--- a/pkg/upload/react-native-ios.go
+++ b/pkg/upload/react-native-ios.go
@@ -135,7 +135,7 @@ func ProcessReactNativeIos(
 					plistPath = plistPathExpected
 					log.Info("Found Info.plist at expected location: " + plistPath)
 				} else {
-					plistPathExpected = filepath.Join(buildSettings.ProjectTempRoot, "ArchiveIntermediates", scheme, "BuildProductsPath", filepath.Base(buildSettings.BuiltProductsDir), buildSettings.InfoPlistPath)				
+					plistPathExpected = filepath.Join(buildSettings.ProjectTempRoot, "ArchiveIntermediates", scheme, "BuildProductsPath", filepath.Base(buildSettings.BuiltProductsDir), buildSettings.InfoPlistPath)
 					if utils.FileExists(plistPathExpected) {
 						plistPath = plistPathExpected
 						log.Info("Found Info.plist at: " + plistPath)


### PR DESCRIPTION
## Goal

- Add fallback endpoint for DSYM uploads when processing the DSYM API request.

## Changeset

Following the design for Android Proguard, we're going to attempt to send the request to the `\dsym` endpoint. However, if that returns a 404, we will attempt to send the request to the fallback URL.

## Testing

Covered by CI