### PR TITLE
[PLAT-11746] Deprecate `--fail-on-upload-error` and handling for duplicate file response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## 2.1.0 (TBD)
 
+### Breaking Changes
+- Deprecate the `--fail-on-upload-error` flag. [95](https://github.com/bugsnag/bugsnag-cli/pull/90)
+
 ### Enhancements
 
 - Add support for React Native source maps for iOS [online docs (TBD)]()
-- Allow `create build` to extract relevant information from a given Android manifest or AAB file.[65](https://github.com/bugsnag/bugsnag-cli/pull/65)
 - Add support for dSYM uploads for iOS [online docs (TBD)]()
+- Allow `create build` to extract relevant information from a given Android manifest or AAB file.[65](https://github.com/bugsnag/bugsnag-cli/pull/65)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 ### Fixes
 
 - Ensure that `--ios-app-path` exists when passed as an option via the `upload dart` CLI. [67](https://github.com/bugsnag/bugsnag-cli/pull/67)
-- Ensure that we handle `--fail-on-upload-error` and multiple files correctly for Android AAB and NDK. [68](https://github.com/bugsnag/bugsnag-cli/pull/68)
 - Ensure that uploads are retried when passing the `--retries=x` argument to the CLI. [70](https://github.com/bugsnag/bugsnag-cli/pull/70)
 
 ## 2.0.0 (2023-10-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add support for React Native source maps for iOS [online docs (TBD)]()
 - Allow `create build` to extract relevant information from a given Android manifest or AAB file.[65](https://github.com/bugsnag/bugsnag-cli/pull/65)
+- Add support for dSYM uploads for iOS [online docs (TBD)]()
 
 ### Fixes
 

--- a/features/dsym/expected_err_and_warn_scenarios.feature
+++ b/features/dsym/expected_err_and_warn_scenarios.feature
@@ -23,11 +23,3 @@ Feature: dSYM Expected Error and Warning scenario Integration Tests
   Scenario: If --ignore-missing-dwarf is not set, then the log message returned should be [ERROR]
     When I run bugsnag-cli with upload dsym --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/path/to/project/root --scheme=test features/dsym/fixtures/MissingDWARFdSYM
     Then I should see a log level of "[ERROR]" when no dSYM files could be found
-
-  Scenario: If --fail-on-upload-error is set to true, then the log message returned should be [ERROR]
-    When I run bugsnag-cli with upload dsym --upload-api-root-url=http://localhost:9333 --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/path/to/project/root --scheme=test --fail-on-upload-error=true features/dsym/fixtures/dsyms.zip
-    Then I should see a log level of "[ERROR]" when no dSYM files could be uploaded
-
-  Scenario: If --fail-on-upload-error is not set, then the log message returned should be [WARN]
-    When I run bugsnag-cli with upload dsym --upload-api-root-url=http://localhost:9333 --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/path/to/project/root --scheme=test features/dsym/fixtures/dsyms.zip
-    Then I should see a log level of "[WARN]" when no dSYM files could be uploaded

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 	}
 
 	if commands.FailOnUploadError {
-		log.Warn("The `--fail-on-upload-error` flag is deprecated and will be removed in a future release.")
+		log.Warn("The `--fail-on-upload-error` flag is deprecated and will be removed in a future release. All commands now fail if the upload is unsuccessful.")
 	}
 
 	switch ctx.Command() {

--- a/main.go
+++ b/main.go
@@ -42,6 +42,10 @@ func main() {
 		log.Info("Performing dry run - no data will be sent to BugSnag")
 	}
 
+	if commands.FailOnUploadError {
+		log.Warn("The `--fail-on-upload-error` flag is deprecated and will be removed in a future release.")
+	}
+
 	switch ctx.Command() {
 
 	case "upload all <path>":
@@ -58,7 +62,6 @@ func main() {
 			commands.Upload.Retries,
 			commands.Upload.Overwrite,
 			commands.ApiKey,
-			commands.FailOnUploadError,
 			commands.DryRun,
 		)
 
@@ -77,7 +80,6 @@ func main() {
 			commands.Upload.AndroidAab.VersionCode,
 			commands.Upload.AndroidAab.VersionName,
 			endpoint,
-			commands.FailOnUploadError,
 			commands.Upload.Retries,
 			commands.Upload.Timeout,
 			commands.Upload.Overwrite,
@@ -101,7 +103,6 @@ func main() {
 			commands.Upload.AndroidNdk.VersionCode,
 			commands.Upload.AndroidNdk.VersionName,
 			endpoint,
-			commands.FailOnUploadError,
 			commands.Upload.Retries,
 			commands.Upload.Timeout,
 			commands.Upload.Overwrite,
@@ -141,7 +142,8 @@ func main() {
 			log.Error("missing api key, please specify using `--api-key`", 1)
 		}
 
-		err := upload.Dart(commands.Upload.DartSymbol.Path,
+		err := upload.Dart(
+			commands.Upload.DartSymbol.Path,
 			commands.Upload.DartSymbol.VersionName,
 			commands.Upload.DartSymbol.VersionCode,
 			commands.Upload.DartSymbol.BundleVersion,
@@ -151,7 +153,6 @@ func main() {
 			commands.Upload.Retries,
 			commands.Upload.Overwrite,
 			commands.ApiKey,
-			commands.FailOnUploadError,
 			commands.DryRun,
 		)
 
@@ -220,7 +221,6 @@ func main() {
 			commands.Upload.Dsym.ProjectRoot,
 			commands.Upload.Dsym.IgnoreMissingDwarf,
 			commands.Upload.Dsym.IgnoreEmptyDsym,
-			commands.FailOnUploadError,
 			commands.Upload.Dsym.Path,
 			endpoint,
 			commands.Upload.Timeout,
@@ -248,7 +248,6 @@ func main() {
 			commands.Upload.UnityAndroid.ProjectRoot,
 			commands.Upload.UnityAndroid.Path,
 			endpoint,
-			commands.FailOnUploadError,
 			commands.Upload.Timeout,
 			commands.Upload.Retries,
 			commands.Upload.Overwrite,

--- a/pkg/android/process-uploads.go
+++ b/pkg/android/process-uploads.go
@@ -7,7 +7,19 @@ import (
 	"path/filepath"
 )
 
-func UploadAndroidNdk(fileList []string, apiKey string, applicationId string, versionName string, versionCode string, projectRoot string, overwrite bool, endpoint string, timeout int, retries int, dryRun bool, failOnUploadError bool) error {
+func UploadAndroidNdk(
+	fileList []string,
+	apiKey string,
+	applicationId string,
+	versionName string,
+	versionCode string,
+	projectRoot string,
+	overwrite bool,
+	endpoint string,
+	timeout int,
+	retries int,
+	dryRun bool,
+) error {
 	fileFieldData := make(map[string]string)
 
 	numberOfFiles := len(fileList)
@@ -29,15 +41,7 @@ func UploadAndroidNdk(fileList []string, apiKey string, applicationId string, ve
 		err = server.ProcessFileRequest(endpoint+"/ndk-symbol", uploadOptions, fileFieldData, timeout, retries, file, dryRun)
 
 		if err != nil {
-			if numberOfFiles > 1 {
-				if failOnUploadError {
-					return err
-				} else {
-					log.Warn(err.Error())
-				}
-			} else {
-				return err
-			}
+			return err
 		} else {
 			log.Success("Uploaded " + filepath.Base(file))
 		}

--- a/pkg/android/process-uploads.go
+++ b/pkg/android/process-uploads.go
@@ -5,6 +5,7 @@ import (
 	"github.com/bugsnag/bugsnag-cli/pkg/server"
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
 	"path/filepath"
+	"strings"
 )
 
 func UploadAndroidNdk(
@@ -41,7 +42,11 @@ func UploadAndroidNdk(
 		err = server.ProcessFileRequest(endpoint+"/ndk-symbol", uploadOptions, fileFieldData, timeout, retries, file, dryRun)
 
 		if err != nil {
-			return err
+			if strings.Contains(err.Error(), "409") && strings.Contains(err.Error(), "duplicate") {
+				log.Warn("Duplicate file detected, skipping upload of " + filepath.Base(file))
+			} else {
+				return err
+			}
 		} else {
 			log.Success("Uploaded " + filepath.Base(file))
 		}

--- a/pkg/android/process-uploads.go
+++ b/pkg/android/process-uploads.go
@@ -5,7 +5,6 @@ import (
 	"github.com/bugsnag/bugsnag-cli/pkg/server"
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
 	"path/filepath"
-	"strings"
 )
 
 func UploadAndroidNdk(
@@ -42,13 +41,7 @@ func UploadAndroidNdk(
 		err = server.ProcessFileRequest(endpoint+"/ndk-symbol", uploadOptions, fileFieldData, timeout, retries, file, dryRun)
 
 		if err != nil {
-			if strings.Contains(err.Error(), "409") && strings.Contains(err.Error(), "duplicate") {
-				log.Warn("Duplicate file detected, skipping upload of " + filepath.Base(file))
-			} else {
-				return err
-			}
-		} else {
-			log.Success("Uploaded " + filepath.Base(file))
+			return err
 		}
 	}
 

--- a/pkg/server/request.go
+++ b/pkg/server/request.go
@@ -93,8 +93,15 @@ func ProcessFileRequest(endpoint string, uploadOptions map[string]string, fileFi
 		log.Info("Uploading " + filepath.Base(fileName) + " to " + endpoint)
 
 		err = processRequest(req, timeout, retries)
+
 		if err != nil {
-			return err
+			if strings.Contains(err.Error(), "409") {
+				log.Warn("Duplicate file detected, skipping upload of " + filepath.Base(fileName))
+			} else {
+				return err
+			}
+		} else {
+			log.Success("Uploaded " + filepath.Base(fileName))
 		}
 	} else {
 		log.Info("(dryrun) Skipping upload of " + filepath.Base(fileName) + " to " + endpoint)

--- a/pkg/upload/all.go
+++ b/pkg/upload/all.go
@@ -4,8 +4,6 @@ import (
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
 	"github.com/bugsnag/bugsnag-cli/pkg/server"
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
-	"path/filepath"
-	"strings"
 )
 
 type DiscoverAndUploadAny struct {
@@ -62,13 +60,8 @@ func All(
 		err := server.ProcessFileRequest(endpoint, uploadOptions, fileFieldData, timeout, retries, file, dryRun)
 
 		if err != nil {
-			if strings.Contains(err.Error(), "409") && strings.Contains(err.Error(), "duplicate") {
-				log.Warn("Duplicate file detected, skipping upload of " + filepath.Base(file))
-			} else {
-				return err
-			}
-		} else {
-			log.Success("Uploaded " + filepath.Base(file))
+
+			return err
 		}
 	}
 

--- a/pkg/upload/all.go
+++ b/pkg/upload/all.go
@@ -12,14 +12,21 @@ type DiscoverAndUploadAny struct {
 	UploadOptions map[string]string `help:"Additional arguments to pass to the upload request" mapsep:","`
 }
 
-func All(paths []string, options map[string]string, endpoint string, timeout int, retries int, overwrite bool,
-	apiKey string, failOnUploadError bool, dryRun bool) error {
+func All(
+	paths []string,
+	options map[string]string,
+	endpoint string,
+	timeout int,
+	retries int,
+	overwrite bool,
+	apiKey string,
+	dryRun bool,
+) error {
 
 	// Build the file list from the path(s)
 	log.Info("building file list...")
 
 	fileList, err := utils.BuildFileList(paths)
-	numberOfFiles := len(fileList)
 
 	if err != nil {
 		log.Error(" error building file list", 1)
@@ -54,15 +61,7 @@ func All(paths []string, options map[string]string, endpoint string, timeout int
 		requestStatus := server.ProcessFileRequest(endpoint, uploadOptions, fileFieldData, timeout, retries, file, dryRun)
 
 		if requestStatus != nil {
-			if numberOfFiles > 1 {
-				if failOnUploadError {
-					return err
-				} else {
-					log.Warn(err.Error())
-				}
-			} else {
-				return err
-			}
+			return err
 		} else {
 			log.Success("Uploaded " + filepath.Base(file))
 		}

--- a/pkg/upload/all.go
+++ b/pkg/upload/all.go
@@ -5,6 +5,7 @@ import (
 	"github.com/bugsnag/bugsnag-cli/pkg/server"
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
 	"path/filepath"
+	"strings"
 )
 
 type DiscoverAndUploadAny struct {
@@ -58,10 +59,14 @@ func All(
 			fileFieldData["file"] = file
 		}
 
-		requestStatus := server.ProcessFileRequest(endpoint, uploadOptions, fileFieldData, timeout, retries, file, dryRun)
+		err := server.ProcessFileRequest(endpoint, uploadOptions, fileFieldData, timeout, retries, file, dryRun)
 
-		if requestStatus != nil {
-			return err
+		if err != nil {
+			if strings.Contains(err.Error(), "409") && strings.Contains(err.Error(), "duplicate") {
+				log.Warn("Duplicate file detected, skipping upload of " + filepath.Base(file))
+			} else {
+				return err
+			}
 		} else {
 			log.Success("Uploaded " + filepath.Base(file))
 		}

--- a/pkg/upload/android-aab.go
+++ b/pkg/upload/android-aab.go
@@ -18,7 +18,20 @@ type AndroidAabMapping struct {
 	VersionName   string      `help:"Module version name"`
 }
 
-func ProcessAndroidAab(apiKey string, applicationId string, buildUuid string, paths []string, projectRoot string, versionCode string, versionName string, endpoint string, failOnUploadError bool, retries int, timeout int, overwrite bool, dryRun bool) error {
+func ProcessAndroidAab(
+	apiKey string,
+	applicationId string,
+	buildUuid string,
+	paths []string,
+	projectRoot string,
+	versionCode string,
+	versionName string,
+	endpoint string,
+	retries int,
+	timeout int,
+	overwrite bool,
+	dryRun bool,
+) error {
 
 	var manifestData map[string]string
 	var aabDir string
@@ -59,7 +72,22 @@ func ProcessAndroidAab(apiKey string, applicationId string, buildUuid string, pa
 		}
 
 		if len(soFileList) > 0 {
-			err = ProcessAndroidNDK(manifestData["apiKey"], manifestData["applicationId"], "", "", soFileList, projectRoot, "", manifestData["versionCode"], manifestData["versionName"], endpoint, failOnUploadError, retries, timeout, overwrite, dryRun)
+			err = ProcessAndroidNDK(
+				manifestData["apiKey"],
+				manifestData["applicationId"],
+				"",
+				"",
+				soFileList,
+				projectRoot,
+				"",
+				manifestData["versionCode"],
+				manifestData["versionName"],
+				endpoint,
+				retries,
+				timeout,
+				overwrite,
+				dryRun,
+			)
 
 			if err != nil {
 				return err

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -22,7 +22,22 @@ type AndroidNdkMapping struct {
 	VersionName    string      `help:"Module version name"`
 }
 
-func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot string, appManifestPath string, paths []string, projectRoot string, variant string, versionCode string, versionName string, endpoint string, failOnUploadError bool, retries int, timeout int, overwrite bool, dryRun bool) error {
+func ProcessAndroidNDK(
+	apiKey string,
+	applicationId string,
+	androidNdkRoot string,
+	appManifestPath string,
+	paths []string,
+	projectRoot string,
+	variant string,
+	versionCode string,
+	versionName string,
+	endpoint string,
+	retries int,
+	timeout int,
+	overwrite bool,
+	dryRun bool,
+) error {
 
 	var fileList []string
 	var symbolFileList []string
@@ -192,7 +207,19 @@ func ProcessAndroidNDK(apiKey string, applicationId string, androidNdkRoot strin
 		}
 	}
 
-	err = android.UploadAndroidNdk(symbolFileList, apiKey, applicationId, versionName, versionCode, projectRoot, overwrite, endpoint, timeout, retries, dryRun, failOnUploadError)
+	err = android.UploadAndroidNdk(
+		symbolFileList,
+		apiKey,
+		applicationId,
+		versionName,
+		versionCode,
+		projectRoot,
+		overwrite,
+		endpoint,
+		timeout,
+		retries,
+		dryRun,
+	)
 
 	if err != nil {
 		return err

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -199,7 +199,11 @@ func ProcessAndroidProguard(
 		}
 
 		if err != nil {
-			return err
+			if strings.Contains(err.Error(), "409") && strings.Contains(err.Error(), "duplicate") {
+				log.Warn("Duplicate file detected, skipping upload of " + filepath.Base(mappingFile))
+			} else {
+				return err
+			}
 		} else {
 			log.Success("Uploaded " + filepath.Base(mappingFile))
 		}

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -199,13 +199,7 @@ func ProcessAndroidProguard(
 		}
 
 		if err != nil {
-			if strings.Contains(err.Error(), "409") && strings.Contains(err.Error(), "duplicate") {
-				log.Warn("Duplicate file detected, skipping upload of " + filepath.Base(mappingFile))
-			} else {
-				return err
-			}
-		} else {
-			log.Success("Uploaded " + filepath.Base(mappingFile))
+			return err
 		}
 	}
 	return nil

--- a/pkg/upload/dart.go
+++ b/pkg/upload/dart.go
@@ -74,13 +74,8 @@ func Dart(
 			err := server.ProcessFileRequest(endpoint+"/dart-symbol", uploadOptions, fileFieldData, timeout, retries, file, dryRun)
 
 			if err != nil {
-				if strings.Contains(err.Error(), "409") && strings.Contains(err.Error(), "duplicate") {
-					log.Warn("Duplicate file detected, skipping upload of " + filepath.Base(file))
-				} else {
-					return err
-				}
-			} else {
-				log.Success("Uploaded " + filepath.Base(file))
+
+				return err
 			}
 
 			continue
@@ -123,13 +118,8 @@ func Dart(
 			}
 
 			if err != nil {
-				if strings.Contains(err.Error(), "409") && strings.Contains(err.Error(), "duplicate") {
-					log.Warn("Duplicate file detected, skipping upload of " + filepath.Base(file))
-				} else {
-					return err
-				}
-			} else {
-				log.Success("Uploaded " + filepath.Base(file))
+
+				return err
 			}
 
 			continue

--- a/pkg/upload/dart.go
+++ b/pkg/upload/dart.go
@@ -26,12 +26,22 @@ type DartSymbolOptions struct {
 	BundleVersion string      `help:"The bundle version for the application (iOS only)." xor:"app-bundle-version,bundle-version"`
 }
 
-func Dart(paths []string, version string, versionCode string, bundleVersion string, iosAppPath string, endpoint string, timeout int, retries int, overwrite bool, apiKey string, failOnUploadError bool, dryRun bool) error {
+func Dart(
+	paths []string,
+	version string,
+	versionCode string,
+	bundleVersion string,
+	iosAppPath string,
+	endpoint string,
+	timeout int, retries int,
+	overwrite bool,
+	apiKey string,
+	dryRun bool,
+) error {
 
 	log.Info("Building file list from path")
 
 	fileList, err := utils.BuildFileList(paths)
-	numberOfFiles := len(fileList)
 
 	if err != nil {
 		log.Error("error building file list", 1)
@@ -64,15 +74,8 @@ func Dart(paths []string, version string, versionCode string, bundleVersion stri
 			requestStatus := server.ProcessFileRequest(endpoint+"/dart-symbol", uploadOptions, fileFieldData, timeout, retries, file, dryRun)
 
 			if requestStatus != nil {
-				if numberOfFiles > 1 {
-					if failOnUploadError {
-						return err
-					} else {
-						log.Warn(err.Error())
-					}
-				} else {
-					return err
-				}
+
+				return err
 			} else {
 				log.Success(file)
 			}
@@ -117,15 +120,7 @@ func Dart(paths []string, version string, versionCode string, bundleVersion stri
 			}
 
 			if err != nil {
-				if numberOfFiles > 1 {
-					if failOnUploadError {
-						return err
-					} else {
-						log.Warn(err.Error())
-					}
-				} else {
-					return err
-				}
+				return err
 			} else {
 				log.Success(file)
 			}

--- a/pkg/upload/dart.go
+++ b/pkg/upload/dart.go
@@ -71,13 +71,16 @@ func Dart(
 			fileFieldData := make(map[string]string)
 			fileFieldData["symbolFile"] = file
 
-			requestStatus := server.ProcessFileRequest(endpoint+"/dart-symbol", uploadOptions, fileFieldData, timeout, retries, file, dryRun)
+			err := server.ProcessFileRequest(endpoint+"/dart-symbol", uploadOptions, fileFieldData, timeout, retries, file, dryRun)
 
-			if requestStatus != nil {
-
-				return err
+			if err != nil {
+				if strings.Contains(err.Error(), "409") && strings.Contains(err.Error(), "duplicate") {
+					log.Warn("Duplicate file detected, skipping upload of " + filepath.Base(file))
+				} else {
+					return err
+				}
 			} else {
-				log.Success(file)
+				log.Success("Uploaded " + filepath.Base(file))
 			}
 
 			continue
@@ -120,9 +123,13 @@ func Dart(
 			}
 
 			if err != nil {
-				return err
+				if strings.Contains(err.Error(), "409") && strings.Contains(err.Error(), "duplicate") {
+					log.Warn("Duplicate file detected, skipping upload of " + filepath.Base(file))
+				} else {
+					return err
+				}
 			} else {
-				log.Success(file)
+				log.Success("Uploaded " + filepath.Base(file))
 			}
 
 			continue

--- a/pkg/upload/dsym.go
+++ b/pkg/upload/dsym.go
@@ -172,13 +172,8 @@ func ProcessDsym(
 			}
 
 			if err != nil {
-				if strings.Contains(err.Error(), "409") && strings.Contains(err.Error(), "duplicate") {
-					log.Warn("Duplicate file detected, skipping upload of " + dsym.Location + "/" + dsym.Name)
-				} else {
-					return err
-				}
-			} else {
-				log.Success("Uploaded dSYM: " + dsym.Location + "/" + dsym.Name)
+
+				return err
 			}
 		}
 	}

--- a/pkg/upload/dsym.go
+++ b/pkg/upload/dsym.go
@@ -32,7 +32,6 @@ func ProcessDsym(
 	projectRoot string,
 	ignoreMissingDwarf bool,
 	ignoreEmptyDsym bool,
-	failOnUploadError bool,
 	paths []string,
 	endpoint string,
 	timeout int,
@@ -173,15 +172,7 @@ func ProcessDsym(
 			}
 
 			if err != nil {
-				if len(dwarfInfo) > 1 {
-					if failOnUploadError {
-						return err
-					} else {
-						log.Warn(err.Error())
-					}
-				} else {
-					return err
-				}
+				return err
 			} else {
 				log.Success("Uploaded dSYM: " + dsym.Location + "/" + dsym.Name)
 			}

--- a/pkg/upload/dsym.go
+++ b/pkg/upload/dsym.go
@@ -172,7 +172,11 @@ func ProcessDsym(
 			}
 
 			if err != nil {
-				return err
+				if strings.Contains(err.Error(), "409") && strings.Contains(err.Error(), "duplicate") {
+					log.Warn("Duplicate file detected, skipping upload of " + dsym.Location + "/" + dsym.Name)
+				} else {
+					return err
+				}
 			} else {
 				log.Success("Uploaded dSYM: " + dsym.Location + "/" + dsym.Name)
 			}

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -26,7 +26,24 @@ type ReactNativeAndroid struct {
 	VersionCode  string      `help:"The version code for the application (Android only)."`
 }
 
-func ProcessReactNativeAndroid(apiKey string, appManifestPath string, bundlePath string, codeBundleId string, dev bool, paths []string, projectRoot string, variant string, versionName string, versionCode string, sourceMapPath string, endpoint string, timeout int, retries int, overwrite bool, dryRun bool) error {
+func ProcessReactNativeAndroid(
+	apiKey string,
+	appManifestPath string,
+	bundlePath string,
+	codeBundleId string,
+	dev bool,
+	paths []string,
+	projectRoot string,
+	variant string,
+	versionName string,
+	versionCode string,
+	sourceMapPath string,
+	endpoint string,
+	timeout int,
+	retries int,
+	overwrite bool,
+	dryRun bool,
+) error {
 
 	var err error
 	var uploadOptions map[string]string

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -2,11 +2,9 @@ package upload
 
 import (
 	"fmt"
-	"path/filepath"
-	"strings"
-
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
+	"path/filepath"
 
 	"github.com/bugsnag/bugsnag-cli/pkg/android"
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
@@ -190,13 +188,8 @@ func ProcessReactNativeAndroid(
 		err = server.ProcessFileRequest(endpoint+"/react-native-source-map", uploadOptions, fileFieldData, timeout, retries, sourceMapPath, dryRun)
 
 		if err != nil {
-			if strings.Contains(err.Error(), "409") && strings.Contains(err.Error(), "duplicate") {
-				log.Warn("Duplicate file detected, skipping upload of " + filepath.Base(sourceMapPath))
-			} else {
-				return err
-			}
-		} else {
-			log.Success("Uploaded " + filepath.Base(sourceMapPath))
+
+			return err
 		}
 	}
 

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -3,6 +3,7 @@ package upload
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -189,7 +190,11 @@ func ProcessReactNativeAndroid(
 		err = server.ProcessFileRequest(endpoint+"/react-native-source-map", uploadOptions, fileFieldData, timeout, retries, sourceMapPath, dryRun)
 
 		if err != nil {
-			return err
+			if strings.Contains(err.Error(), "409") && strings.Contains(err.Error(), "duplicate") {
+				log.Warn("Duplicate file detected, skipping upload of " + filepath.Base(sourceMapPath))
+			} else {
+				return err
+			}
 		} else {
 			log.Success("Uploaded " + filepath.Base(sourceMapPath))
 		}

--- a/pkg/upload/react-native-ios.go
+++ b/pkg/upload/react-native-ios.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -231,7 +232,11 @@ func ProcessReactNativeIos(
 	err = server.ProcessFileRequest(endpoint+"/react-native-source-map", uploadOptions, fileFieldData, timeout, retries, sourceMapPath, dryRun)
 
 	if err != nil {
-		return err
+		if strings.Contains(err.Error(), "409") && strings.Contains(err.Error(), "duplicate") {
+			log.Warn("Duplicate file detected, skipping upload of " + filepath.Base(sourceMapPath))
+		} else {
+			return err
+		}
 	} else {
 		log.Success("Uploaded " + filepath.Base(sourceMapPath))
 	}

--- a/pkg/upload/react-native-ios.go
+++ b/pkg/upload/react-native-ios.go
@@ -2,11 +2,9 @@ package upload
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
-	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/bugsnag/bugsnag-cli/pkg/ios"
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
@@ -232,13 +230,8 @@ func ProcessReactNativeIos(
 	err = server.ProcessFileRequest(endpoint+"/react-native-source-map", uploadOptions, fileFieldData, timeout, retries, sourceMapPath, dryRun)
 
 	if err != nil {
-		if strings.Contains(err.Error(), "409") && strings.Contains(err.Error(), "duplicate") {
-			log.Warn("Duplicate file detected, skipping upload of " + filepath.Base(sourceMapPath))
-		} else {
-			return err
-		}
-	} else {
-		log.Success("Uploaded " + filepath.Base(sourceMapPath))
+
+		return err
 	}
 
 	return nil

--- a/pkg/upload/unity-android.go
+++ b/pkg/upload/unity-android.go
@@ -20,7 +20,21 @@ type UnityAndroid struct {
 	BuildUuid     string      `help:"Module Build UUID"`
 }
 
-func ProcessUnityAndroid(apiKey string, aabPath string, applicationId string, versionCode string, buildUuid string, versionName string, projectRoot string, paths []string, endpoint string, failOnUploadError bool, retries int, timeout int, overwrite bool, dryRun bool) error {
+func ProcessUnityAndroid(
+	apiKey string,
+	aabPath string,
+	applicationId string,
+	versionCode string,
+	buildUuid string,
+	versionName string,
+	projectRoot string,
+	paths []string,
+	endpoint string,
+	retries int,
+	timeout int,
+	overwrite bool,
+	dryRun bool,
+) error {
 	var err error
 	var zipPath string
 	var archList []string
@@ -68,7 +82,20 @@ func ProcessUnityAndroid(apiKey string, aabPath string, applicationId string, ve
 			return err
 		}
 
-		err = ProcessAndroidAab(manifestData["apiKey"], manifestData["applicationId"], manifestData["buildUuid"], []string{aabDir}, projectRoot, manifestData["versionCode"], manifestData["versionName"], endpoint, failOnUploadError, retries, timeout, overwrite, dryRun)
+		err = ProcessAndroidAab(
+			manifestData["apiKey"],
+			manifestData["applicationId"],
+			manifestData["buildUuid"],
+			[]string{aabDir},
+			projectRoot,
+			manifestData["versionCode"],
+			manifestData["versionName"],
+			endpoint,
+			retries,
+			timeout,
+			overwrite,
+			dryRun,
+		)
 
 		if err != nil {
 			return err
@@ -109,7 +136,19 @@ func ProcessUnityAndroid(apiKey string, aabPath string, applicationId string, ve
 		}
 	}
 
-	err = android.UploadAndroidNdk(symbolFileList, manifestData["apiKey"], manifestData["applicationId"], manifestData["versionName"], manifestData["versionCode"], projectRoot, overwrite, endpoint, timeout, retries, dryRun, failOnUploadError)
+	err = android.UploadAndroidNdk(
+		symbolFileList,
+		manifestData["apiKey"],
+		manifestData["applicationId"],
+		manifestData["versionName"],
+		manifestData["versionCode"],
+		projectRoot,
+		overwrite,
+		endpoint,
+		timeout,
+		retries,
+		dryRun,
+	)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
## Goal

Deprecate the `--fail-on-upload-error` flag and log a warning if the flag is used. From now on when an upload fails it will always fail unless the API server returns a `409` error where it will instead log a warning informing the end user  that the duplicate file has been skipped.

I have also updated the formatting of some of the longer functions to fall inline with recent styling changes to make them easier to read.

## Testing

Covered by CI