### PR TITLE
Replace `axios` with NPMs built in `fetch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Fixes
 - Ensure that the node package is configured correctly so that you can run `npx @bugsnag/cli` and `yarn bugsnag-cli`. [144](https://github.com/bugsnag/bugsnag-cli/pull/144)
+- Replace the axios dependency with fetch to reduce the size of the package. [145](https://github.com/bugsnag/bugsnag-cli/pull/144)
 
 ## 2.6.1 (2024-09-18)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/cli",
-  "version": "2.6.1",
+  "version": "2.6.4-alpha",
   "description": "BugSnag CLI",
   "main": "install.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/cli",
-  "version": "2.6.4-alpha",
+  "version": "2.6.1",
   "description": "BugSnag CLI",
   "main": "install.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "homepage": "https://github.com/bugsnag/bugsnag-cli#readme",
   "dependencies": {
-    "axios": "^1.7.4",
     "js-yaml": "^4.1.0"
   },
   "files": [


### PR DESCRIPTION
## Goal

Replace the use of the `axios` npm package to reduce the size of the package and the dependency on a 3rd party packages. As we no longer support nodejs 14 and lower we can use the built in `fetch` method.

## Testing

Covered by CI