### PR TITLE
[PLAT-11977] Include Windows_NT in supported-platforms.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `upload android-proguard` will now attempt to automatically locate the `classes.dex` files if no build-uuid or dex-files are found or specified [92](https://github.com/bugsnag/bugsnag-cli/pull/92)
 - Added the `--no-build-uuid` option to the `upload android-*` options [92](https://github.com/bugsnag/bugsnag-cli/pull/92)
+- Added `Windows_NT` to `supported-platforms.yml` [95](https://github.com/bugsnag/bugsnag-cli/pull/95)
 
 ## 2.1.1 (2023-03-22)
 

--- a/supported-platforms.yml
+++ b/supported-platforms.yml
@@ -8,6 +8,16 @@
   ARTIFACT_NAME: 'i386-windows-bugsnag-cli.exe'
   BINARY_NAME: 'bugsnag-cli.exe'
 
+- TYPE: 'Windows_NT'
+  ARCHITECTURE: 'x64'
+  ARTIFACT_NAME: 'x86_64-windows-bugsnag-cli.exe'
+  BINARY_NAME: 'bugsnag-cli.exe'
+
+- TYPE: 'Windows_NT'
+  ARCHITECTURE: 'i386'
+  ARTIFACT_NAME: 'i386-windows-bugsnag-cli.exe'
+  BINARY_NAME: 'bugsnag-cli.exe'
+  
 - TYPE: 'Linux'
   ARCHITECTURE: 'x64'
   ARTIFACT_NAME: 'x86_64-linux-bugsnag-cli'


### PR DESCRIPTION
@goblinbr raised [an issue](https://github.com/bugsnag/bugsnag-cli/issues/93) that highlighted the need for including `Windows_NT` in our supported platforms config file. 

Their original fix can be viewed [here](https://github.com/bugsnag/bugsnag-cli/pull/94) which includes 32 and 64 bit definitions identically defined as our pre-existing `Windows` definitions.