### PR TITLE
[PLAT-12453]  Ensure that extracted `.aab` files can be processed by the Android AAB upload function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Fixes
+
+- Ensure that extracted `.aab` files can be processed by the Android AAB upload function [114](https://github.com/bugsnag/bugsnag-cli/pull/114)
+
 ## 2.4.0 (2024-07-08)
 
 ### Enhancements

--- a/pkg/upload/android-aab.go
+++ b/pkg/upload/android-aab.go
@@ -1,7 +1,6 @@
 package upload
 
 import (
-	"fmt"
 	"github.com/bugsnag/bugsnag-cli/pkg/android"
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
@@ -38,6 +37,7 @@ func ProcessAndroidAab(
 
 	var manifestData map[string]string
 	var aabDir string
+	var aabFile string
 	var err error
 
 	for _, path := range paths {
@@ -49,22 +49,24 @@ func ProcessAndroidAab(
 				aabDir = path
 			} else {
 				arr := []string{"*", "build", "outputs", "bundle", "release", "*-release*.aab"}
-				path, err = android.FindAabPath(arr, path)
+				aabFile, err = android.FindAabPath(arr, path)
 
 				if err != nil {
 					return err
 				}
 			}
 		} else if filepath.Ext(path) == ".aab" {
-			aabDir, err = utils.ExtractFile(path, "aab")
+			aabFile = path
+		}
+
+		if aabFile != "" && aabDir == "" {
+			aabDir, err = utils.ExtractFile(aabFile, "aab")
 
 			defer os.RemoveAll(aabDir)
 
 			if err != nil {
 				return err
 			}
-		} else {
-			return fmt.Errorf("%s is not an AAB file/directory", path)
 		}
 	}
 

--- a/pkg/upload/android-aab.go
+++ b/pkg/upload/android-aab.go
@@ -54,19 +54,17 @@ func ProcessAndroidAab(
 				if err != nil {
 					return err
 				}
-
-				if filepath.Ext(path) != ".aab" {
-					return fmt.Errorf("%s is not an AAB file/directory", path)
-				} else {
-					aabDir, err = utils.ExtractFile(path, "aab")
-
-					defer os.RemoveAll(aabDir)
-
-					if err != nil {
-						return err
-					}
-				}
 			}
+		} else if filepath.Ext(path) == ".aab" {
+			aabDir, err = utils.ExtractFile(path, "aab")
+
+			defer os.RemoveAll(aabDir)
+
+			if err != nil {
+				return err
+			}
+		} else {
+			return fmt.Errorf("%s is not an AAB file/directory", path)
 		}
 	}
 


### PR DESCRIPTION
## Goal

Ensure that extracted `.aab` files can be processed by the Android AAB upload function

## Changeset

Check to see if the path that has been given to the `ProcessAndroidAab` function contains folders that indicate it is an extracted `aab` file so that we can skip looking for an `aab` file within the provided folder.

## Testing

Covered by CI