### PR TITLE
[PLAT-12916] Adjust logging and handling around `--project-root` for dSYM uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## TBD
+
+### Enhancements
+
+- Default the `--project-root` to the current working directory for the `upload dsym` command. [148](https://github.com/bugsnag/bugsnag-cli/pull/148)
+
 ## 2.6.2 (2024-10-17)
 
 ### Fixes

--- a/features/dsym/dsym_upload.feature
+++ b/features/dsym/dsym_upload.feature
@@ -49,10 +49,6 @@ Feature: dSYM Upload Integration Tests
     Then the sourcemaps Content-Type header is valid multipart form-data
     And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
 
-  Scenario: Attempt to upload a single dSYM sourcemap using path containing one dSYM but --project-root is not defined in the command
-    When I run bugsnag-cli with upload dsym --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF features/dsym/fixtures/single-dsym
-    Then I should see the Project Root error
-
   Scenario: Build and Upload dSYM
     When I make the "features/base-fixtures/dsym"
     Then I wait for the build to succeed

--- a/pkg/upload/dsym.go
+++ b/pkg/upload/dsym.go
@@ -44,11 +44,12 @@ func ProcessDsym(options options.CLI, endpoint string, logger log.Logger) error 
 		}
 
 		if xcodeProjPath != "" {
-			dsymOptions.ProjectRoot = ios.GetDefaultProjectRoot(xcodeProjPath, dsymOptions.ProjectRoot)
-			logger.Debug(fmt.Sprintf("Defaulting to '%s' as the project root", dsymOptions.ProjectRoot))
+			if dsymOptions.ProjectRoot == "" {
+				dsymOptions.ProjectRoot = ios.GetDefaultProjectRoot(xcodeProjPath, dsymOptions.ProjectRoot)
+				logger.Info(fmt.Sprintf("Setting `--project-root` from Xcode project settings: %s", dsymOptions.ProjectRoot))
+			}
 
 			// Get build settings and dsymPath
-
 			// If options.Scheme is set explicitly, check if it exists
 			if dsymOptions.Scheme != "" {
 				_, err := ios.IsSchemeInPath(xcodeProjPath, dsymOptions.Scheme)
@@ -85,7 +86,8 @@ func ProcessDsym(options options.CLI, endpoint string, logger log.Logger) error 
 		}
 
 		if dsymOptions.ProjectRoot == "" {
-			return fmt.Errorf("--project-root is required when uploading dSYMs from a directory that is not an Xcode project or workspace")
+			dsymOptions.ProjectRoot, _ = os.Getwd()
+			logger.Info(fmt.Sprintf("Setting `--project-root` to current working directory: %s", dsymOptions.ProjectRoot))
 		}
 
 		if dsymPath == "" {


### PR DESCRIPTION
## Goal

Adjust the logging and handling around `--project-root` for dSYM uploads

## Testing

Covered by CI