### PR TITLE
[PLAT-12131] Add the ability to set the log level 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `upload android-proguard` will now attempt to automatically locate the `classes.dex` files if no build-uuid or dex-files are found or specified [92](https://github.com/bugsnag/bugsnag-cli/pull/92)
 - Added the `--no-build-uuid` option to the `upload android-*` options [92](https://github.com/bugsnag/bugsnag-cli/pull/92)
 - Added `Windows_NT` to `supported-platforms.yml` [95](https://github.com/bugsnag/bugsnag-cli/pull/95)
+- Add the ability to set the log leveL via the `--log-level` flag [103](https://github.com/bugsnag/bugsnag-cli/pull/103)
 
 ## 2.1.1 (2023-03-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.0 (TBD)
+
+- Add the ability to set the log leveL via the `--log-level` flag [103](https://github.com/bugsnag/bugsnag-cli/pull/103)
+
 ## 2.2.0 (2024-04-17)
 
 ### Enhancements

--- a/features/cli/bugsnag-cli.feature
+++ b/features/cli/bugsnag-cli.feature
@@ -19,3 +19,8 @@ Feature: Basic CLI behavior
   Scenario: Starting bugsnag-cli and checking the version
     When I run bugsnag-cli with --version
     Then the version number should match the version set in main.go
+
+  Scenario: Starting bugsnag-cli upload and setting the log level to fatal
+    When I run bugsnag-cli with upload android-ndk --api-key=1234567890ABCDEF1234567890ABCDEF features/android/fixtures/app/build/outputs/mapping/release
+    Then I should only see the fatal log level messages
+

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -152,3 +152,11 @@ When(/^I make the "([^"]*)"$/) do |arg|
   @output = `make #{arg} 2>&1`
   puts @output
 end
+
+Then(/^I should only see the fatal log level messages$/) do
+  Maze.check.include(run_output, "[FATAL]")
+  Maze.check.not_include(run_output, "[ERROR]")
+  Maze.check.not_include(run_output, "[WARN]")
+  Maze.check.not_include(run_output, "[INFO]")
+  Maze.check.not_include(run_output, "[DEBUG]")
+end

--- a/install.sh
+++ b/install.sh
@@ -91,7 +91,7 @@ display_help() {
 EOS
 }
 
-VERSION="2.2.0"
+VERSION="2.3.0"
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in

--- a/main.go
+++ b/main.go
@@ -32,7 +32,11 @@ func main() {
 			"version": package_version,
 		})
 
-	logger := log.NewLoggerWrapper(commands.Verbose, commands.LogLevel)
+	if commands.Verbose {
+		commands.LogLevel = "debug"
+	}
+
+	logger := log.NewLoggerWrapper(commands.LogLevel)
 
 	// Build connection URI
 	endpoint, err := utils.BuildEndpointUrl(commands.UploadAPIRootUrl, commands.Port)

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 			"version": package_version,
 		})
 
-	logger := log.NewLoggerWrapper(commands.Verbose)
+	logger := log.NewLoggerWrapper(commands.Verbose, commands.LogLevel)
 
 	// Build connection URI
 	endpoint, err := utils.BuildEndpointUrl(commands.UploadAPIRootUrl, commands.Port)

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
 )
 
