### PR TITLE
[PLAT-12319] Ensure that the binary is installed when using `pnpm`  and `yarn`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.3.0",
   "description": "BugSnag CLI",
   "main": "install.js",
+  "bin": {
+    "bugsnag-cli": "bin/bugsnag-cli"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/bugsnag/bugsnag-cli.git"


### PR DESCRIPTION
## Goal

Ensure that the binary for the bugsnag-cli is correctly installed when using `pnpm` and `yarn` 

## Changeset

Add the `bin` directive to the `package.json` 

## Testing

Tested locally.