### PR TITLE
[PLAT-13629] Get NDK version from the properties file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## TBD
 
 ### Fixes
-- Get NDK version from the `source.properties` file when uploading NDK symbol files
+- Get NDK version from the `source.properties` file when uploading NDK symbol files [172](https://github.com/bugsnag/bugsnag-cli/pull/172)
 
 ## 2.9.1 - (2025-01-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+### Fixes
+- Get NDK version from the `source.properties` file when uploading NDK symbol files
+
 ## 2.9.1 - (2025-01-23)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## 2.10.0 (2025-02-11)
 
 ### Fixes
 - Get NDK version from the `source.properties` file when uploading NDK symbol files [172](https://github.com/bugsnag/bugsnag-cli/pull/172)

--- a/features/Unity-Android/unity.feature
+++ b/features/Unity-Android/unity.feature
@@ -18,7 +18,7 @@ Feature: Unity Android integration tests
     And I wait for the Unity symbols to generate
 
     Given I set the NDK path to the Unity bundled version
-    When I run bugsnag-cli with upload unity-android --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF--overwrite platforms-examples/Unity/
+    When I run bugsnag-cli with upload unity-android --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite platforms-examples/Unity/
     Then I wait to receive 5 sourcemaps
     Then the sourcemap is valid for the Android Build API
     Then the sourcemaps Content-Type header is valid multipart form-data

--- a/features/Unity-Android/unity.feature
+++ b/features/Unity-Android/unity.feature
@@ -13,6 +13,21 @@ Feature: Unity Android integration tests
     And the sourcemap payload field "versionName" equals "1.0"
     And the sourcemap payload field "overwrite" equals "true"
 
+  Scenario: Unity Android integration tests using the bundled NDK
+    Given I build the Unity Android example project
+    And I wait for the Unity symbols to generate
+
+    Given I set the NDK path to the Unity bundled version
+    When I run bugsnag-cli with upload unity-android --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF--overwrite platforms-examples/Unity/
+    Then I wait to receive 5 sourcemaps
+    Then the sourcemap is valid for the Android Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
+    And the sourcemap payload field "appId" equals "com.bugsnag.example.unity.android"
+    And the sourcemap payload field "versionCode" equals "1"
+    And the sourcemap payload field "versionName" equals "1.0"
+    And the sourcemap payload field "overwrite" equals "true"
+
 
   Scenario: Unity Android integration tests passing the aab file
     Given I build the Unity Android example project

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -230,3 +230,8 @@ end
 And('I wait for the Unity symbols to generate') do
   Maze.check.include(`ls #{@fixture_dir}`, 'UnityExample-1.0-v1-IL2CPP.symbols.zip')
 end
+
+Given(/^I set the NDK path to the Unity bundled version$/) do
+#  Set the environment variable to the path of the NDK bundled with Unity
+  ENV['ANDROID_NDK_ROOT'] = "/Applications/Unity/Hub/Editor/#{ENV['UNITY_VERSION']}/PlaybackEngines/AndroidPlayer/NDK"
+end

--- a/install.sh
+++ b/install.sh
@@ -91,7 +91,7 @@ display_help() {
 EOS
 }
 
-VERSION="2.9.1"
+VERSION="2.10.0"
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
 )
 
-var package_version = "2.9.1"
+var package_version = "2.10.0"
 
 func main() {
 	commands := options.CLI{}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/cli",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "description": "BugSnag CLI",
   "main": "bugsnag-cli-wrapper.js",
   "bin": {

--- a/pkg/android/get-ndk-version.go
+++ b/pkg/android/get-ndk-version.go
@@ -1,21 +1,52 @@
 package android
 
 import (
+	"bufio"
+	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 )
 
 // GetNdkVersion - Returns the major NDK version
-func GetNdkVersion(path string) (int, error) {
+func GetNdkVersion(ndkPath string) (int, error) {
+	// Construct the path to source.properties
+	sourceFile := filepath.Join(ndkPath, "source.properties")
 
-	ndkVersion := strings.Split(filepath.Base(path), ".")
-
-	ndkIntVersion, err := strconv.Atoi(ndkVersion[0])
-
+	// Open the file
+	file, err := os.Open(sourceFile)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to open source.properties: %v", err)
+	}
+	defer file.Close()
+
+	// Read the file line by line
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "Pkg.Revision") {
+			// Extract version string
+			parts := strings.Split(line, " = ")
+			if len(parts) == 2 {
+				versionStr := parts[1]
+				// Extract major version (before the first dot)
+				versionParts := strings.Split(versionStr, ".")
+				if len(versionParts) > 0 {
+					majorVersion, err := strconv.Atoi(versionParts[0])
+					if err != nil {
+						return 0, fmt.Errorf("failed to parse major version: %v", err)
+					}
+					return majorVersion, nil
+				}
+			}
+		}
 	}
 
-	return ndkIntVersion, nil
+	// Check for errors while scanning
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("error reading source.properties: %v", err)
+	}
+
+	return 0, fmt.Errorf("NDK version not found in source.properties")
 }

--- a/pkg/android/get-ndk-version.go
+++ b/pkg/android/get-ndk-version.go
@@ -27,7 +27,8 @@ func GetNdkVersion(ndkPath string) (int, error) {
 		line := scanner.Text()
 		if strings.HasPrefix(line, "Pkg.Revision") {
 			// Extract version string
-			parts := strings.Split(line, " = ")
+			parts := strings.Split(line, "=")
+			parts[1] = strings.TrimSpace(parts[1])
 			if len(parts) == 2 {
 				versionStr := parts[1]
 				// Extract major version (before the first dot)


### PR DESCRIPTION
## Goal

Ensure that we get the Android NDK version from a reliable source.

## Changeset

Get the `Pkg.Revision` from the NDK `source.properties` file

## Testing

Covered by CI