### PR TITLE
[PLAT-12862] Adjust the NPM package to allow execution from YARN 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
+## TBD
+
+### Fixes
+- Ensure that the node package is configured correctly so that you can run `npx @bugsnag/cli` and `yarn bugsnag-cli`. [144](https://github.com/bugsnag/bugsnag-cli/pull/144)
+
 ## 2.6.1 (2024-09-18)
 
-# Fixes
+### Fixes
 - Ensure that we only pass either `--code-bundle-id` or `--version-code`/`--version-name`/`--bundle-version` to the upload API. [140](https://github.com/bugsnag/bugsnag-cli/pull/140)
 
 ## 2.6.0 (2024-09-09)

--- a/bin/bugsnag-cli
+++ b/bin/bugsnag-cli
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+console.log("error - bugsnag-cli binary has not been installed successfully")

--- a/install.js
+++ b/install.js
@@ -51,7 +51,7 @@ const getPlatformMetadata = () => {
 
 const downloadBinaryFromGitHub = async (downloadUrl, outputPath) => {
     try {
-        const binDir = path.resolve(process.cwd(),'..','..','.bin');
+        const binDir = path.resolve(process.cwd(),'.bin');
         if (!fs.existsSync(binDir)) {
             fs.mkdirSync(binDir, { recursive: true });
         }
@@ -61,6 +61,9 @@ const downloadBinaryFromGitHub = async (downloadUrl, outputPath) => {
         fs.writeFileSync(outputPath, binaryData, 'binary');
         fs.chmodSync(outputPath, '755');
         console.log('Binary downloaded successfully!');
+        nodeBinPath = path.join(path.resolve(process.cwd(),'..','..','.bin'),path.basename(outputPath));
+        fs.symlinkSync(outputPath, nodeBinPath, 'file');
+
     } catch (err) {
         console.error('Error downloading binary:', err.message);
     }
@@ -69,6 +72,6 @@ const downloadBinaryFromGitHub = async (downloadUrl, outputPath) => {
 const platformMetadata = getPlatformMetadata();
 const repoUrl = removeGitPrefixAndSuffix(repository.url);
 const binaryUrl = `${repoUrl}/releases/download/v${version}/${platformMetadata.ARTIFACT_NAME}`;
-const binaryOutputPath = path.join(process.cwd(),'..','..','.bin', platformMetadata.BINARY_NAME);
+const binaryOutputPath = path.join(process.cwd(),'.bin', platformMetadata.BINARY_NAME);
 
 downloadBinaryFromGitHub(binaryUrl, binaryOutputPath);

--- a/install.js
+++ b/install.js
@@ -51,7 +51,7 @@ const getPlatformMetadata = () => {
 
 const downloadBinaryFromGitHub = async (downloadUrl, outputPath) => {
     try {
-        const binDir = path.resolve(process.cwd(),'.bin');
+        const binDir = path.resolve(process.cwd(),'bin');
         if (!fs.existsSync(binDir)) {
             fs.mkdirSync(binDir, { recursive: true });
         }
@@ -61,9 +61,6 @@ const downloadBinaryFromGitHub = async (downloadUrl, outputPath) => {
         fs.writeFileSync(outputPath, binaryData, 'binary');
         fs.chmodSync(outputPath, '755');
         console.log('Binary downloaded successfully!');
-        nodeBinPath = path.join(path.resolve(process.cwd(),'..','..','.bin'),path.basename(outputPath));
-        fs.symlinkSync(outputPath, nodeBinPath, 'file');
-
     } catch (err) {
         console.error('Error downloading binary:', err.message);
     }
@@ -72,6 +69,6 @@ const downloadBinaryFromGitHub = async (downloadUrl, outputPath) => {
 const platformMetadata = getPlatformMetadata();
 const repoUrl = removeGitPrefixAndSuffix(repository.url);
 const binaryUrl = `${repoUrl}/releases/download/v${version}/${platformMetadata.ARTIFACT_NAME}`;
-const binaryOutputPath = path.join(process.cwd(),'.bin', platformMetadata.BINARY_NAME);
+const binaryOutputPath = path.join(process.cwd(),'bin', platformMetadata.BINARY_NAME);
 
 downloadBinaryFromGitHub(binaryUrl, binaryOutputPath);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "BugSnag CLI",
   "main": "install.js",
   "bin": {
-    "bugsnag-cli": "./.bin/bugsnag-cli"
+    "bugsnag-cli": "bin/bugsnag-cli"
   },
   "repository": {
     "type": "git",
@@ -25,6 +25,7 @@
   },
   "files": [
     "install.js",
+    "bin/bugsnag-cli",
     "supported-platforms.yml"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "BugSnag CLI",
   "main": "install.js",
   "bin": {
-    "bugsnag-cli": "bin/bugsnag-cli"
+    "bugsnag-cli": "./.bin/bugsnag-cli"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Goal

Allow execution when running `yarn bugsnag-cli`  and `npx @bugsnag/cli`

## Changeset

Install the bugsnag-cli binary into the package directory so that the package manager can create a symlink to the `node_modules/.bin` folder

## Testing

Covered by CI