### PR TITLE
[PLAT-13424] Check for .so.* files aswell as .so files when processing NDK source maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 ## TBD
 
 ### Enhancements
-- Add a wrapper for the `npm` package to interact with the BugSnag CLI []()
+- Add a wrapper for the `npm` package to interact with the BugSnag CLI [161](https://github.com/bugsnag/bugsnag-cli/pull/161)
+- Add the support for .so.* files when processing ndk symbol files [163](https://github.com/bugsnag/bugsnag-cli/pull/163)
 
 ## 2.8.0 (2025-01-06)
 

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/bugsnag/bugsnag-cli/pkg/android"
@@ -22,6 +23,9 @@ func ProcessAndroidNDK(options options.CLI, endpoint string, logger log.Logger) 
 	var workingDir string
 	var appManifestPathExpected string
 	var objCopyPath string
+
+	soFilePattern := `\.so.*$` // Regular expression to match strings ending in ".txt"
+	soFileRegex := regexp.MustCompile(soFilePattern)
 
 	for _, path := range ndkOptions.Path {
 
@@ -125,7 +129,7 @@ func ProcessAndroidNDK(options options.CLI, endpoint string, logger log.Logger) 
 	for _, file := range fileList {
 		if strings.HasSuffix(file, ".so.sym") {
 			symbolFileList = append(symbolFileList, file)
-		} else if filepath.Ext(file) == ".so" || strings.HasPrefix(filepath.Ext(file), ".so.") {
+		} else if soFileRegex.MatchString(file) {
 			// Check NDK path is set
 			if objCopyPath == "" {
 				ndkOptions.AndroidNdkRoot, err = android.GetAndroidNDKRoot(ndkOptions.AndroidNdkRoot)

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -125,7 +125,7 @@ func ProcessAndroidNDK(options options.CLI, endpoint string, logger log.Logger) 
 	for _, file := range fileList {
 		if strings.HasSuffix(file, ".so.sym") {
 			symbolFileList = append(symbolFileList, file)
-		} else if filepath.Ext(file) == ".so" {
+		} else if filepath.Ext(file) == ".so" || strings.HasPrefix(filepath.Ext(file), ".so.") {
 			// Check NDK path is set
 			if objCopyPath == "" {
 				ndkOptions.AndroidNdkRoot, err = android.GetAndroidNDKRoot(ndkOptions.AndroidNdkRoot)

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -24,7 +24,7 @@ func ProcessAndroidNDK(options options.CLI, endpoint string, logger log.Logger) 
 	var appManifestPathExpected string
 	var objCopyPath string
 
-	soFilePattern := `\.so.*$` // Regular expression to match strings ending in ".txt"
+	soFilePattern := `\.so.*$`
 	soFileRegex := regexp.MustCompile(soFilePattern)
 
 	for _, path := range ndkOptions.Path {


### PR DESCRIPTION
## Goal

Update the file check within the `upload android-ndk` command to check for any `.so*` files after it has checked for `.so.sym` files. This is to allow for additional file types introduced by Unity 6.

## Testing

This has been tested locally but we should update the Unity tests to account for this. 