### PR TITLE
[PLAT-12221] Ensure content of XCBuildData is never committed to bugsnag-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ bin/**/**
 node_modules/
 package-lock.json
 
+# Xcode
+**/XCBuildData/
 
 .idea/
 maze_output/


### PR DESCRIPTION
## Goal
To exclude unnecessary files included in `XCBuildData` when pushing new or modifying existing Xcode test fixtures.

## Changeset
One liner added into our `.gitignore`

## Testing
N/A