### PR TITLE
[PLAT-12424] Dont show `--upload-api-root-url` and `--build-api-root-url` flags in the general help output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Fixes
+
+- Dont show `--upload-api-root-url` and `--build-api-root-url` flags in the general help output [115](https://github.com/bugsnag/bugsnag-cli/pull/115)
+
 ## 2.4.0 (2024-07-08)
 
 ### Enhancements

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func main() {
 	logger := log.NewLoggerWrapper(commands.LogLevel)
 
 	// Build connection URI
-	endpoint, err := utils.BuildEndpointUrl(commands.UploadAPIRootUrl, commands.Port)
+	endpoint, err := utils.BuildEndpointUrl(commands.Upload.UploadAPIRootUrl, commands.Port)
 
 	if err != nil {
 		logger.Fatal(fmt.Sprintf("Failed to build upload url: %s", err.Error()))
@@ -293,7 +293,7 @@ func main() {
 		}
 
 		// Get Endpoint URL
-		endpoint, err = utils.BuildEndpointUrl(commands.BuildApiRootUrl, commands.Port)
+		endpoint, err = utils.BuildEndpointUrl(commands.CreateBuild.BuildApiRootUrl, commands.Port)
 
 		if err != nil {
 			logger.Fatal(fmt.Sprintf("Failed to build upload url: %s", err.Error()))

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -7,8 +7,6 @@ import (
 
 // Global CLI options
 type Globals struct {
-	UploadAPIRootUrl  string            `help:"Bugsnag On-Premise upload server URL. Can contain port number" default:"https://upload.bugsnag.com"`
-	BuildApiRootUrl   string            `help:"Bugsnag On-Premise build server URL. Can contain port number" default:"https://build.bugsnag.com"`
 	Port              int               `help:"Port number for the upload server" default:"443"`
 	ApiKey            string            `help:"(required) Bugsnag integration API key for this application"`
 	FailOnUploadError bool              `help:"Stops the upload when a mapping file fails to upload to Bugsnag successfully" default:"false"`
@@ -24,9 +22,10 @@ type CLI struct {
 
 	Upload struct {
 		// shared options
-		Overwrite bool `help:"Whether to overwrite any existing symbol file with a matching ID"`
-		Timeout   int  `help:"Number of seconds to wait before failing an upload request" default:"300"`
-		Retries   int  `help:"Number of retry attempts before failing an upload request" default:"0"`
+		UploadAPIRootUrl string `help:"Bugsnag On-Premise upload server URL. Can contain port number" default:"https://upload.bugsnag.com"`
+		Overwrite        bool   `help:"Whether to overwrite any existing symbol file with a matching ID"`
+		Timeout          int    `help:"Number of seconds to wait before failing an upload request" default:"300"`
+		Retries          int    `help:"Number of retry attempts before failing an upload request" default:"0"`
 
 		// required options
 		AndroidAab         upload.AndroidAabMapping      `cmd:"" help:"Process and upload application bundle files for Android"`
@@ -58,6 +57,7 @@ type IosBuildOptions struct {
 }
 
 type CreateBuild struct {
+	BuildApiRootUrl   string            `help:"Bugsnag On-Premise build server URL. Can contain port number" default:"https://build.bugsnag.com"`
 	BuilderName       string            `help:"The name of the entity that triggered the build. Could be a user, system etc."`
 	Metadata          map[string]string `help:"Additional build information"`
 	ReleaseStage      string            `help:"The release stage (eg, production, staging) that is being released (if applicable)."`


### PR DESCRIPTION
## Goal

Dont show `--upload-api-root-url` and `--build-api-root-url` flags in the general help output

## Design

<!-- Why was this approach used? -->

## Changeset

Move the `UploadAPIRootUrl` and `BuildApiRootUrl` to their respective structs to ensure that these options are not displayed under the general help output but only when you specify `--help` for upload or create-build.

## Testing

Covered by CI