### PR TITLE
Using fmt to concatenate strings throughout codebase for consistency

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"fmt"
 
 	"github.com/alecthomas/kong"
 
@@ -35,7 +36,7 @@ func main() {
 	endpoint, err := utils.BuildEndpointUrl(commands.UploadAPIRootUrl, commands.Port)
 
 	if err != nil {
-		log.Error(fmt.Sprintf("Failed to build upload url: %w", err.Error()), 1)
+		log.Error(fmt.Sprintf("Failed to build upload url: %s", err.Error()), 1)
 	}
 
 	if commands.DryRun {
@@ -280,7 +281,7 @@ func main() {
 		endpoint, err = utils.BuildEndpointUrl(commands.BuildApiRootUrl, commands.Port)
 
 		if err != nil {
-			log.Error(fmt.Sprintf("Failed to build upload url: %w", err.Error()), 1)
+			log.Error(fmt.Sprintf("Failed to build upload url: %s", err.Error()), 1)
 		}
 
 		err = build.ProcessCreateBuild(CreateBuildOptions, endpoint, commands.DryRun, commands.CreateBuild.Timeout, commands.CreateBuild.Retries)

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 	endpoint, err := utils.BuildEndpointUrl(commands.UploadAPIRootUrl, commands.Port)
 
 	if err != nil {
-		log.Error("Failed to build upload url: "+err.Error(), 1)
+		log.Error(fmt.Sprintf("Failed to build upload url: %w", err.Error()), 1)
 	}
 
 	if commands.DryRun {
@@ -280,7 +280,7 @@ func main() {
 		endpoint, err = utils.BuildEndpointUrl(commands.BuildApiRootUrl, commands.Port)
 
 		if err != nil {
-			log.Error("Failed to build upload url: "+err.Error(), 1)
+			log.Error(fmt.Sprintf("Failed to build upload url: %w", err.Error()), 1)
 		}
 
 		err = build.ProcessCreateBuild(CreateBuildOptions, endpoint, commands.DryRun, commands.CreateBuild.Timeout, commands.CreateBuild.Retries)

--- a/pkg/android/aab.go
+++ b/pkg/android/aab.go
@@ -32,7 +32,7 @@ func MergeUploadOptionsFromAabManifest(path string, apiKey string, applicationId
 			manifestData, err = ReadAabManifest(filepath.Join(aabManifestPath))
 
 			if err != nil {
-				return aabUploadOptions, fmt.Errorf("unable to read data from %s %w", path, err.Error())
+				return aabUploadOptions, fmt.Errorf("unable to read data from %s %s", path, err.Error())
 			}
 		} else {
 			return aabUploadOptions, fmt.Errorf("AndroidManifest.xml not found in AAB file")

--- a/pkg/android/aab.go
+++ b/pkg/android/aab.go
@@ -32,7 +32,7 @@ func MergeUploadOptionsFromAabManifest(path string, apiKey string, applicationId
 			manifestData, err = ReadAabManifest(filepath.Join(aabManifestPath))
 
 			if err != nil {
-				return aabUploadOptions, fmt.Errorf("unable to read data from " + path + " " + err.Error())
+				return aabUploadOptions, fmt.Errorf("unable to read data from %s %w", path, err.Error())
 			}
 		} else {
 			return aabUploadOptions, fmt.Errorf("AndroidManifest.xml not found in AAB file")
@@ -40,22 +40,22 @@ func MergeUploadOptionsFromAabManifest(path string, apiKey string, applicationId
 
 		if aabUploadOptions["apiKey"] == "" && manifestData["apiKey"] != "" {
 			aabUploadOptions["apiKey"] = manifestData["apiKey"]
-			log.Info("Using " + manifestData["apiKey"] + " as API key from AndroidManifest.xml")
+			log.Info(fmt.Sprintf("Using %s as API key from AndroidManifest.xml", manifestData["apiKey"]))
 		}
 
 		if aabUploadOptions["applicationId"] == "" && manifestData["applicationId"] != "" {
 			aabUploadOptions["applicationId"] = manifestData["applicationId"]
-			log.Info("Using " + aabUploadOptions["applicationId"] + " as application ID from AndroidManifest.xml")
+			log.Info(fmt.Sprintf("Using %s as application ID from AndroidManifest.xml", aabUploadOptions["applicationId"]))
 		}
 
 		if aabUploadOptions["buildUuid"] == "" && !noBuildUuid {
 			aabUploadOptions["buildUuid"] = manifestData["buildUuid"]
 			if aabUploadOptions["buildUuid"] != "" {
-				log.Info("Using " + aabUploadOptions["buildUuid"] + " as build ID from AndroidManifest.xml")
+				log.Info(fmt.Sprintf("Using %s as build ID from AndroidManifest.xml", aabUploadOptions["buildUuid"]))
 			} else {
 				aabUploadOptions["buildUuid"] = GetDexBuildId(filepath.Join(path, "base", "dex"))
 				if aabUploadOptions["buildUuid"] != "" {
-					log.Info("Using " + aabUploadOptions["buildUuid"] + " as build ID from dex signatures")
+					log.Info(fmt.Sprintf("Using %s as build ID from dex signatures", aabUploadOptions["buildUuid"]))
 				}
 			}
 		} else if aabUploadOptions["buildUuid"] == "none" || noBuildUuid {
@@ -65,12 +65,12 @@ func MergeUploadOptionsFromAabManifest(path string, apiKey string, applicationId
 
 		if aabUploadOptions["versionCode"] == "" && manifestData["versionCode"] != "" {
 			aabUploadOptions["versionCode"] = manifestData["versionCode"]
-			log.Info("Using " + aabUploadOptions["versionCode"] + " as version code from AndroidManifest.xml")
+			log.Info(fmt.Sprintf("Using %s as version code from AndroidManifest.xml", aabUploadOptions["versionCode"]))
 		}
 
 		if aabUploadOptions["versionName"] == "" && manifestData["versionName"] != "" {
 			aabUploadOptions["versionName"] = manifestData["versionName"]
-			log.Info("Using " + aabUploadOptions["versionName"] + " as version name from AndroidManifest.xml")
+			log.Info(fmt.Sprintf("Using %s as version name from AndroidManifest.xml", aabUploadOptions["versionName"]))
 		}
 	}
 	return aabUploadOptions, nil

--- a/pkg/android/build-objcopy-path.go
+++ b/pkg/android/build-objcopy-path.go
@@ -12,7 +12,7 @@ func BuildObjcopyPath(path string) (string, error) {
 	ndkVersion, err := GetNdkVersion(path)
 
 	if err != nil {
-		return "", fmt.Errorf("unable to determine ndk version from " + path)
+		return "", fmt.Errorf("unable to determine ndk version from %s", path)
 	}
 
 	if ndkVersion < 24 {
@@ -27,7 +27,7 @@ func BuildObjcopyPath(path string) (string, error) {
 		}
 
 		if directoryMatches == nil {
-			return "", fmt.Errorf("Unable to find objcopy within: " + path)
+			return "", fmt.Errorf("Unable to find objcopy within: %s", path)
 		}
 
 		if runtime.GOOS == "windows" {

--- a/pkg/android/dex-build-id.go
+++ b/pkg/android/dex-build-id.go
@@ -58,7 +58,7 @@ func GetClassesDexFromDir(dexDir string) []string {
 
 	dexFiles := []string{filename}
 	for dexIndex := 2; ; dexIndex++ {
-		filename = filepath.Join(dexDir, "classes"+strconv.Itoa(dexIndex)+".dex")
+		filename = filepath.Join(dexDir, fmt.Sprintf("classes%s.dex", strconv.Itoa(dexIndex)))
 		if !utils.FileExists(filename) {
 			break
 		} else {

--- a/pkg/android/get-android-info.go
+++ b/pkg/android/get-android-info.go
@@ -109,13 +109,13 @@ func GetAndroidManifestFileFromAAB(path string) (string, error) {
 func getAndroidXMLData(manifestFile string) (*AndroidManifestData, error) {
 	data, err := os.ReadFile(manifestFile)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read " + manifestFile + " : " + err.Error())
+		return nil, fmt.Errorf("unable to read %s : %w", manifestFile, err.Error())
 	}
 
 	var manifestData *AndroidManifestData
 	err = xml.Unmarshal(data, &manifestData)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse data from " + manifestFile + " : " + err.Error())
+		return nil, fmt.Errorf("unable to parse data from %s : %w", manifestFile, err.Error())
 	}
 
 	return manifestData, nil

--- a/pkg/android/get-android-info.go
+++ b/pkg/android/get-android-info.go
@@ -109,13 +109,13 @@ func GetAndroidManifestFileFromAAB(path string) (string, error) {
 func getAndroidXMLData(manifestFile string) (*AndroidManifestData, error) {
 	data, err := os.ReadFile(manifestFile)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read %s : %w", manifestFile, err.Error())
+		return nil, fmt.Errorf("unable to read %s : %s", manifestFile, err.Error())
 	}
 
 	var manifestData *AndroidManifestData
 	err = xml.Unmarshal(data, &manifestData)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse data from %s : %w", manifestFile, err.Error())
+		return nil, fmt.Errorf("unable to parse data from %s : %s", manifestFile, err.Error())
 	}
 
 	return manifestData, nil

--- a/pkg/android/get-ndk-root.go
+++ b/pkg/android/get-ndk-root.go
@@ -21,7 +21,7 @@ func GetAndroidNDKRoot(path string) (string, error) {
 	}
 
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return path, fmt.Errorf(path + " does not exist on the system")
+		return path, fmt.Errorf("%s does not exist on the system", path)
 	}
 
 	return path, nil

--- a/pkg/android/get-variant.go
+++ b/pkg/android/get-variant.go
@@ -47,7 +47,7 @@ func GetVariantDirectory(path string) (string, error) {
 	variant := variants[0]
 
 	if !utils.FileExists(filepath.Join(path, variant)) {
-		return "", fmt.Errorf("variant path " + filepath.Join(path, variant) + " doesn't exist on the system")
+		return "", fmt.Errorf("variant path %s doesn't exist on the system", filepath.Join(path, variant))
 	}
 
 	return variant, nil

--- a/pkg/android/manifest-reader-xml.go
+++ b/pkg/android/manifest-reader-xml.go
@@ -29,13 +29,13 @@ type MetaData struct {
 func ParseAndroidManifestXML(manifestFile string) (*Manifest, error) {
 	data, err := os.ReadFile(manifestFile)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read " + manifestFile + " : " + err.Error())
+		return nil, fmt.Errorf("unable to read %s : %w", manifestFile, err.Error())
 	}
 
 	var manifestData *Manifest
 	err = xml.Unmarshal(data, &manifestData)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse data from " + manifestFile + " : " + err.Error())
+		return nil, fmt.Errorf("unable to parse data from %s : %w", manifestFile, err.Error())
 	}
 
 	return manifestData, nil

--- a/pkg/android/manifest-reader-xml.go
+++ b/pkg/android/manifest-reader-xml.go
@@ -29,13 +29,13 @@ type MetaData struct {
 func ParseAndroidManifestXML(manifestFile string) (*Manifest, error) {
 	data, err := os.ReadFile(manifestFile)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read %s : %w", manifestFile, err.Error())
+		return nil, fmt.Errorf("unable to read %s : %s", manifestFile, err.Error())
 	}
 
 	var manifestData *Manifest
 	err = xml.Unmarshal(data, &manifestData)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse data from %s : %w", manifestFile, err.Error())
+		return nil, fmt.Errorf("unable to parse data from %s : %s", manifestFile, err.Error())
 	}
 
 	return manifestData, nil

--- a/pkg/android/process-uploads.go
+++ b/pkg/android/process-uploads.go
@@ -5,6 +5,7 @@ import (
 	"github.com/bugsnag/bugsnag-cli/pkg/server"
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
 	"path/filepath"
+	"fmt"
 )
 
 func UploadAndroidNdk(
@@ -38,7 +39,7 @@ func UploadAndroidNdk(
 
 		fileFieldData["soFile"] = file
 
-		err = server.ProcessFileRequest(endpoint+"/ndk-symbol", uploadOptions, fileFieldData, timeout, retries, file, dryRun)
+		err = server.ProcessFileRequest(fmt.Sprintf("%s/ndk-symbol", endpoint), uploadOptions, fileFieldData, timeout, retries, file, dryRun)
 
 		if err != nil {
 			return err

--- a/pkg/build/process-create-build.go
+++ b/pkg/build/process-create-build.go
@@ -33,7 +33,7 @@ type Payload struct {
 func ProcessCreateBuild(buildOptions CreateBuildInfo, endpoint string, dryRun bool, timeout int, retries int) error {
 	buildPayload, err := json.Marshal(buildOptions)
 	if err != nil {
-		return fmt.Errorf("Failed to create build information payload: %w", err.Error())
+		return fmt.Errorf("Failed to create build information payload: %s", err.Error())
 	}
 
 	prettyBuildPayload, _ := utils.PrettyPrintJson(string(buildPayload))

--- a/pkg/build/process-create-build.go
+++ b/pkg/build/process-create-build.go
@@ -33,11 +33,11 @@ type Payload struct {
 func ProcessCreateBuild(buildOptions CreateBuildInfo, endpoint string, dryRun bool, timeout int, retries int) error {
 	buildPayload, err := json.Marshal(buildOptions)
 	if err != nil {
-		return fmt.Errorf("Failed to create build information payload: " + err.Error())
+		return fmt.Errorf("Failed to create build information payload: %w", err.Error())
 	}
 
 	prettyBuildPayload, _ := utils.PrettyPrintJson(string(buildPayload))
-	log.Info("Build information:\n" + prettyBuildPayload)
+	log.Info(fmt.Sprintf("Build information:\n%s", prettyBuildPayload))
 
 	err = server.ProcessBuildRequest(endpoint, buildPayload, timeout, retries, dryRun)
 	if err != nil {

--- a/pkg/ios/dsym-utils.go
+++ b/pkg/ios/dsym-utils.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"fmt"
 
 	"github.com/pkg/errors"
 

--- a/pkg/ios/dsym-utils.go
+++ b/pkg/ios/dsym-utils.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
 )

--- a/pkg/ios/dsym-utils.go
+++ b/pkg/ios/dsym-utils.go
@@ -36,15 +36,15 @@ func FindDsymsInPath(path string, ignoreEmptyDsym, ignoreMissingDwarf bool) ([]*
 		if strings.HasSuffix(strings.ToLower(path), ".zip") {
 
 			fileName := filepath.Base(path)
-			log.Info("Attempting to unzip " + fileName + " before proceeding to upload")
+			log.Info(fmt.Sprintf("Attempting to unzip %s before proceeding to upload", fileName))
 
 			var err error
 			tempDir, err = utils.ExtractFile(path, "dsym")
 
 			if err != nil {
-				return nil, tempDir, errors.New("Could not unzip " + fileName + " to a temporary directory, skipping")
+				return nil, tempDir, fmt.Errorf("Could not unzip %s to a temporary directory, skipping", fileName)
 			} else {
-				log.Info("Unzipped " + fileName + " to " + tempDir + " for uploading")
+				log.Info(fmt.Sprintf("Unzipped %s to %s for uploading", fileName, tempDir))
 				dsymLocations = findDsyms(tempDir)
 			}
 
@@ -58,7 +58,7 @@ func FindDsymsInPath(path string, ignoreEmptyDsym, ignoreMissingDwarf bool) ([]*
 	// If we have found dSYMs, use dwarfdump to get the UUID etc for each dSYM
 	if len(dsymLocations) > 0 {
 		if !isDwarfDumpInstalled() {
-			return nil, tempDir, errors.New("Unable to locate dwarfdump on this system.")
+			return nil, tempDir, fmt.Errorf("Unable to locate dwarfdump on this system.")
 		}
 
 		for _, dsymLocation := range dsymLocations {
@@ -80,17 +80,17 @@ func FindDsymsInPath(path string, ignoreEmptyDsym, ignoreMissingDwarf bool) ([]*
 					info := getDwarfFileInfo(dsymLocation, file.Name())
 					if len(info) == 0 {
 						if ignoreMissingDwarf {
-							log.Info(fileInfo.Name() + " is not a valid DWARF file, skipping")
+							log.Info(fmt.Sprintf("%s is not a valid DWARF file, skipping", fileInfo.Name()))
 						} else {
-							return nil, tempDir, errors.New(fileInfo.Name() + " is not a valid DWARF file")
+							return nil, tempDir, fmt.Errorf("%s is not a valid DWARF file", fileInfo.Name())
 						}
 					}
 					dwarfInfo = append(dwarfInfo, info...)
 				} else {
 					if ignoreEmptyDsym {
-						log.Info(file.Name() + " is empty, skipping")
+						log.Info(fmt.Sprintf("%s is empty, skipping", file.Name()))
 					} else {
-						return nil, tempDir, errors.New(file.Name() + " is empty")
+						return nil, tempDir, fmt.Errorf("%s is empty", file.Name())
 					}
 				}
 			}

--- a/pkg/ios/xcodebuild-utils.go
+++ b/pkg/ios/xcodebuild-utils.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"fmt"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"

--- a/pkg/ios/xcodebuild-utils.go
+++ b/pkg/ios/xcodebuild-utils.go
@@ -117,10 +117,10 @@ func getXcodeBuildSettings(path, schemeName string) (*map[string]*string, error)
 		} else if strings.HasSuffix(path, ".xcodeproj") {
 			cmd = exec.Command(utils.LocationOf(utils.XCODEBUILD), "-project", path, "-scheme", schemeName, "-showBuildSettings")
 		} else {
-			return nil, errors.New("Unable to locate xcodeproj or xcworkspace in the given path")
+			return nil, fmt.Errorf("Unable to locate xcodeproj or xcworkspace in the given path")
 		}
 	} else {
-		return nil, errors.New("Unable to locate xcodebuild on this system.")
+		return nil, fmt.Errorf("Unable to locate xcodebuild on this system.")
 	}
 
 	output, err := cmd.Output()

--- a/pkg/log/logging.go
+++ b/pkg/log/logging.go
@@ -14,9 +14,9 @@ const White = "\033[37m"
 
 func LogMessage(message string, status string, color string) {
 	if isatty.IsTerminal(os.Stdout.Fd()) {
-		fmt.Println("[", color, status, Reset, "] ", message)
+		fmt.Printf("[%s%s%s] %s", color, status, Reset, message)
 	} else {
-		fmt.Println("[", status, "] ", message)
+		fmt.Printf("[%s] %s", status, message)
 	}
 }
 

--- a/pkg/log/logging.go
+++ b/pkg/log/logging.go
@@ -14,9 +14,9 @@ const White = "\033[37m"
 
 func LogMessage(message string, status string, color string) {
 	if isatty.IsTerminal(os.Stdout.Fd()) {
-		fmt.Println("[" + color + status + Reset + "] " + message)
+		fmt.Println("[%s%s%s] %s", color, status, Reset, message)
 	} else {
-		fmt.Println("[" + status + "] " + message)
+		fmt.Println("[%s] %s", status, message)
 	}
 }
 

--- a/pkg/log/logging.go
+++ b/pkg/log/logging.go
@@ -14,9 +14,9 @@ const White = "\033[37m"
 
 func LogMessage(message string, status string, color string) {
 	if isatty.IsTerminal(os.Stdout.Fd()) {
-		fmt.Println("[%s%s%s] %s", color, status, Reset, message)
+		fmt.Println("[", color, status, Reset, "] ", message)
 	} else {
-		fmt.Println("[%s] %s", status, message)
+		fmt.Println("[", status, "] ", message)
 	}
 }
 

--- a/pkg/server/request.go
+++ b/pkg/server/request.go
@@ -90,21 +90,21 @@ func ProcessFileRequest(endpoint string, uploadOptions map[string]string, fileFi
 	}
 
 	if !dryRun {
-		log.Info("Uploading " + filepath.Base(fileName) + " to " + endpoint)
+		log.Info(fmt.Sprintf("Uploading %s to %s", filepath.Base(fileName), endpoint))
 
 		err = processRequest(req, timeout, retries)
 
 		if err != nil {
 			if strings.Contains(err.Error(), "409") {
-				log.Warn("Duplicate file detected, skipping upload of " + filepath.Base(fileName))
+				log.Warn(fmt.Sprintf("Duplicate file detected, skipping upload of %s", filepath.Base(fileName)))
 			} else {
 				return err
 			}
 		} else {
-			log.Success("Uploaded " + filepath.Base(fileName))
+			log.Success(fmt.Sprintf("Uploaded %s", filepath.Base(fileName)))
 		}
 	} else {
-		log.Info("(dryrun) Skipping upload of " + filepath.Base(fileName) + " to " + endpoint)
+		log.Info(fmt.Sprintf("(dryrun) Skipping upload of %s to %s", filepath.Base(fileName), endpoint))
 	}
 
 	return nil
@@ -126,14 +126,14 @@ func ProcessBuildRequest(endpoint string, payload []byte, timeout int, retries i
 	req.Header.Add("Content-Type", "application/json")
 
 	if !dryRun {
-		log.Info("Sending build information to " + endpoint)
+		log.Info(fmt.Sprintf("Sending build information to %s", endpoint))
 
 		err := processRequest(req, timeout, retries)
 		if err != nil {
 			return err
 		}
 	} else {
-		log.Info("(dryrun) Skipping sending build information to " + endpoint)
+		log.Info(fmt.Sprintf("(dryrun) Skipping sending build information to %s", endpoint))
 	}
 
 	return nil

--- a/pkg/upload/android-aab.go
+++ b/pkg/upload/android-aab.go
@@ -43,7 +43,7 @@ func ProcessAndroidAab(
 		// Check to see if we are dealing with a .aab file and extract it into a temp directory
 		if filepath.Ext(path) == ".aab" {
 
-			log.Info("Extracting " + filepath.Base(path) + " into a temporary directory")
+			log.Info(fmt.Sprintf("Extracting %s into a temporary directory", filepath.Base(path)))
 			aabDir, err = utils.ExtractFile(path, "aab")
 
 			defer os.RemoveAll(aabDir)
@@ -54,7 +54,7 @@ func ProcessAndroidAab(
 		} else if utils.IsDir(path) {
 			aabDir = path
 		} else {
-			return fmt.Errorf(path + " is not an AAB file/directory")
+			return fmt.Errorf("%s is not an AAB file/directory", path)
 		}
 	}
 

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -67,7 +67,7 @@ func ProcessAndroidNDK(
 			fileList, err = utils.BuildFileList([]string{filepath.Join(mergeNativeLibPath, variant)})
 
 			if err != nil {
-				return fmt.Errorf("error building file list for variant: %s. %w", variant, err.Error())
+				return fmt.Errorf("error building file list for variant: %s. %s", variant, err.Error())
 			}
 
 			if appManifestPath == "" {
@@ -191,7 +191,7 @@ func ProcessAndroidNDK(
 				workingDir, err = os.MkdirTemp("", "bugsnag-cli-ndk-*")
 
 				if err != nil {
-					return fmt.Errorf("error creating temporary working directory %w", err.Error())
+					return fmt.Errorf("error creating temporary working directory %s", err.Error())
 				}
 
 				defer os.RemoveAll(workingDir)
@@ -200,7 +200,7 @@ func ProcessAndroidNDK(
 			outputFile, err := android.Objcopy(objCopyPath, file, workingDir)
 
 			if err != nil {
-				return fmt.Errorf("failed to process file, %s using objcopy : %w", file, err.Error())
+				return fmt.Errorf("failed to process file, %s using objcopy : %s", file, err.Error())
 			}
 
 			symbolFileList = append(symbolFileList, outputFile)

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -53,7 +53,7 @@ func ProcessAndroidNDK(
 
 			// Check to see if we can find app/build/intermediates/merged_native_libs from the given path
 			if !utils.FileExists(mergeNativeLibPath) {
-				return fmt.Errorf("unable to find the merged_native_libs in " + path)
+				return fmt.Errorf("unable to find the merged_native_libs in %s", path)
 			}
 
 			if variant == "" {
@@ -67,14 +67,14 @@ func ProcessAndroidNDK(
 			fileList, err = utils.BuildFileList([]string{filepath.Join(mergeNativeLibPath, variant)})
 
 			if err != nil {
-				return fmt.Errorf("error building file list for variant: " + variant + ". " + err.Error())
+				return fmt.Errorf("error building file list for variant: %s. %w", variant, err.Error())
 			}
 
 			if appManifestPath == "" {
 				appManifestPathExpected = filepath.Join(path, "app", "build", "intermediates", "merged_manifests", variant, "AndroidManifest.xml")
 				if utils.FileExists(appManifestPathExpected) {
 					appManifestPath = appManifestPathExpected
-					log.Info("Found app manifest at: " + appManifestPath)
+					log.Info(fmt.Sprintf("Found app manifest at: %s", appManifestPath))
 				}
 			}
 
@@ -97,7 +97,7 @@ func ProcessAndroidNDK(
 							appManifestPathExpected = filepath.Join(mergeNativeLibPath, "..", "merged_manifests", variant, "AndroidManifest.xml")
 							if utils.FileExists(appManifestPathExpected) {
 								appManifestPath = appManifestPathExpected
-								log.Info("Found app manifest at: " + appManifestPath)
+								log.Info(fmt.Sprintf("Found app manifest at: %s", appManifestPath))
 							}
 						}
 
@@ -112,7 +112,7 @@ func ProcessAndroidNDK(
 	}
 
 	if projectRoot != "" {
-		log.Info("Using " + projectRoot + " as the project root")
+		log.Info(fmt.Sprintf("Using %s as the project root", projectRoot))
 	}
 
 	// Check to see if we need to read the manifest file due to missing options
@@ -133,7 +133,7 @@ func ProcessAndroidNDK(
 			}
 
 			if apiKey != "" {
-				log.Info("Using " + apiKey + " as API key from AndroidManifest.xml")
+				log.Info(fmt.Sprintf("Using %s as API key from AndroidManifest.xml", apiKey))
 
 			}
 		}
@@ -142,7 +142,7 @@ func ProcessAndroidNDK(
 			applicationId = manifestData.ApplicationId
 
 			if applicationId != "" {
-				log.Info("Using " + applicationId + " as application ID from AndroidManifest.xml")
+				log.Info(fmt.Sprintf("Using %s as application ID from AndroidManifest.xml", applicationId))
 			}
 		}
 
@@ -150,7 +150,7 @@ func ProcessAndroidNDK(
 			versionCode = manifestData.VersionCode
 
 			if versionCode != "" {
-				log.Info("Using " + versionCode + " as version code from AndroidManifest.xml")
+				log.Info(fmt.Sprintf("Using %s as version code from AndroidManifest.xml", versionCode))
 			}
 		}
 
@@ -158,7 +158,7 @@ func ProcessAndroidNDK(
 			versionName = manifestData.VersionName
 
 			if versionName != "" {
-				log.Info("Using " + versionName + " as version name from AndroidManifest.xml")
+				log.Info(fmt.Sprintf("Using %s as version name from AndroidManifest.xml", versionName))
 			}
 		}
 	}
@@ -182,16 +182,16 @@ func ProcessAndroidNDK(
 					return err
 				}
 
-				log.Info("Located objcopy within Android NDK path: " + androidNdkRoot)
+				log.Info(fmt.Sprintf("Located objcopy within Android NDK path: %s", androidNdkRoot))
 			}
 
-			log.Info("Extracting debug info from " + filepath.Base(file) + " using objcopy")
+			log.Info(fmt.Sprintf("Extracting debug info from %s using objcopy", filepath.Base(file)))
 
 			if workingDir == "" {
 				workingDir, err = os.MkdirTemp("", "bugsnag-cli-ndk-*")
 
 				if err != nil {
-					return fmt.Errorf("error creating temporary working directory " + err.Error())
+					return fmt.Errorf("error creating temporary working directory %w", err.Error())
 				}
 
 				defer os.RemoveAll(workingDir)
@@ -200,7 +200,7 @@ func ProcessAndroidNDK(
 			outputFile, err := android.Objcopy(objCopyPath, file, workingDir)
 
 			if err != nil {
-				return fmt.Errorf("failed to process file, " + file + " using objcopy : " + err.Error())
+				return fmt.Errorf("failed to process file, %s using objcopy : %w", file, err.Error())
 			}
 
 			symbolFileList = append(symbolFileList, outputFile)

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -51,7 +51,7 @@ func ProcessAndroidProguard(
 			mappingPath := filepath.Join(path, "app", "build", "outputs", "mapping")
 
 			if !utils.FileExists(mappingPath) {
-				return fmt.Errorf("unable to find the mapping directory in " + path)
+				return fmt.Errorf("unable to find the mapping directory in %s", path)
 			}
 
 			if variant == "" {
@@ -72,7 +72,7 @@ func ProcessAndroidProguard(
 				appManifestPathExpected = filepath.Join(path, "app", "build", "intermediates", "merged_manifests", variant, "AndroidManifest.xml")
 				if utils.FileExists(appManifestPathExpected) {
 					appManifestPath = appManifestPathExpected
-					log.Info("Found app manifest at: " + appManifestPath)
+					log.Info(fmt.Sprintf("Found app manifest at: %s", appManifestPath))
 				}
 			}
 
@@ -90,7 +90,7 @@ func ProcessAndroidProguard(
 							appManifestPathExpected = filepath.Join(mergedManifestPath, variant, "AndroidManifest.xml")
 							if utils.FileExists(appManifestPathExpected) {
 								appManifestPath = appManifestPathExpected
-								log.Info("Found app manifest at: " + appManifestPath)
+								log.Info(fmt.Sprintf("Found app manifest at: %s", appManifestPath))
 							}
 						}
 					}
@@ -117,7 +117,7 @@ func ProcessAndroidProguard(
 				}
 
 				if apiKey != "" {
-					log.Info("Using " + apiKey + " as API key from AndroidManifest.xml")
+					log.Info(fmt.Sprintf("Using %s as API key from AndroidManifest.xml", apiKey))
 				}
 			}
 
@@ -125,7 +125,7 @@ func ProcessAndroidProguard(
 				applicationId = manifestData.ApplicationId
 
 				if applicationId != "" {
-					log.Info("Using " + applicationId + " as application ID from AndroidManifest.xml")
+					log.Info(fmt.Sprintf("Using %s as application ID from AndroidManifest.xml", applicationId))
 				}
 			}
 
@@ -157,10 +157,10 @@ func ProcessAndroidProguard(
 					buildUuid = fmt.Sprintf("%x", signature)
 
 					if buildUuid != "" {
-						log.Info("Using " + buildUuid + " as build ID from classes.dex")
+						log.Info(fmt.Sprintf("Using %s as build ID from classes.dex", buildUuid))
 					}
 				} else {
-					log.Info("Using " + buildUuid + " as build UUID from AndroidManifest.xml")
+					log.Info(fmt.Sprintf("Using %s as build UUID from AndroidManifest.xml", buildUuid))
 				}
 			}
 
@@ -168,7 +168,7 @@ func ProcessAndroidProguard(
 				versionCode = manifestData.VersionCode
 
 				if versionCode != "" {
-					log.Info("Using " + versionCode + " as version code from AndroidManifest.xml")
+					log.Info(fmt.Sprintf("Using %s as version code from AndroidManifest.xml", versionCode))
 				}
 			}
 
@@ -176,12 +176,12 @@ func ProcessAndroidProguard(
 				versionName = manifestData.VersionName
 
 				if versionName != "" {
-					log.Info("Using " + versionName + " as version name from AndroidManifest.xml")
+					log.Info(fmt.Sprintf("Using %s as version name from AndroidManifest.xml", versionName))
 				}
 			}
 		}
 
-		log.Info("Compressing " + mappingFile)
+		log.Info(fmt.Sprintf("Compressing %s", mappingFile))
 
 		outputFile, err := utils.GzipCompress(mappingFile)
 
@@ -198,11 +198,11 @@ func ProcessAndroidProguard(
 		fileFieldData := make(map[string]string)
 		fileFieldData["proguard"] = outputFile
 
-		err = server.ProcessFileRequest(endpoint+"/proguard", uploadOptions, fileFieldData, timeout, retries, outputFile, dryRun)
+		err = server.ProcessFileRequest(fmt.Sprintf("%s/proguard", endpoint), uploadOptions, fileFieldData, timeout, retries, outputFile, dryRun)
 
 		if err != nil {
 			if strings.Contains(err.Error(), "404 Not Found") {
-				log.Info("Trying " + endpoint)
+				log.Info(fmt.Sprintf("Trying %s", endpoint))
 				err = server.ProcessFileRequest(endpoint, uploadOptions, fileFieldData, timeout, retries, outputFile, dryRun)
 			}
 		}

--- a/pkg/upload/dart.go
+++ b/pkg/upload/dart.go
@@ -58,7 +58,7 @@ func Dart(
 
 		// Start processing the android symbol file
 		if isAndroidPlatform {
-			log.Info("Processing android symbol file: " + file)
+			log.Info(fmt.Sprintf("Processing android symbol file: %s", file))
 
 			var buildId string
 			buildId, err = GetBuildIdFromElfFile(file)
@@ -72,7 +72,7 @@ func Dart(
 			fileFieldData := make(map[string]string)
 			fileFieldData["symbolFile"] = file
 
-			err := server.ProcessFileRequest(endpoint+"/dart-symbol", uploadOptions, fileFieldData, timeout, retries, file, dryRun)
+			err := server.ProcessFileRequest(fmt.Sprintf("%s/dart-symbol", endpoint), uploadOptions, fileFieldData, timeout, retries, file, dryRun)
 
 			if err != nil {
 
@@ -84,7 +84,7 @@ func Dart(
 
 		// Process iOS file
 		if isIosPlatform {
-			log.Info("Processing iOS symbol file: " + file)
+			log.Info(fmt.Sprintf("Processing iOS symbol file: %s", file))
 
 			if iosAppPath == "" {
 				iosAppPath, err = GetIosAppPath(file)
@@ -115,7 +115,7 @@ func Dart(
 			if dryRun {
 				err = nil
 			} else {
-				err = server.ProcessFileRequest(endpoint+"/dart-symbol", uploadOptions, fileFieldData, timeout, retries, file, dryRun)
+				err = server.ProcessFileRequest(fmt.Sprintf("%s/dart-symbol", endpoint), uploadOptions, fileFieldData, timeout, retries, file, dryRun)
 			}
 
 			if err != nil {
@@ -125,7 +125,7 @@ func Dart(
 
 			continue
 		}
-		log.Info("Skipping " + file)
+		log.Info(fmt.Sprintf("Skipping %s", file))
 	}
 
 	return nil

--- a/pkg/upload/dsym.go
+++ b/pkg/upload/dsym.go
@@ -1,7 +1,6 @@
 package upload
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"

--- a/pkg/upload/dsym.go
+++ b/pkg/upload/dsym.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"fmt"
 
 	"github.com/bugsnag/bugsnag-cli/pkg/ios"
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
@@ -67,7 +68,7 @@ func ProcessDsym(
 
 		if xcodeProjPath != "" {
 			projectRoot = ios.GetDefaultProjectRoot(xcodeProjPath, projectRoot)
-			log.Info("Defaulting to '" + projectRoot + "' as the project root")
+			log.Info(fmt.Sprintf("Defaulting to '%s' as the project root", projectRoot))
 
 			// Get build settings and dsymPath
 
@@ -101,17 +102,17 @@ func ProcessDsym(
 				_, err := os.Stat(possibleDsymPath)
 				if err == nil {
 					dsymPath = possibleDsymPath
-					log.Info("Using dSYM path: " + dsymPath)
+					log.Info(fmt.Sprintf("Using dSYM path: %s", dsymPath))
 				}
 			}
 		}
 
 		if projectRoot == "" {
-			return errors.New("--project-root is required when uploading dSYMs from a directory that is not an Xcode project or workspace")
+			return fmt.Errorf("--project-root is required when uploading dSYMs from a directory that is not an Xcode project or workspace")
 		}
 
 		if dsymPath == "" {
-			return errors.New("No dSYM locations detected. Please provide a valid dSYM path or an Xcode project/workspace path")
+			return fmt.Errorf("No dSYM locations detected. Please provide a valid dSYM path or an Xcode project/workspace path")
 		}
 
 		dwarfInfo, tempDir, err = ios.FindDsymsInPath(dsymPath, ignoreEmptyDsym, ignoreMissingDwarf)
@@ -119,7 +120,7 @@ func ProcessDsym(
 		if err != nil {
 			return err
 		} else if len(dwarfInfo) == 0 {
-			return errors.New("No dSYM files found in: " + dsymPath)
+			return fmt.Errorf("No dSYM files found in: %s", dsymPath)
 		}
 
 		// If the Info.plist path is not defined, we need to build the path to Info.plist from build settings values
@@ -128,9 +129,9 @@ func ProcessDsym(
 				plistPathExpected := filepath.Join(buildSettings.ConfigurationBuildDir, buildSettings.InfoPlistPath)
 				if utils.FileExists(plistPathExpected) {
 					plistPath = plistPathExpected
-					log.Info("Found Info.plist at expected location: " + plistPath)
+					log.Info(fmt.Sprintf("Found Info.plist at expected location: %s", plistPath))
 				} else {
-					log.Info("No Info.plist found at expected location: " + plistPathExpected)
+					log.Info(fmt.Sprintf("No Info.plist found at expected location: %s", plistPathExpected))
 				}
 			}
 		}
@@ -146,14 +147,14 @@ func ProcessDsym(
 			if apiKey == "" {
 				apiKey = plistData.BugsnagProjectDetails.ApiKey
 				if apiKey != "" {
-					log.Info("Using API key from Info.plist: " + apiKey)
+					log.Info(fmt.Sprintf("Using API key from Info.plist: %s", apiKey))
 				}
 			}
 		}
 
 		for _, dsym := range dwarfInfo {
-			dsymInfo := "(UUID: " + dsym.UUID + ", Name: " + dsym.Name + ", Arch: " + dsym.Arch + ")"
-			log.Info("Uploading dSYM " + dsymInfo)
+			dsymInfo := fmt.Sprintf("(UUID: %s, Name: %s, Arch: %s)", dsym.UUID, dsym.Name, dsym.Arch)
+			log.Info(fmt.Sprintf("Uploading dSYM %s", dsymInfo))
 
 			uploadOptions, err = utils.BuildDsymUploadOptions(apiKey, projectRoot)
 			if err != nil {
@@ -163,7 +164,7 @@ func ProcessDsym(
 			fileFieldData := make(map[string]string)
 			fileFieldData["dsym"] = filepath.Join(dsym.Location, dsym.Name)
 
-			err = server.ProcessFileRequest(endpoint+"/dsym", uploadOptions, fileFieldData, timeout, retries, dsym.UUID, dryRun)
+			err = server.ProcessFileRequest(fmt.Sprintf("%s/dsym", endpoint), uploadOptions, fileFieldData, timeout, retries, dsym.UUID, dryRun)
 
 			if err != nil {
 				if strings.Contains(err.Error(), "404 Not Found") {

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -60,7 +60,7 @@ func ProcessReactNativeAndroid(
 			if utils.FileExists(buildDirPath) {
 				rootDirPath = filepath.Join(path, "..")
 			} else if bundlePath == "" || sourceMapPath == "" {
-				return fmt.Errorf("unable to find bundle files or source maps in within " + path)
+				return fmt.Errorf("unable to find bundle files or source maps in within %s", path)
 			}
 		}
 
@@ -104,7 +104,7 @@ func ProcessReactNativeAndroid(
 		}
 
 		if !utils.FileExists(bundlePath) {
-			return fmt.Errorf("unable to find index.android.bundle at " + bundlePath)
+			return fmt.Errorf("unable to find index.android.bundle at %s", bundlePath)
 		}
 
 		if sourceMapPath == "" {
@@ -133,16 +133,16 @@ func ProcessReactNativeAndroid(
 		}
 
 		if !utils.FileExists(sourceMapPath) {
-			return fmt.Errorf("unable to find index.android.bundle at " + sourceMapPath)
+			return fmt.Errorf("unable to find index.android.bundle at %s", sourceMapPath)
 		}
 
 		if appManifestPath == "" {
 			appManifestPathExpected := filepath.Join(buildDirPath, "intermediates", "merged_manifests", variant, "AndroidManifest.xml")
 			if utils.FileExists(appManifestPathExpected) {
 				appManifestPath = appManifestPathExpected
-				log.Info("Found app manifest at: " + appManifestPath)
+				log.Info(fmt.Sprintf("Found app manifest at: %s", appManifestPath))
 			} else {
-				log.Info("No app manifest found at: " + appManifestPathExpected)
+				log.Info(fmt.Sprintf("No app manifest found at: %s", appManifestPathExpected))
 			}
 		}
 
@@ -161,17 +161,17 @@ func ProcessReactNativeAndroid(
 					}
 				}
 
-				log.Info("Using " + apiKey + " as API key from AndroidManifest.xml")
+				log.Info(fmt.Sprintf("Using %s as API key from AndroidManifest.xml", apiKey))
 			}
 
 			if versionName == "" {
 				versionName = manifestData.VersionName
-				log.Info("Using " + versionName + " as version name from AndroidManifest.xml")
+				log.Info(fmt.Sprintf("Using %s as version name from AndroidManifest.xml", versionName))
 			}
 
 			if versionCode == "" {
 				versionCode = manifestData.VersionCode
-				log.Info("Using " + versionCode + " as version code from AndroidManifest.xml")
+				log.Info(fmt.Sprintf("Using %s as version code from AndroidManifest.xml", versionCode))
 			}
 		}
 
@@ -185,7 +185,7 @@ func ProcessReactNativeAndroid(
 		fileFieldData["sourceMap"] = sourceMapPath
 		fileFieldData["bundle"] = bundlePath
 
-		err = server.ProcessFileRequest(endpoint+"/react-native-source-map", uploadOptions, fileFieldData, timeout, retries, sourceMapPath, dryRun)
+		err = server.ProcessFileRequest(fmt.Sprintf("%s/react-native-source-map", endpoint), uploadOptions, fileFieldData, timeout, retries, sourceMapPath, dryRun)
 
 		if err != nil {
 

--- a/pkg/upload/react-native-ios.go
+++ b/pkg/upload/react-native-ios.go
@@ -61,7 +61,7 @@ func ProcessReactNativeIos(
 				rootDirPath = filepath.Join(path, "..")
 
 			} else if bundlePath == "" || sourceMapPath == "" {
-				return fmt.Errorf("unable to find bundle files or source maps in within " + path)
+				return fmt.Errorf("unable to find bundle files or source maps in within %s", path)
 			}
 		}
 
@@ -76,7 +76,7 @@ func ProcessReactNativeIos(
 			// Validate workspacePath (if provided) or attempt to find one
 			if xcodeProjPath != "" {
 				if !utils.FileExists(xcodeProjPath) {
-					return errors.New("unable to find the specified Xcode project file: " + xcodeProjPath)
+					return fmt.Errorf("unable to find the specified Xcode project file: %s", xcodeProjPath)
 				}
 			} else {
 				if ios.IsPathAnXcodeProjectOrWorkspace(filepath.Join(rootDirPath, "ios")) {
@@ -107,27 +107,27 @@ func ProcessReactNativeIos(
 					}
 				}
 			} else {
-				return errors.New("Could not find an Xcode project file, please specify the path by using --xcode-proj-path")
+				return fmt.Errorf("Could not find an Xcode project file, please specify the path by using --xcode-proj-path")
 			}
 
 			// Check to see if we have the Info.Plist path
 			if plistPath != "" {
 				if !utils.FileExists(plistPath) {
-					return errors.New("unable to find specified Info.plist file: " + plistPath)
+					return fmt.Errorf("unable to find specified Info.plist file: %s", plistPath)
 				}
 			} else if buildSettings != nil {
 				// If not, we need to build it from build settings values
 				plistPathExpected := filepath.Join(buildSettings.ConfigurationBuildDir, buildSettings.InfoPlistPath)
 				if utils.FileExists(plistPathExpected) {
 					plistPath = plistPathExpected
-					log.Info("Found Info.plist at expected location: " + plistPath)
+					log.Info(fmt.Sprintf("Found Info.plist at expected location: %s", plistPath))
 				} else {
 					plistPathExpected = filepath.Join(buildSettings.ProjectTempRoot, "ArchiveIntermediates", scheme, "BuildProductsPath", filepath.Base(buildSettings.BuiltProductsDir), buildSettings.InfoPlistPath)
 					if utils.FileExists(plistPathExpected) {
 						plistPath = plistPathExpected
-						log.Info("Found Info.plist at: " + plistPath)
+						log.Info(fmt.Sprintf("Found Info.plist at: %s", plistPath))
 					} else {
-						log.Info("No Info.plist found at: " + plistPathExpected)
+						log.Info(fmt.Sprintf("No Info.plist found at: %s", plistPathExpected))
 					}
 				}
 			}
@@ -137,7 +137,7 @@ func ProcessReactNativeIos(
 		// Check that the bundle file exists and error out if it doesn't
 		if bundlePath != "" {
 			if !utils.FileExists(bundlePath) {
-				return errors.New("unable to find specified bundle file: " + bundlePath)
+				return fmt.Errorf("unable to find specified bundle file: %s", bundlePath)
 			}
 		} else {
 			// Set a bundlePath if it's not defined and check that it exists before proceeding
@@ -145,14 +145,14 @@ func ProcessReactNativeIos(
 				possibleBundleFilePath := filepath.Join(buildSettings.ConfigurationBuildDir, "main.jsbundle")
 				if utils.FileExists(possibleBundleFilePath) {
 					bundlePath = possibleBundleFilePath
-					log.Info("Found bundle file at: " + bundlePath)
+					log.Info(fmt.Sprintf("Found bundle file at: %s", bundlePath))
 				} else {
 					possibleBundleFilePath = filepath.Join(buildSettings.ProjectTempRoot, "ArchiveIntermediates", scheme, "BuildProductsPath", filepath.Base(buildSettings.BuiltProductsDir), "main.jsbundle")
 					if utils.FileExists(possibleBundleFilePath) {
 						bundlePath = possibleBundleFilePath
-						log.Info("Found bundle file at: " + bundlePath)
+						log.Info(fmt.Sprintf("Found bundle file at: %s", bundlePath))
 					} else {
-						log.Info("No bundle file found at: " + possibleBundleFilePath)
+						log.Info(fmt.Sprintf("No bundle file found at: %s", possibleBundleFilePath))
 					}
 				}
 			}
@@ -160,13 +160,13 @@ func ProcessReactNativeIos(
 
 		// Check that we now have a bundle path
 		if bundlePath == "" {
-			return errors.New("Could not find a bundle file, please specify the path by using --bundle-path")
+			return fmt.Errorf("Could not find a bundle file, please specify the path by using --bundle-path")
 		}
 
 		// Check that the source map file exists and error out if it doesn't
 		if sourceMapPath != "" {
 			if !utils.FileExists(sourceMapPath) {
-				return errors.New("unable to find specified source map: " + sourceMapPath)
+				return fmt.Errorf("unable to find specified source map: %s", sourceMapPath)
 			}
 		} else {
 			// Use SOURCEMAP_FILE environment variable, if defined, or use the build directory
@@ -178,15 +178,15 @@ func ProcessReactNativeIos(
 			possibleSourceMapPath := filepath.Join(sourceMapDirPath, "sourcemaps", "main.jsbundle.map")
 			if utils.FileExists(possibleSourceMapPath) {
 				sourceMapPath = possibleSourceMapPath
-				log.Info("Found source map at: " + sourceMapPath)
+				log.Info(fmt.Sprintf("Found source map at: %s", sourceMapPath))
 			} else {
-				log.Info("No source map found at: " + possibleSourceMapPath)
+				log.Info(fmt.Sprintf("No source map found at: %s", possibleSourceMapPath))
 			}
 		}
 
 		// Check that we now have a source map path
 		if sourceMapPath == "" {
-			return errors.New("Could not find a source map, please specify the path by using --source-map or SOURCEMAP_FILE environment variable")
+			return fmt.Errorf("Could not find a source map, please specify the path by using --source-map or SOURCEMAP_FILE environment variable")
 		}
 
 		if plistPath != "" && (apiKey == "" || versionName == "" || bundleVersion == "") {
@@ -199,18 +199,18 @@ func ProcessReactNativeIos(
 			// Check if the variables are empty, set if they are abd log that we are using setting from the plist file
 			if bundleVersion == "" {
 				bundleVersion = plistData.BundleVersion
-				log.Info("Using bundle version from Info.plist: " + bundleVersion)
+				log.Info(fmt.Sprintf("Using bundle version from Info.plist: %s", bundleVersion))
 			}
 
 			if versionName == "" {
 				versionName = plistData.VersionName
-				log.Info("Using version name from Info.plist: " + versionName)
+				log.Info(fmt.Sprintf("Using version name from Info.plist: %s", versionName))
 
 			}
 
 			if apiKey == "" {
 				apiKey = plistData.BugsnagProjectDetails.ApiKey
-				log.Info("Using API key from Info.plist: " + apiKey)
+				log.Info(fmt.Sprintf("Using API key from Info.plist: %s", apiKey))
 			}
 
 		}
@@ -227,7 +227,7 @@ func ProcessReactNativeIos(
 	fileFieldData["sourceMap"] = sourceMapPath
 	fileFieldData["bundle"] = bundlePath
 
-	err = server.ProcessFileRequest(endpoint+"/react-native-source-map", uploadOptions, fileFieldData, timeout, retries, sourceMapPath, dryRun)
+	err = server.ProcessFileRequest(fmt.Sprintf("%s/react-native-source-map", endpoint), uploadOptions, fileFieldData, timeout, retries, sourceMapPath, dryRun)
 
 	if err != nil {
 

--- a/pkg/upload/react-native-ios.go
+++ b/pkg/upload/react-native-ios.go
@@ -2,7 +2,6 @@ package upload
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
 

--- a/pkg/upload/unity-android.go
+++ b/pkg/upload/unity-android.go
@@ -63,12 +63,12 @@ func ProcessUnityAndroid(
 				aabPath, _ = utils.FindLatestFileWithSuffix(buildDirectory, ".aab")
 			}
 		} else {
-			return fmt.Errorf(path + " is not a .symbols.zip file or containing directory")
+			return fmt.Errorf("%s is not a .symbols.zip file or containing directory", path)
 		}
 	}
 
 	if aabPath != "" {
-		log.Info("Extracting " + filepath.Base(aabPath) + " into a temporary directory")
+		log.Info(fmt.Sprintf("Extracting %s into a temporary directory", filepath.Base(aabPath)))
 
 		aabDir, err := utils.ExtractFile(aabPath, "aab")
 
@@ -105,7 +105,7 @@ func ProcessUnityAndroid(
 		}
 	}
 
-	log.Info("Extracting " + filepath.Base(zipPath) + " into a temporary directory")
+	log.Info(fmt.Sprintf("Extracting %s into a temporary directory", filepath.Base(zipPath)))
 
 	if manifestData == nil {
 		manifestData, _ = android.MergeUploadOptionsFromAabManifest("", apiKey, applicationId, buildUuid, noBuildUuid, versionCode, versionName)

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -120,7 +120,7 @@ func ExtractFile(file string, slug string) (string, error) {
 	tempDir, err := os.MkdirTemp("", fmt.Sprintf("bugsnag-cli-%s-unpacking-*", slug))
 
 	if err != nil {
-		return "", fmt.Errorf("error creating temporary working directory %w", err.Error())
+		return "", fmt.Errorf("error creating temporary working directory %s", err.Error())
 	}
 
 	err = Unzip(file, tempDir)

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -110,17 +110,17 @@ func FindLatestFileWithSuffix(directory string, targetSuffix string) (string, er
 	}
 
 	if newestFile == "" {
-		return "", fmt.Errorf("Unable to find " + targetSuffix + " files in " + directory)
+		return "", fmt.Errorf("Unable to find %s files in %s", targetSuffix, directory)
 	}
 
 	return newestFile, err
 }
 
 func ExtractFile(file string, slug string) (string, error) {
-	tempDir, err := os.MkdirTemp("", "bugsnag-cli-"+slug+"-unpacking-*")
+	tempDir, err := os.MkdirTemp("", fmt.Sprintf("bugsnag-cli-%s-unpacking-*", slug))
 
 	if err != nil {
-		return "", fmt.Errorf("error creating temporary working directory " + err.Error())
+		return "", fmt.Errorf("error creating temporary working directory %w", err.Error())
 	}
 
 	err = Unzip(file, tempDir)

--- a/pkg/utils/get-repository-info.go
+++ b/pkg/utils/get-repository-info.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"os/exec"
 	"strings"
+	"fmt"
 )
 
 // GetRepoUrl - Gets the URl of a git repo.
@@ -23,7 +24,7 @@ func GetRepoUrl(repoPath string) string {
 			return ""
 		}
 		remotes := strings.Split(string(remoteCmdOutput), "\n")
-		remoteOriginCmd = exec.Command(gitLocation, "-C", repoPath, "config", "--get", "remote."+remotes[0]+".url")
+		remoteOriginCmd = exec.Command(gitLocation, "-C", repoPath, "config", "--get", fmt.Sprintf("remote.%s.url", remotes[0]))
 		remoteOriginCmdOutput, err = remoteOriginCmd.CombinedOutput()
 		if err != nil {
 			return ""

--- a/pkg/utils/gzip.go
+++ b/pkg/utils/gzip.go
@@ -20,7 +20,7 @@ func GzipCompress(file string) (string, error) {
 		return "", err
 	}
 
-	newFile := file + ".gz"
+	newFile := fmt.Sprintf("%s.gz", file)
 
 	gzipFile, err := os.Create(newFile)
 

--- a/pkg/utils/gzip.go
+++ b/pkg/utils/gzip.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"io"
 	"os"
+	"fmt"
 )
 
 func GzipCompress(file string) (string, error) {

--- a/pkg/utils/unzip.go
+++ b/pkg/utils/unzip.go
@@ -18,7 +18,7 @@ func Unzip(path, outputPath string) error {
 
 	for _, f := range archive.File {
 		filePath := filepath.Join(outputPath, f.Name)
-		if !strings.HasPrefix(filePath, filepath.Clean(outputPath)+string(os.PathSeparator)) {
+		if !strings.HasPrefix(filePath, fmt.Sprintf("%s%s", filepath.Clean(outputPath), string(os.PathSeparator))) {
 			return fmt.Errorf("invalid file path")
 		}
 		if f.FileInfo().IsDir() {


### PR DESCRIPTION
- Using fmt to concatenate strings throughout codebase for consistency
- I left any instances of filepath.Join as they were as I wasn't sure, but I can change these to use fmt if the reviewer thinks so?
- I only used fmt.Sprintf in log messages that needed to be concatenated. I can change this to use fmt.Sprintf in all log messages if the reviewer think so