### PR TITLE
[PLAT-13456] Change the `js-yaml` node package to the `yaml` package 

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,6 +2,12 @@ agents:
   queue: macos-14
 
 steps:
+  - name: ':copyright: License Audit'
+    plugins:
+      docker-compose#v3.7.0:
+        run: license_finder
+    command: /bin/bash -lc '/scan/scripts/license_finder.sh'
+
   - label: ":hammer: CLI Binaries"
     key: build
     commands:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,6 +3,8 @@ agents:
 
 steps:
   - name: ':copyright: License Audit'
+    agents:
+      queue: opensource
     plugins:
       docker-compose#v3.7.0:
         run: license_finder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,23 @@
 # Changelog
+
+## 2.9.1 - (2025-01-23)
+
+### Patch
+
+- Switch `js-yaml` to `yaml` for the NodeJS package [168](https://github.com/bugsnag/bugsnag-cli/pull/168) 
+
 ## 2.9.0 (2025-01-20)
 
 ### Enhancements
+
 - Add a wrapper for the `npm` package to interact with the BugSnag CLI [161](https://github.com/bugsnag/bugsnag-cli/pull/161)
 - Add the support for .so.* files when processing ndk symbol files [163](https://github.com/bugsnag/bugsnag-cli/pull/163)
 - Add additional logging to the Android AAB upload command [165](https://github.com/bugsnag/bugsnag-cli/pull/165)
+
 ## 2.8.0 (2025-01-06)
 
 ### Enhancements
+
 - Add the Xcode Archive Command to support the uploading of xcarchive files [156](https://github.com/bugsnag/bugsnag-cli/pull/156)
 - Rename the `dsym` upload command to `xcode-build` to better reflect the command's purpose. `dsym` will be removed in the next major release [156](https://github.com/bugsnag/bugsnag-cli/pull/156)
 
@@ -30,12 +40,14 @@
 ## 2.6.2 (2024-10-17)
 
 ### Fixes
+
 - Ensure that the node package is configured correctly so that you can run `npx @bugsnag/cli` and `yarn bugsnag-cli`. [144](https://github.com/bugsnag/bugsnag-cli/pull/144)
 - Replace the axios dependency with fetch to reduce the size of the package. [145](https://github.com/bugsnag/bugsnag-cli/pull/144)
 
 ## 2.6.1 (2024-09-18)
 
 ### Fixes
+
 - Ensure that we only pass either `--code-bundle-id` or `--version-code`/`--version-name`/`--bundle-version` to the upload API. [140](https://github.com/bugsnag/bugsnag-cli/pull/140)
 
 ## 2.6.0 (2024-09-09)

--- a/bugsnag-cli-install.js
+++ b/bugsnag-cli-install.js
@@ -1,35 +1,35 @@
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
-const yaml = require('js-yaml');
-const createWriteStream = require('fs').createWriteStream;
-const Readable = require('stream').Readable;
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+const YAML = require('yaml')
+const createWriteStream = require('fs').createWriteStream
+const Readable = require('stream').Readable
 
-const supportedPlatformsConfig = fs.readFileSync(path.join(__dirname, 'supported-platforms.yml'), 'utf8');
-const { name, repository, version } = require('./package.json');
+const supportedPlatformsConfig = fs.readFileSync(path.join(__dirname, 'supported-platforms.yml'), 'utf8')
+const { name, repository, version } = require('./package.json')
 
 const handleError = (msg) => {
-    console.error(msg);
-    process.exit(1);
-};
+    console.error(msg)
+    process.exit(1)
+}
 
 // Remove the git prefix and suffix from the repository URL
 const removeGitPrefixAndSuffix = (input) => {
-    let result = input.replace(/^git\+/, '');
-    result = result.replace(/\.git$/, '');
-    return result;
-};
+    let result = input.replace(/^git\+/, '')
+    result = result.replace(/\.git$/, '')
+    return result
+}
 
 // Parse supported-platforms.yml into an iterable array
-const supportedPlatforms = yaml.load(supportedPlatformsConfig);
+const supportedPlatforms = YAML.parse(supportedPlatformsConfig)
 
 const getPlatformMetadata = () => {
-    const type = os.type();
-    const architecture = os.arch();
+    const type = os.type()
+    const architecture = os.arch()
 
     for (const supportedPlatform of supportedPlatforms) {
         if (type === supportedPlatform.TYPE && architecture === supportedPlatform.ARCHITECTURE) {
-            return supportedPlatform;
+            return supportedPlatform
         }
     }
 
@@ -38,8 +38,8 @@ const getPlatformMetadata = () => {
             Type: platform.TYPE,
             Architecture: platform.ARCHITECTURE,
             Artifact: platform.ARTIFACT_NAME
-        };
-    });
+        }
+    })
 
     handleError(
         `Platform with type "${type}" and architecture "${architecture}" is not supported by ${name}.\nYour system must be one of the following:\n\n${JSON.stringify(
@@ -47,34 +47,34 @@ const getPlatformMetadata = () => {
             null,
             2
         )}`
-    );
-};
+    )
+}
 
 const downloadBinaryFromGitHub = async (downloadUrl, outputPath) => {
     try {
-        const binDir = path.resolve(process.cwd(),'bin');
+        const binDir = path.resolve(process.cwd(), 'bin')
         if (!fs.existsSync(binDir)) {
-            fs.mkdirSync(binDir, { recursive: true });
+            fs.mkdirSync(binDir, { recursive: true })
         }
 
-        const fileName = downloadUrl.split("/").pop();
-        const resp = await fetch(downloadUrl);
+        const fileName = downloadUrl.split("/").pop()
+        const resp = await fetch(downloadUrl)
 
         if (resp.ok && resp.body) {
-            let writer = createWriteStream(outputPath);
-            Readable.fromWeb(resp.body).pipe(writer);
+            let writer = createWriteStream(outputPath)
+            Readable.fromWeb(resp.body).pipe(writer)
         }
 
-        fs.chmodSync(outputPath, '755');
-        console.log('Binary downloaded successfully!');
+        fs.chmodSync(outputPath, '755')
+        console.log('Binary downloaded successfully!')
     } catch (err) {
-        console.error('Error downloading binary:', err.message);
+        console.error('Error downloading binary:', err.message)
     }
-};
+}
 
