### PR TITLE
[PLAT-13056] Add `--code-bundle-id` to the `upload js` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 - Default the `--project-root` to the current working directory for the `upload dsym` command. [148](https://github.com/bugsnag/bugsnag-cli/pull/148)
 
+### Fixes
+
+- Add the `--code-bundle-id` option to the `upload js` command. [148](
+
 ## 2.6.2 (2024-10-17)
 
 ### Fixes

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -73,13 +73,14 @@ type Dsym struct {
 }
 
 type Js struct {
-	Path        utils.Paths `arg:"" name:"path" help:"The path to the directory or file to upload" type:"path" default:"."`
-	BaseUrl     string      `help:"For directory-based uploads, the URL of the base directory for the minified JavaScript files that the source maps relate to. The relative path is appended onto this for each file. Asterisks can be used as a wildcard."`
-	Bundle      string      `help:"Path to the minified JavaScript file that the source map relates to. If this is not provided then the file will be obtained when an error event is received." type:"path"`
-	BundleUrl   string      `help:"For single file uploads, the URL of the minified JavaScript file that the source map relates to. Asterisks can be used as a wildcard."`
-	ProjectRoot string      `help:"The path to strip from the beginning of source file names referenced in stacktraces on the BugSnag dashboard" type:"path"`
-	SourceMap   string      `help:"Path to the source map file. This usually has the .min.js extension." type:"path"`
-	VersionName string      `help:"The version of the app that the source map applies to. Defaults to the version in the package.json file (if found)."`
+	Path         utils.Paths `arg:"" name:"path" help:"The path to the directory or file to upload" type:"path" default:"."`
+	BaseUrl      string      `help:"For directory-based uploads, the URL of the base directory for the minified JavaScript files that the source maps relate to. The relative path is appended onto this for each file. Asterisks can be used as a wildcard."`
+	Bundle       string      `help:"Path to the minified JavaScript file that the source map relates to. If this is not provided then the file will be obtained when an error event is received." type:"path"`
+	BundleUrl    string      `help:"For single file uploads, the URL of the minified JavaScript file that the source map relates to. Asterisks can be used as a wildcard."`
+	ProjectRoot  string      `help:"The path to strip from the beginning of source file names referenced in stacktraces on the BugSnag dashboard" type:"path"`
+	SourceMap    string      `help:"Path to the source map file. This usually has the .min.js extension." type:"path"`
+	VersionName  string      `help:"The version of the app that the source map applies to. Defaults to the version in the package.json file (if found)."`
+	CodeBundleId string      `help:"A unique identifier for the JavaScript bundle"`
 }
 
 type ReactNative struct {

--- a/pkg/upload/js.go
+++ b/pkg/upload/js.go
@@ -266,7 +266,7 @@ func uploadSingleSourceMap(options options.CLI, jsOptions options.Js, endpoint s
 		logger.Debug(fmt.Sprintf("Generated URL %s using the base URL %s", url, jsOptions.BaseUrl))
 	}
 
-	uploadOptions, err := utils.BuildJsUploadOptions(options.ApiKey, jsOptions.VersionName, url, jsOptions.ProjectRoot, options.Upload.Overwrite)
+	uploadOptions, err := utils.BuildJsUploadOptions(options.ApiKey, jsOptions.VersionName, jsOptions.CodeBundleId, url, jsOptions.ProjectRoot, options.Upload.Overwrite)
 
 	if err != nil {
 		return fmt.Errorf("failed to build upload options: %s", err.Error())

--- a/pkg/utils/upload-options.go
+++ b/pkg/utils/upload-options.go
@@ -141,7 +141,7 @@ func BuildReactNativeUploadOptions(apiKey string, appVersion string, versionCode
 	return uploadOptions, nil
 }
 
-func BuildJsUploadOptions(apiKey string, versionName string, bundleUrl string, projectRoot string, overwrite bool) (map[string]string, error) {
+func BuildJsUploadOptions(apiKey string, versionName string, codeBundleId string, bundleUrl string, projectRoot string, overwrite bool) (map[string]string, error) {
 	uploadOptions := make(map[string]string)
 
 	if apiKey != "" {
@@ -162,6 +162,10 @@ func BuildJsUploadOptions(apiKey string, versionName string, bundleUrl string, p
 
 	if projectRoot != "" {
 		uploadOptions["projectRoot"] = projectRoot
+	}
+
+	if codeBundleId != "" {
+		uploadOptions["codeBundleId"] = codeBundleId
 	}
 
 	if overwrite {


### PR DESCRIPTION
## Goal

Ensure that we have all options available for the `upload js` command and pass `--code-bundle-id` to the API endpoint

## Testing

Covered by CI