### PR TITLE
[PLAT-12623] Allow spaces when uploading dSYM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Fixes
+
+- Allow spaces when processing and uploading dSYM files [135](https://github.com/bugsnag/bugsnag-cli/pull/135)
+
 ## 2.5.0 (2024-07-31)
 
 ### Enhancements

--- a/pkg/ios/dsym-utils.go
+++ b/pkg/ios/dsym-utils.go
@@ -124,11 +124,11 @@ func getDwarfFileInfo(path, fileName string) []*DwarfInfo {
 		for _, str := range outputSlice {
 			if strings.Contains(str, "UUID: ") {
 				rawDwarfInfo := strings.Split(str, " ")
-				if len(rawDwarfInfo) == 4 {
+				if len(rawDwarfInfo) > 4 {
 					dwarf := &DwarfInfo{}
 					dwarf.UUID = rawDwarfInfo[1]
 					dwarf.Arch = rawDwarfInfo[2]
-					dwarf.Name = rawDwarfInfo[3]
+					dwarf.Name = strings.Join(rawDwarfInfo[3:], " ")
 					dwarf.Location = path
 					dwarfInfo = append(dwarfInfo, dwarf)
 				}

--- a/pkg/ios/dsym-utils.go
+++ b/pkg/ios/dsym-utils.go
@@ -124,7 +124,7 @@ func getDwarfFileInfo(path, fileName string) []*DwarfInfo {
 		for _, str := range outputSlice {
 			if strings.Contains(str, "UUID: ") {
 				rawDwarfInfo := strings.Split(str, " ")
-				if len(rawDwarfInfo) > 4 {
+				if len(rawDwarfInfo) >= 4 {
 					dwarf := &DwarfInfo{}
 					dwarf.UUID = rawDwarfInfo[1]
 					dwarf.Arch = rawDwarfInfo[2]

--- a/pkg/ios/xcodebuild-utils.go
+++ b/pkg/ios/xcodebuild-utils.go
@@ -1,11 +1,11 @@
 package ios
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"fmt"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -130,8 +130,7 @@ func getXcodeBuildSettings(path, schemeName string) (*map[string]*string, error)
 	}
 
 	buildSettings := strings.SplitAfterN(string(output), "Build settings for action build and target ", 2)[1]
-	buildSettingsSlice := strings.Split(strings.ReplaceAll(buildSettings, " ", ""), "\n")
-
+	buildSettingsSlice := strings.Split(buildSettings, "\n")
 	buildSettingsMap := make(map[string]*string)
 	for _, line := range buildSettingsSlice {
 		parts := strings.SplitN(line, "=", 2)


### PR DESCRIPTION
## Goal

Allow dSYM files with spaces in the name to be uploaded.

## Changeset

- Don't strip spaces from the Xcode build info
- Accept dSYM info length if its GT or EQ to 4 

## Testing

Covered by CI