### PR TITLE
[PLAT-13381] Remove `upload dsym` command from the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 3.0.0 (TBD)
+
+### Breaking Changes
+- The `upload dsym` command has been removed in favor of the `xcode-build` command.
+
 ## 2.8.0 (2025-01-06)
 
 ### Enhancements

--- a/main.go
+++ b/main.go
@@ -151,16 +151,6 @@ func main() {
 			logger.Fatal(err.Error())
 		}
 
-	case "upload dsym", "upload dsym <path>":
-
-		logger.Warn("The `upload dsym` command is deprecated and will be removed in a future release. Please use `upload xcode-build` instead.")
-
-		err := upload.ProcessXcodeBuild(commands, endpoint, logger)
-
-		if err != nil {
-			logger.Fatal(err.Error())
-		}
-
 	case "upload unity-android <path>":
 
 		if commands.ApiKey == "" {

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -169,7 +169,6 @@ type CLI struct {
 		AndroidProguard    AndroidProguardMapping `cmd:"" help:"Process and upload Proguard/R8 mapping files for Android"`
 		DartSymbol         DartSymbol             `cmd:"" help:"Process and upload symbol files for Flutter" name:"dart"`
 		XcodeBuild         XcodeBuild             `cmd:"" help:"Upload dSYMs for iOS from a build"`
-		Dsym               XcodeBuild             `cmd:"" help:"(deprecated) Upload dSYMs for iOS"`
 		XcodeArchive       XcodeArchive           `cmd:"" help:"Upload dSYMs for iOS from a Xcarchive"`
 		Js                 Js                     `cmd:"" help:"Upload source maps for JavaScript"`
 		ReactNative        ReactNative            `cmd:"" help:"Upload source maps for React Native"`


### PR DESCRIPTION
## Goal

Remove the deprecated `upload dsym` command from the CLI

## Testing

Covered by CI