### PR TITLE
[PLAT-13408] Android AAB extra debug logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Enhancements
 - Add a wrapper for the `npm` package to interact with the BugSnag CLI [161](https://github.com/bugsnag/bugsnag-cli/pull/161)
 - Add the support for .so.* files when processing ndk symbol files [163](https://github.com/bugsnag/bugsnag-cli/pull/163)
+- Add additional logging to the Android AAB upload command [165](https://github.com/bugsnag/bugsnag-cli/pull/165)
 
 ## 2.8.0 (2025-01-06)
 

--- a/pkg/upload/android-aab.go
+++ b/pkg/upload/android-aab.go
@@ -1,6 +1,7 @@
 package upload
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -38,6 +39,7 @@ func ProcessAndroidAab(globalOptions options.CLI, endpoint string, logger log.Lo
 		}
 
 		if aabFile != "" && aabDir == "" {
+			logger.Debug(fmt.Sprintf("Extracting AAB file: %s", aabFile))
 			aabDir, err = utils.ExtractFile(aabFile, "aab")
 
 			defer os.RemoveAll(aabDir)
@@ -57,6 +59,7 @@ func ProcessAndroidAab(globalOptions options.CLI, endpoint string, logger log.Lo
 	soFilePath := filepath.Join(aabDir, "BUNDLE-METADATA", "com.android.tools.build.debugsymbols")
 
 	if utils.FileExists(soFilePath) {
+		logger.Debug(fmt.Sprintf("Found NDK (.so) files at: %s", soFilePath))
 		soFileList, err := utils.BuildFileList([]string{soFilePath})
 
 		if err != nil {
@@ -87,6 +90,7 @@ func ProcessAndroidAab(globalOptions options.CLI, endpoint string, logger log.Lo
 	mappingFilePath := filepath.Join(aabDir, "BUNDLE-METADATA", "com.android.tools.build.obfuscation", "proguard.map")
 
 	if utils.FileExists(mappingFilePath) {
+		logger.Debug(fmt.Sprintf("Found Proguard (mapping.txt) file at: %s", mappingFilePath))
 		globalOptions.Upload.AndroidProguard = options.AndroidProguardMapping{
 			ApplicationId: manifestData["applicationId"],
 			BuildUuid:     manifestData["buildUuid"],


### PR DESCRIPTION
## Goal

Add some extra logging to the Android AAB upload process to show what paths are used when trying to upload .so files and proguard mappings

## Testing

Covered by CI