-var package_version = "2.2.0"
+var package_version = "2.3.0"
 
 func main() {
 	commands := options.CLI{}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/cli",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "BugSnag CLI",
   "main": "install.js",
   "repository": {

--- a/pkg/log/logrus-wrapper.go
+++ b/pkg/log/logrus-wrapper.go
@@ -49,14 +49,20 @@ func (f *CustomFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	return []byte(output), nil
 }
 
-func NewLogrusLogger(verbose bool) *LogrusLogger {
+func NewLogrusLogger(verbose bool, logLevel string) *LogrusLogger {
 	logger := logrus.New()
 	logger.Out = os.Stdout
 	logger.Formatter = &CustomFormatter{}
 
-	// Set the log level to debug if verbose is true
+	// Set the log level to debug if verbose is true or logLevel is set
 	if verbose {
 		logger.SetLevel(logrus.DebugLevel)
+	} else if logLevel != "" {
+		level, err := logrus.ParseLevel(logLevel)
+		if err != nil {
+			logger.Fatal("Invalid log level")
+		}
+		logger.SetLevel(level)
 	}
 
 	return &LogrusLogger{logger: logger}

--- a/pkg/log/logrus-wrapper.go
+++ b/pkg/log/logrus-wrapper.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"fmt"
 	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
 	"os"
@@ -49,18 +50,15 @@ func (f *CustomFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	return []byte(output), nil
 }
 
-func NewLogrusLogger(verbose bool, logLevel string) *LogrusLogger {
+func NewLogrusLogger(logLevel string) *LogrusLogger {
 	logger := logrus.New()
 	logger.Out = os.Stdout
 	logger.Formatter = &CustomFormatter{}
 
-	// Set the log level to debug if verbose is true or logLevel is set
-	if verbose {
-		logger.SetLevel(logrus.DebugLevel)
-	} else if logLevel != "" {
+	if logLevel != "" {
 		level, err := logrus.ParseLevel(logLevel)
 		if err != nil {
-			logger.Fatal("Invalid log level")
+			logger.Fatal(fmt.Sprintf("%s is an invalid log level", logLevel))
 		}
 		logger.SetLevel(level)
 	}

--- a/pkg/log/main.go
+++ b/pkg/log/main.go
@@ -4,8 +4,8 @@ type LoggerWrapper struct {
 	logger Logger
 }
 
-func NewLoggerWrapper(verbose bool, logLevel string) *LoggerWrapper {
-	logger := NewLogrusLogger(verbose, logLevel)
+func NewLoggerWrapper(logLevel string) *LoggerWrapper {
+	logger := NewLogrusLogger(logLevel)
 
 	return &LoggerWrapper{logger: logger}
 }

--- a/pkg/log/main.go
+++ b/pkg/log/main.go
@@ -4,8 +4,8 @@ type LoggerWrapper struct {
 	logger Logger
 }
 
-func NewLoggerWrapper(verbose bool) *LoggerWrapper {
-	logger := NewLogrusLogger(verbose)
+func NewLoggerWrapper(verbose bool, logLevel string) *LoggerWrapper {
+	logger := NewLogrusLogger(verbose, logLevel)
 
 	return &LoggerWrapper{logger: logger}
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -14,6 +14,7 @@ type Globals struct {
 	FailOnUploadError bool              `help:"Stops the upload when a mapping file fails to upload to Bugsnag successfully" default:"false"`
 	Version           utils.VersionFlag `name:"version" help:"Print version information and quit"`
 	Verbose           bool              `name:"verbose" help:"Print verbose output"`
+	LogLevel          string            `help:"Set the log level" default:"info"`
 	DryRun            bool              `help:"Validate but do not process"`
 }
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -14,7 +14,7 @@ type Globals struct {
 	FailOnUploadError bool              `help:"Stops the upload when a mapping file fails to upload to Bugsnag successfully" default:"false"`
 	Version           utils.VersionFlag `name:"version" help:"Print version information and quit"`
 	Verbose           bool              `name:"verbose" help:"Print verbose output"`
-	LogLevel          string            `help:"Set the log level" default:"info"`
+	LogLevel          string            `help:"Sets the log level to debug, info, warn or fatal" default:"info"`
 	DryRun            bool              `help:"Validate but do not process"`
 }
 

--- a/pkg/utils/validation.go
+++ b/pkg/utils/validation.go
@@ -1,12 +1,14 @@
 package utils
 
 import (
+	"fmt"
 	"os"
 	"strings"
 )
 
 type Paths []string
 type Path string
+type LogLevels string
 
 // Validate that the path(s) exist
 func (p Paths) Validate() error {
@@ -26,6 +28,7 @@ func (p Path) Validate() error {
 	return nil
 }
 
+// ContainsString Check if a string is in a slice
 func ContainsString(slice []string, target string) bool {
 	for _, element := range slice {
 		if strings.Contains(element, target) {
@@ -33,4 +36,14 @@ func ContainsString(slice []string, target string) bool {
 		}
 	}
 	return false
+}
+
+// Validate that the log level is valid
+func (l LogLevels) Validate() error {
+	switch strings.ToLower(string(l)) {
+	case "debug", "info", "warn", "fatal":
+		return nil
+	default:
+		return fmt.Errorf("invalid log level: %s", l)
+	}
 }


### PR DESCRIPTION
## Goal

Add the ability to change the `logLevel` via the `--log-level` command line option.
Add validation to the setting of the log level to ensure that only accepted values are passed.

example:

```
$ bugsnag-cli upload react-native-android ... --log-level=fatal
```

Output:
```
[FATAL] failed after 1 attempts. 401 Unauthorized: invalid apiKey
```

## Testing

Covered by CI