-const platformMetadata = getPlatformMetadata();
-const repoUrl = removeGitPrefixAndSuffix(repository.url);
-const binaryUrl = `${repoUrl}/releases/download/v${version}/${platformMetadata.ARTIFACT_NAME}`;
-const binaryOutputPath = path.join(process.cwd(),'bin', platformMetadata.BINARY_NAME);
+const platformMetadata = getPlatformMetadata()
+const repoUrl = removeGitPrefixAndSuffix(repository.url)
+const binaryUrl = `${repoUrl}/releases/download/v${version}/${platformMetadata.ARTIFACT_NAME}`
+const binaryOutputPath = path.join(process.cwd(), 'bin', platformMetadata.BINARY_NAME)
 
-downloadBinaryFromGitHub(binaryUrl, binaryOutputPath);
+downloadBinaryFromGitHub(binaryUrl, binaryOutputPath)

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,1 @@
+decisions.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+
+  license_finder:
+    build:
+      dockerfile: dockerfiles/Dockerfile.audit
+      context: .
+    volumes:
+      - ./:/scan

--- a/dockerfiles/Dockerfile.audit
+++ b/dockerfiles/Dockerfile.audit
@@ -1,0 +1,5 @@
+FROM licensefinder/license_finder
+
+WORKDIR /scan
+
+CMD /scan/scripts/license_finder.sh

--- a/features/cli/create-build.feature
+++ b/features/cli/create-build.feature
@@ -13,7 +13,7 @@ Feature: Bugsnag CLI create-build behavior
     Then the build is valid for the Builds API
     And the builds payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
     And the builds payload field "appVersion" equals "1.2.3"
