### PR TITLE
Document js upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ To get unminified stack traces for JavaScript code in your React Native app buil
 
 See the [`upload react-native-ios`](https://docs.bugsnag.com/build-integrations/bugsnag-cli/upload-rn-ios/) command reference for full usage information.
 
+### JavaScript source maps
+
+To get unminified stack traces for JavaScript code on the web, source maps must be generated and uploaded to BugSnag.
+
+    $ bugsnag-cli upload js
+
+See the [`upload js`](https://docs.bugsnag.com/build-integrations/bugsnag-cli/upload-js/) command reference for full usage information.
+
 ### Dart symbols for Flutter
 
 If you are stripping debug symbols from your Dart code when building your Flutter apps, you will need to upload symbol files in order to see full stacktraces using the following command:


### PR DESCRIPTION
## Goal

Add the README documentation for the js command. The URL is currently broken but will be added by https://github.com/bugsnag/docs.bugsnag.com/pull/2333.