-    And the builds payload field "sourceControl.repository" equals "git@github.com:bugsnag/bugsnag-cli.git"
+    And the builds payload field "sourceControl.repository" equals "https://github.com/bugsnag/bugsnag-cli.git"
 
   Scenario: Starting bugsnag-cli create-build and passing an AAB file
     When I run bugsnag-cli with create-build --build-api-root-url=http://localhost:9339/builds --api-key=1234567890ABCDEF1234567890ABCDEF --android-aab=features/android/fixtures/aab/app-release.aab
@@ -21,7 +21,7 @@ Feature: Bugsnag CLI create-build behavior
     Then the build is valid for the Builds API
     And the builds payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
     And the builds payload field "appVersion" equals "1.0"
-    And the builds payload field "sourceControl.repository" equals "git@github.com:bugsnag/bugsnag-cli.git"
+    And the builds payload field "sourceControl.repository" equals "https://github.com/bugsnag/bugsnag-cli.git"
 
   Scenario: Starting bugsnag-cli create-build and passing an Android manifest file
     When I run bugsnag-cli with create-build --build-api-root-url=http://localhost:9339/builds --app-manifest=features/android/fixtures/app/build/intermediates/merged_manifests/release/AndroidManifest.xml
@@ -29,7 +29,7 @@ Feature: Bugsnag CLI create-build behavior
     Then the build is valid for the Builds API
     And the builds payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
     And the builds payload field "appVersion" equals "1.0"
-    And the builds payload field "sourceControl.repository" equals "git@github.com:bugsnag/bugsnag-cli.git"
+    And the builds payload field "sourceControl.repository" equals "https://github.com/bugsnag/bugsnag-cli.git"
 
   Scenario: Starting bugsnag-cli create-build with invalid source control provider
     When I run bugsnag-cli with create-build --build-api-root-url=http://localhost:9339/builds --api-key=1234567890ABCDEF1234567890ABCDEF --version-name=1.2.3 --provider=test

--- a/install.sh
+++ b/install.sh
@@ -91,7 +91,7 @@ display_help() {
 EOS
 }
 
-VERSION="2.9.0"
+VERSION="2.9.1"
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
 )
 
-var package_version = "2.9.0"
+var package_version = "2.9.1"
 
 func main() {
 	commands := options.CLI{}

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   ],
   "scripts": {
     "postinstall": "node bugsnag-cli-install.js"
+  },
+  "devDependencies": {
+    "yaml": "^2.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/cli",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "BugSnag CLI",
   "main": "bugsnag-cli-wrapper.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "access": "public"
   },
   "homepage": "https://github.com/bugsnag/bugsnag-cli#readme",
+  "dependencies": {
+    "yaml": "^2.7.0"
+  },
   "files": [
     "bugsnag-cli-install.js",
     "bugsnag-cli-wrapper.js",
@@ -27,8 +30,5 @@
   ],
   "scripts": {
     "postinstall": "node bugsnag-cli-install.js"
-  },
-  "devDependencies": {
-    "yaml": "^2.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
     "access": "public"
   },
   "homepage": "https://github.com/bugsnag/bugsnag-cli#readme",
-  "dependencies": {
-    "js-yaml": "^4.1.0"
-  },
   "files": [
     "bugsnag-cli-install.js",
     "bugsnag-cli-wrapper.js",

--- a/scripts/license_finder.sh
+++ b/scripts/license_finder.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Download decision files
+curl https://raw.githubusercontent.com/bugsnag/license-audit/master/config/decision_files/global.yml -o config/decisions.yml
+curl https://raw.githubusercontent.com/bugsnag/license-audit/master/config/decision_files/common-js.yml >> config/decisions.yml
+
+npm install
+license_finder -d --decisions-file=config/decisions.yml --enabled-package-managers=npm


### PR DESCRIPTION
## Goal

Due to the old license used for the `js-yaml` package, to comply with the License Audit we've updated to use the `yaml` node package

I have also added the license auditor step to the CI to ensure all packages comply.

## Testing

Covered by CI