### PR TITLE
[PLAT-13836] dSYM Super Command

### DIFF
--- a/features/react-native/scripts/generate.js
+++ b/features/react-native/scripts/generate.js
@@ -43,7 +43,7 @@ if (!process.env.SKIP_GENERATE_FIXTURE) {
     }
 
     // create the test fixture
-    const RNInitArgs = ['@react-native-community/cli@latest', 'init', 'reactnative', '--directory', fixtureDir, '--version', reactNativeVersion, '--pm', 'npm', '--skip-install']
+    const RNInitArgs = ['@react-native-community/cli@16', 'init', 'reactnative', '--directory', fixtureDir, '--version', reactNativeVersion, '--pm', 'npm', '--skip-install']
     execFileSync('npx', RNInitArgs, { stdio: 'inherit' })
 
     replaceGeneratedFixtureFiles()

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -236,6 +236,75 @@ Given(/^I set the NDK path to the Unity bundled version$/) do
   ENV['ANDROID_NDK_ROOT'] = "/Applications/Unity/Hub/Editor/#{ENV['UNITY_VERSION']}/PlaybackEngines/AndroidPlayer/NDK"
 end
 
+# dSYM
+Before('@CleanAndBuildDsym') do
+  scheme = 'dSYM-Example'
+  project_path = 'features/base-fixtures/dsym'
+
+  # Find the Xcode archive path dynamically
+  custom_archives_path = `defaults read com.apple.dt.Xcode IDECustomDistributionArchivesLocation`.strip
+  archives_path = custom_archives_path.empty? ? File.expand_path("~/Library/Developer/Xcode/Archives/") : custom_archives_path
+  today = Date.today.strftime('%Y-%m-%d')
+
+  # Delete archives for the given scheme created today
+  Dir.glob(File.join(archives_path, "#{today}*")) do |archive|
+    if archive.include?(scheme)
+      puts "Removing archive: #{archive}"
+      FileUtils.rm_rf(archive)
+    end
+  end
+
+  # Clear Xcode build directories matching wildcard pattern
+  build_paths = Dir.glob(File.expand_path("~/Library/Developer/Xcode/DerivedData/dSYM-Example-*"))
+
+  if build_paths.any?
+    build_paths.each do |path|
+      puts "Clearing Xcode build directory: #{path}"
+      FileUtils.rm_rf(path)
+    end
+  else
+    puts "No matching build directories found."
+  end
+
+  # Build the project
+  puts "Building project: #{project_path}"
+  @output = `make features/base-fixtures/dsym`
+end
+
+Before('@CleanAndArchiveDsym') do
+  scheme = 'dSYM-Example'
+  project_path = 'features/base-fixtures/dsym'
+
+  # Find the Xcode archive path dynamically
+  custom_archives_path = `defaults read com.apple.dt.Xcode IDECustomDistributionArchivesLocation`.strip
+  archives_path = custom_archives_path.empty? ? File.expand_path("~/Library/Developer/Xcode/Archives/") : custom_archives_path
+  today = Date.today.strftime('%Y-%m-%d')
+
+  # Delete archives for the given scheme created today
+  Dir.glob(File.join(archives_path, "#{today}*")) do |archive|
+    if archive.include?(scheme)
+      puts "Removing archive: #{archive}"
+      FileUtils.rm_rf(archive)
+    end
+  end
+
+  # Clear Xcode build directories matching wildcard pattern
+  build_paths = Dir.glob(File.expand_path("~/Library/Developer/Xcode/DerivedData/dSYM-Example-*"))
+
+  if build_paths.any?
+    build_paths.each do |path|
+      puts "Clearing Xcode build directory: #{path}"
+      FileUtils.rm_rf(path)
+    end
+  else
+    puts "No matching build directories found."
+  end
+
+  # Build the project
+  puts "Building project: #{project_path}"
+  @output = `make features/base-fixtures/dsym/archive`
+end
+
 # React Native
 Before('@BuildRNAndroid') do
   unless defined?($setup_android) && $setup_android

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -349,7 +349,7 @@ Before('@BuildRNAndroid') do
     base_path = "features/react-native/fixtures/generated/old-arch/#{ENV['RN_VERSION']}/android/app/build"
     sourcemap_path = "#{base_path}/generated/sourcemaps/react/release/index.android.bundle.map"
 
-    unless Maze.check.include?(`ls #{sourcemap_path}`, 'index.android.bundle.map')
+    unless Maze.check.include(`ls #{sourcemap_path}`, 'index.android.bundle.map')
       raise "❌ Sourcemap not found at: #{sourcemap_path}"
     end
 
@@ -394,7 +394,7 @@ Before('@BuildRNiOS') do
 
     sourcemap_path = "features/react-native/fixtures/generated/old-arch/#{ENV['RN_VERSION']}/ios/build/sourcemaps"
 
-    unless Maze.check.include?(`ls #{sourcemap_path}`, 'main.jsbundle.map')
+    unless Maze.check.include(`ls #{sourcemap_path}`, 'main.jsbundle.map')
       raise "❌ Sourcemap not found at: #{sourcemap_path}/main.jsbundle.map"
     end
 
@@ -419,7 +419,7 @@ Before('@BuildExportRNiOS') do
 
     sourcemap_path = "features/react-native/fixtures/generated/old-arch/#{ENV['RN_VERSION']}/ios/build/sourcemaps"
 
-    unless Maze.check.include?(`ls #{sourcemap_path}`, 'main.jsbundle.map')
+    unless Maze.check.include(`ls #{sourcemap_path}`, 'main.jsbundle.map')
       raise "❌ Sourcemap not found at: #{sourcemap_path}/main.jsbundle.map"
     end
 

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -347,7 +347,7 @@ Before('@BuildRNAndroid') do
     end
 
     base_path = "features/react-native/fixtures/generated/old-arch/#{ENV['RN_VERSION']}/android/app/build"
-    sourcemap_path = "#{base_path}/generated/sourcemaps/react/release/index.android.bundle.map"
+    sourcemap_path = "#{base_path}/generated/sourcemaps/react/release"
 
     unless Maze.check.include(`ls #{sourcemap_path}`, 'index.android.bundle.map')
       raise "❌ Sourcemap not found at: #{sourcemap_path}"

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -349,16 +349,14 @@ Before('@BuildRNAndroid') do
     base_path = "features/react-native/fixtures/generated/old-arch/#{ENV['RN_VERSION']}/android/app/build"
     sourcemap_path = "#{base_path}/generated/sourcemaps/react/release"
 
-    unless Maze.check.include(`ls #{sourcemap_path}`, 'index.android.bundle.map')
-      raise "❌ Sourcemap not found at: #{sourcemap_path}"
-    end
+    Maze.check.include(`ls #{sourcemap_path}`, 'index.android.bundle.map')
 
     puts "📍 Sourcemap verified successfully."
 
     # Set environment variables
     ENV['APP_MANIFEST_PATH'] = "#{base_path}/intermediates/merged_manifests/release/AndroidManifest.xml"
     ENV['BUNDLE_PATH'] = "#{base_path}/generated/assets/createBundleReleaseJsAndAssets/index.android.bundle"
-    ENV['SOURCE_MAP_PATH'] = sourcemap_path
+    ENV['SOURCE_MAP_PATH'] = "#{sourcemap_path}/index.android.bundle.map"
 
     case ENV['RN_VERSION'].to_f
     when 0.70
@@ -394,9 +392,7 @@ Before('@BuildRNiOS') do
 
     sourcemap_path = "features/react-native/fixtures/generated/old-arch/#{ENV['RN_VERSION']}/ios/build/sourcemaps"
 
-    unless Maze.check.include(`ls #{sourcemap_path}`, 'main.jsbundle.map')
-      raise "❌ Sourcemap not found at: #{sourcemap_path}/main.jsbundle.map"
-    end
+    Maze.check.include(`ls #{sourcemap_path}`, 'main.jsbundle.map')
 
     puts "📍 Sourcemap verified successfully."
     $setup_ios = true
@@ -419,9 +415,7 @@ Before('@BuildExportRNiOS') do
 
     sourcemap_path = "features/react-native/fixtures/generated/old-arch/#{ENV['RN_VERSION']}/ios/build/sourcemaps"
 
-    unless Maze.check.include(`ls #{sourcemap_path}`, 'main.jsbundle.map')
-      raise "❌ Sourcemap not found at: #{sourcemap_path}/main.jsbundle.map"
-    end
+    Maze.check.include(`ls #{sourcemap_path}`, 'main.jsbundle.map')
 
     puts "📍 Sourcemap verified successfully."
     $export_ios = true

--- a/features/xcode/dsym.feature
+++ b/features/xcode/dsym.feature
@@ -3,7 +3,6 @@ Feature: dSYM Integration Tests
   Scenario: Upload a dsym from an Xcode Build
     When I run bugsnag-cli with upload dsym --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/dsym/
     And I wait to receive 1 sourcemaps
-    Then I should see the "dSYM files successfully uploaded from the build directory" in the output
     Then the sourcemap is valid for the dSYM Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
     And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
@@ -12,7 +11,6 @@ Feature: dSYM Integration Tests
   Scenario: Upload a dsym from an Xcode Archive
     When I run bugsnag-cli with upload dsym --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/dsym/
     And I wait to receive 1 sourcemaps
-    Then I should see the "dSYM files successfully uploaded from the xcarchive" in the output
     Then the sourcemap is valid for the dSYM Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
     And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"

--- a/features/xcode/dsym.feature
+++ b/features/xcode/dsym.feature
@@ -3,6 +3,7 @@ Feature: dSYM Integration Tests
   Scenario: Upload a dsym from an Xcode Build
     When I run bugsnag-cli with upload dsym --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/dsym/
     And I wait to receive 1 sourcemaps
+    Then I should see the "dSYM files successfully uploaded from the build directory" in the output
     Then the sourcemap is valid for the dSYM Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
     And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
@@ -11,6 +12,7 @@ Feature: dSYM Integration Tests
   Scenario: Upload a dsym from an Xcode Archive
     When I run bugsnag-cli with upload dsym --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/dsym/
     And I wait to receive 1 sourcemaps
+    Then I should see the "dSYM files successfully uploaded from the xcarchive" in the output
     Then the sourcemap is valid for the dSYM Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
     And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"

--- a/features/xcode/dsym.feature
+++ b/features/xcode/dsym.feature
@@ -1,0 +1,16 @@
+Feature: dSYM Integration Tests
+  @CleanAndBuildDsym
+  Scenario: Upload a dsym from an Xcode Build
+    When I run bugsnag-cli with upload dsym --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/dsym/
+    And I wait to receive 1 sourcemaps
+    Then the sourcemap is valid for the dSYM Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
+
+  @CleanAndArchiveDsym
+  Scenario: Upload a dsym from an Xcode Archive
+    When I run bugsnag-cli with upload dsym --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/dsym/
+    And I wait to receive 1 sourcemaps
+    Then the sourcemap is valid for the dSYM Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"

--- a/features/xcode/xcode-archive.feature
+++ b/features/xcode/xcode-archive.feature
@@ -1,4 +1,4 @@
-Feature: Upload Xcode Archives
+Feature: Xcode Archive Integration Tests
   Scenario: Uploading an .xcarchive containing commas and special characters
     When I run bugsnag-cli with upload xcode-archive --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF "features/xcode/fixtures/bugsnag-example 14-05-2021,,, 11.27éøœåñü#.xcarchive"
     And I wait to receive 2 sourcemaps
@@ -9,9 +9,16 @@ Feature: Upload Xcode Archives
   Scenario: Archive and upload an .xcarchive
     When I make the "features/base-fixtures/dsym/archive"
     Then I wait for the build to succeed
-
-
     When I run bugsnag-cli with upload xcode-archive --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/dsym/
+    And I wait to receive 1 sourcemaps
+    Then the sourcemap is valid for the dSYM Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
+
+  Scenario: Archive and export a .xcarchive
+    When I make the "features/base-fixtures/dsym/archive/export"
+    Then I wait for the build to succeed
+    When I run bugsnag-cli with upload xcode-archive --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/dsym/dsym.xcarchive
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the dSYM Build API
     Then the sourcemaps Content-Type header is valid multipart form-data

--- a/features/xcode/xcode-build.feature
+++ b/features/xcode/xcode-build.feature
@@ -1,4 +1,4 @@
-Feature: dSYM Upload Integration Tests
+Feature: Xcode Build Integration Tests
 
   Scenario: Upload a single dSYM sourcemap using path containing one dSYM
     When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/my/project/root/ features/xcode/fixtures/single-dsym

--- a/main.go
+++ b/main.go
@@ -153,9 +153,7 @@ func main() {
 
 	case "upload dsym", "upload dsym <path>":
 
-		logger.Warn("The `upload dsym` command is deprecated and will be removed in a future release. Please use `upload xcode-build` instead.")
-
-		err := upload.ProcessXcodeBuild(commands, endpoint, logger)
+		err := upload.ProcessDsym(commands, endpoint, logger)
 
 		if err != nil {
 			logger.Fatal(err.Error())

--- a/makefile
+++ b/makefile
@@ -91,6 +91,14 @@ features/base-fixtures/dsym/archive:
 	cd features/base-fixtures/dsym && xcrun xcodebuild -allowProvisioningUpdates -scheme dSYM-Example -resolvePackageDependencies
 	cd features/base-fixtures/dsym && xcrun xcodebuild -scheme dSYM-Example -configuration Release -allowProvisioningUpdates archive
 
+.PHONY: features/base-fixtures/dsym/archive/export
+features/base-fixtures/dsym/archive/export:
+	bundle install
+	cd features/base-fixtures/dsym && bundle install
+	cd features/base-fixtures/dsym && xcrun xcodebuild -allowProvisioningUpdates -scheme dSYM-Example -resolvePackageDependencies
+	cd features/base-fixtures/dsym && xcrun xcodebuild DEVELOPMENT_TEAM=7W9PZ27Y5F -scheme dSYM-Example -configuration Release -archivePath dsym.xcarchive -allowProvisioningUpdates archive
+	cd features/base-fixtures/dsym && xcrun xcodebuild -exportArchive -archivePath dsym.xcarchive -exportPath output/ -exportOptionsPlist ../../react-native/fixtures/app/dynamic/ios/exportOptions.plist
+
 .PHONY: features/base-fixtures/js-webpack4
 features/base-fixtures/js-webpack4:
 	cd $@ && npm i && npm run build

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -61,25 +61,29 @@ type DartSymbol struct {
 	VersionCode   string      `help:"The version code of this build of the application (Android only)" xor:"app-version-code,version-code"`
 }
 
+type Dsym struct {
+	Path   utils.Paths `arg:"" name:"path" help:"The path to the directory or file to upload" type:"path" default:"."`
+	Shared DsymShared  `embed:""`
+}
+
 type XcodeBuild struct {
-	Path          utils.Paths `arg:"" name:"path" help:"The path to the directory or file to upload" type:"path" default:"."`
-	Plist         utils.Path  `help:"The path to a .plist file from which to obtain build information" type:"path"`
-	VersionName   string      `help:"The version of the application"`
-	XcodeProject  utils.Path  `help:"The path to an Xcode project, workspace or containing directory from which to obtain build information" type:"path"`
-	Configuration string      `help:"The configuration used to build the application"`
-	Shared        XcodeShared `embed:""`
+	Path   utils.Paths `arg:"" name:"path" help:"The path to the directory or file to upload" type:"path" default:"."`
+	Shared DsymShared  `embed:""`
 }
 
 type XcodeArchive struct {
 	Path   utils.Paths `arg:"" name:"path" help:"The path to the directory or file to upload" type:"path" default:"."`
-	Shared XcodeShared `embed:""`
+	Shared DsymShared  `embed:""`
 }
 
-type XcodeShared struct {
-	IgnoreEmptyDsym    bool   `help:"Throw warnings instead of errors when a dSYM file is found, rather than the expected dSYM directory"`
-	IgnoreMissingDwarf bool   `help:"Throw warnings instead of errors when a dSYM with missing DWARF data is found"`
-	Scheme             string `help:"The name of the Xcode options.Scheme used to build the application"`
-	ProjectRoot        string `help:"The path to strip from the beginning of source file names referenced in stacktraces on the BugSnag dashboard" type:"path"`
+type DsymShared struct {
+	IgnoreEmptyDsym    bool       `help:"Throw warnings instead of errors when a dSYM file is found, rather than the expected dSYM directory"`
+	IgnoreMissingDwarf bool       `help:"Throw warnings instead of errors when a dSYM with missing DWARF data is found"`
+	Configuration      string     `help:"The configuration used to build the application"`
+	Scheme             string     `help:"The name of the Xcode options.Scheme used to build the application"`
+	ProjectRoot        string     `help:"The path to strip from the beginning of source file names referenced in stacktraces on the BugSnag dashboard" type:"path"`
+	Plist              utils.Path `help:"The path to a .plist file from which to obtain build information" type:"path"`
+	XcodeProject       utils.Path `help:"The path to an Xcode project, workspace or containing directory from which to obtain build information" type:"path"`
 }
 
 type Js struct {
@@ -170,7 +174,7 @@ type CLI struct {
 		AndroidProguard    AndroidProguardMapping `cmd:"" help:"Process and upload Proguard/R8 mapping files for Android"`
 		DartSymbol         DartSymbol             `cmd:"" help:"Process and upload symbol files for Flutter" name:"dart"`
 		XcodeBuild         XcodeBuild             `cmd:"" help:"Upload dSYMs for iOS from a build"`
-		Dsym               XcodeBuild             `cmd:"" help:"(deprecated) Upload dSYMs for iOS"`
+		Dsym               Dsym                   `cmd:"" help:"(deprecated) Upload dSYMs for iOS"`
 		XcodeArchive       XcodeArchive           `cmd:"" help:"Upload dSYMs for iOS from a Xcarchive"`
 		Js                 Js                     `cmd:"" help:"Upload source maps for JavaScript"`
 		ReactNative        ReactNative            `cmd:"" help:"Upload source maps for React Native"`

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -132,7 +132,7 @@ type ReactNativeIosSpecific struct {
 	Plist         string     `help:"The path to a .plist file from which to obtain build information" type:"path"`
 	Scheme        string     `help:"The name of the Xcode options.Ios.Scheme used to build the application"`
 	XcodeProject  string     `help:"The path to an Xcode project, workspace or containing directory from which to obtain build information" type:"path"`
-	XcarchivePath utils.Path `help:"The path to the .xcarchive to process if it has been exported" type:"path"`
+	XcarchivePath utils.Path `help:"The path to the Xcode archive to process if it has been exported" type:"path"`
 }
 
 type ReactNativeIos struct {
@@ -175,7 +175,7 @@ type CLI struct {
 		DartSymbol         DartSymbol             `cmd:"" help:"Process and upload symbol files for Flutter" name:"dart"`
 		XcodeBuild         XcodeBuild             `cmd:"" help:"Upload dSYMs for iOS from a build"`
 		Dsym               Dsym                   `cmd:"" help:"(deprecated) Upload dSYMs for iOS"`
-		XcodeArchive       XcodeArchive           `cmd:"" help:"Upload dSYMs for iOS from a Xcarchive"`
+		XcodeArchive       XcodeArchive           `cmd:"" help:"Upload dSYMs for iOS from a Xcode archive"`
 		Js                 Js                     `cmd:"" help:"Upload source maps for JavaScript"`
 		ReactNative        ReactNative            `cmd:"" help:"Upload source maps for React Native"`
 		ReactNativeAndroid ReactNativeAndroid     `cmd:"" help:"Upload source maps for React Native Android"`

--- a/pkg/upload/dsym.go
+++ b/pkg/upload/dsym.go
@@ -1,0 +1,42 @@
+package upload
+
+import (
+	"github.com/bugsnag/bugsnag-cli/pkg/log"
+	"github.com/bugsnag/bugsnag-cli/pkg/options"
+)
+
+func ProcessDsym(globalOptions options.CLI, endpoint string, logger log.Logger) error {
+	dsymOptions := globalOptions.Upload.Dsym
+
+	logger.Info("Searching for dSYM files to upload")
+
+	globalOptions.Upload.XcodeArchive = options.XcodeArchive{
+		Path:   dsymOptions.Path,
+		Shared: dsymOptions.Shared,
+	}
+
+	// Attempt to process dSYMs from the Xcode archive
+	if err := ProcessXcodeArchive(globalOptions, endpoint, logger); err != nil {
+		if err.Error() == "No xcarchive found in specified paths" {
+			logger.Info("No dSYM files found in the xcarchive, searching in the build directory")
+		} else {
+			return err
+		}
+	} else {
+		logger.Info("dSYM files successfully uploaded from the xcarchive")
+		return nil
+	}
+
+	// Attempt to process dSYMs from the Xcode build directory
+	globalOptions.Upload.XcodeBuild = options.XcodeBuild{
+		Path:   dsymOptions.Path,
+		Shared: dsymOptions.Shared,
+	}
+
+	if err := ProcessXcodeBuild(globalOptions, endpoint, logger); err != nil {
+		return err
+	}
+
+	logger.Info("dSYM files successfully uploaded from the build directory")
+	return nil
+}

--- a/pkg/upload/dsym.go
+++ b/pkg/upload/dsym.go
@@ -10,10 +10,8 @@ func ProcessDsym(globalOptions options.CLI, endpoint string, logger log.Logger) 
 
 	logger.Info("Searching for dSYM files to upload")
 
-	globalOptions.Upload.XcodeArchive = options.XcodeArchive{
-		Path:   dsymOptions.Path,
-		Shared: dsymOptions.Shared,
-	}
+	// Convert dsymOptions to XcodeArchive directly
+	globalOptions.Upload.XcodeArchive = options.XcodeArchive(dsymOptions)
 
 	// Attempt to process dSYMs from the Xcode archive
 	if err := ProcessXcodeArchive(globalOptions, endpoint, logger); err != nil {
@@ -27,11 +25,8 @@ func ProcessDsym(globalOptions options.CLI, endpoint string, logger log.Logger) 
 		return nil
 	}
 
-	// Attempt to process dSYMs from the Xcode build directory
-	globalOptions.Upload.XcodeBuild = options.XcodeBuild{
-		Path:   dsymOptions.Path,
-		Shared: dsymOptions.Shared,
-	}
+	// Convert dsymOptions to XcodeBuild directly
+	globalOptions.Upload.XcodeBuild = options.XcodeBuild(dsymOptions)
 
 	if err := ProcessXcodeBuild(globalOptions, endpoint, logger); err != nil {
 		return err

--- a/pkg/upload/dsym.go
+++ b/pkg/upload/dsym.go
@@ -31,10 +31,7 @@ func ProcessDsym(globalOptions options.CLI, endpoint string, logger log.Logger) 
 	globalOptions.Upload.XcodeArchive = options.XcodeArchive(dsymOptions)
 
 	// Locate the Xcode archive (.xcarchive) path based on the provided options
-	xcarchivePath, err = ios.FindXcarchivePath(globalOptions, logger)
-	if err != nil {
-		return err // Return error if the archive path cannot be determined
-	}
+	xcarchivePath, _ = ios.FindXcarchivePath(globalOptions, logger)
 
 	// If no Xcode archive is found, return an error
 	if xcarchivePath != "" {

--- a/pkg/upload/react-native-ios.go
+++ b/pkg/upload/react-native-ios.go
@@ -82,15 +82,15 @@ func ProcessReactNativeIos(options options.CLI, endpoint string, logger log.Logg
 				xcodeArchivePath, err = ios.GetLatestXcodeArchiveForScheme(iosOptions.Ios.Scheme)
 
 				if err != nil {
-					return fmt.Errorf("error locating latest xcarchive from Xcode project (scheme: %s), please specify the archive path directly using --archive-path: %w", iosOptions.Ios.Scheme, err)
+					return fmt.Errorf("error locating latest Xcode archive from Xcode project (scheme: %s), please specify the xcarchive path directly using --xcarchive-path: %w", iosOptions.Ios.Scheme, err)
 				}
 			}
 
 		} else {
-			return fmt.Errorf("path should be an .xcarchive or the directory of your React Native project: %s", path)
+			return fmt.Errorf("path should be an Xcode archive or the directory of your React Native project: %s", path)
 		}
 
-		logger.Debug(fmt.Sprintf("Found Xcode Archive Path: %s", xcodeArchivePath))
+		logger.Debug(fmt.Sprintf("Found Xcode archive Path: %s", xcodeArchivePath))
 
 		// Attempt to parse information from the .xcworkspace file if values aren't provided on the command line
 		if iosOptions.ReactNative.Bundle == "" || (iosOptions.Ios.Plist == "" && (options.ApiKey == "" || iosOptions.ReactNative.VersionName == "" || iosOptions.Ios.BundleVersion == "")) {

--- a/pkg/upload/react-native.go
+++ b/pkg/upload/react-native.go
@@ -58,14 +58,13 @@ func ProcessReactNative(globalOptions options.CLI, endpoint string, logger log.L
 	// Process iOS dSYMs
 	logger.Info("Uploading iOS dSYMs")
 	globalOptions.Upload.XcodeBuild = options.XcodeBuild{
-		Path:        iosPath,
-		VersionName: reactNativeOptions.Shared.VersionName,
-		Shared: options.XcodeShared{
-			ProjectRoot: reactNativeOptions.ProjectRoot,
-			Scheme:      reactNativeOptions.IosSpecific.Scheme,
+		Path: iosPath,
+		Shared: options.DsymShared{
+			ProjectRoot:  reactNativeOptions.ProjectRoot,
+			Scheme:       reactNativeOptions.IosSpecific.Scheme,
+			Plist:        utils.Path(reactNativeOptions.IosSpecific.Plist),
+			XcodeProject: utils.Path(reactNativeOptions.IosSpecific.XcodeProject),
 		},
-		Plist:        utils.Path(reactNativeOptions.IosSpecific.Plist),
-		XcodeProject: utils.Path(reactNativeOptions.IosSpecific.XcodeProject),
 	}
 	if err := ProcessXcodeBuild(globalOptions, endpoint, logger); err != nil {
 		return fmt.Errorf("failed to upload iOS dSYMs: %w", err)

--- a/pkg/upload/xcarhive.go
+++ b/pkg/upload/xcarhive.go
@@ -1,0 +1,66 @@
+package upload
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/bugsnag/bugsnag-cli/pkg/ios"
+	"github.com/bugsnag/bugsnag-cli/pkg/log"
+	"github.com/bugsnag/bugsnag-cli/pkg/options"
+)
+
+// ProcessDsymUpload locates and uploads dSYM files from an Xcode archive to a Bugsnag server.
+//
+// Parameters:
+// - xcarchivePath: The path to the Xcode archive (.xcarchive) containing dSYM files.
+// - endpoint: The server endpoint for uploading dSYM files.
+// - opts: CLI options containing upload configuration.
+// - logger: Logger instance for logging messages during processing.
+//
+// Returns:
+// - The number of dSYM files found and uploaded.
+// - An error if any part of the process fails, otherwise nil.
+func ProcessDsymUpload(xcarchivePath string, endpoint string, opts options.CLI, logger log.Logger) (int, error) {
+	// Locate dSYM files within the specified Xcode archive
+	dwarfInfo, tempDir, err := ios.FindDsymsInPath(
+		xcarchivePath,
+		opts.Upload.XcodeArchive.Shared.IgnoreEmptyDsym,
+		opts.Upload.XcodeArchive.Shared.IgnoreMissingDwarf,
+		logger,
+	)
+	// Ensure temporary directory is removed after execution
+	defer os.RemoveAll(tempDir)
+
+	if err != nil {
+		return 0, fmt.Errorf("error locating dSYM files: %w", err)
+	}
+
+	// If no dSYM files are found, return without an error
+	if len(dwarfInfo) == 0 {
+		return 0, nil
+	}
+
+	// Log the number of dSYM files found
+	logger.Info(fmt.Sprintf("Found %d dSYM files in %s", len(dwarfInfo), xcarchivePath))
+
+	// Set the project root if not already specified
+	opts.Upload.XcodeArchive.Shared.ProjectRoot = ios.GetDefaultProjectRoot(opts.Upload.XcodeArchive.Path[0], opts.Upload.XcodeArchive.Shared.ProjectRoot)
+	logger.Info(fmt.Sprintf("Setting `--project-root`: %s", opts.Upload.XcodeArchive.Shared.ProjectRoot))
+
+	// Process and upload the located dSYM files
+	err = ios.ProcessDsymUpload(
+		filepath.Join(xcarchivePath, "Info.plist"),
+		endpoint,
+		opts.Upload.XcodeArchive.Shared.ProjectRoot,
+		opts,
+		dwarfInfo,
+		logger,
+	)
+	if err != nil {
+		return len(dwarfInfo), fmt.Errorf("error uploading dSYM files: %w", err)
+	}
+
+	// Return the number of successfully uploaded dSYM files
+	return len(dwarfInfo), nil
+}

--- a/pkg/upload/xcode-archive.go
+++ b/pkg/upload/xcode-archive.go
@@ -5,13 +5,10 @@ import (
 	"github.com/bugsnag/bugsnag-cli/pkg/ios"
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
 	"github.com/bugsnag/bugsnag-cli/pkg/options"
-	"github.com/bugsnag/bugsnag-cli/pkg/utils"
-	"os"
-	"path/filepath"
 )
 
-// ProcessXcodeArchive processes an xcarchive, locating its dSYM files and uploading them
-// to a Bugsnag server.
+// ProcessXcodeArchive locates a Xcode archive (xcarchive), extracts its dSYM files,
+// and uploads them to a Bugsnag server.
 //
 // Parameters:
 // - options: CLI options provided by the user, including xcarchive settings.
@@ -21,75 +18,30 @@ import (
 // Returns:
 // - An error if any part of the process fails, otherwise nil.
 func ProcessXcodeArchive(options options.CLI, endpoint string, logger log.Logger) error {
-	xcarchiveOptions := options.Upload.XcodeArchive
 	var (
 		xcarchivePath string
-		plistPath     string
-		dwarfInfo     []*ios.DwarfInfo
-		tempDirs      []string
-		tempDir       string
 		err           error
 	)
 
-	// Ensure temporary directories are cleaned up after execution
-	defer func() {
-		for _, tempDir := range tempDirs {
-			_ = os.RemoveAll(tempDir)
-		}
-	}()
-
-	// Search for an xcarchive in the specified paths
-	for _, path := range xcarchiveOptions.Path {
-		if filepath.Ext(path) == ".xcarchive" {
-			xcarchivePath = path
-		} else if utils.IsDir(path) {
-			logger.Info(fmt.Sprintf("Searching for xcarchives in %s", path))
-			if ios.IsPathAnXcodeProjectOrWorkspace(path) {
-				xcarchiveOptions.Shared.ProjectRoot = ios.GetDefaultProjectRoot(path, xcarchiveOptions.Shared.ProjectRoot)
-				logger.Info(fmt.Sprintf("Setting `--project-root` from Xcode project settings: %s", xcarchiveOptions.Shared.ProjectRoot))
-
-				if xcarchiveOptions.Shared.Scheme == "" {
-					xcarchiveOptions.Shared.Scheme, err = ios.GetDefaultScheme(path)
-					if err != nil {
-						return fmt.Errorf("Error determining default scheme: %w", err)
-					}
-				}
-
-				xcarchivePath, err = ios.GetLatestXcodeArchiveForScheme(xcarchiveOptions.Shared.Scheme)
-				if err != nil {
-					logger.Debug(fmt.Sprintf("Error locating latest xcarchive: %s", err))
-				}
-			}
-		}
-
-		if xcarchivePath == "" {
-			return fmt.Errorf("No xcarchive found in specified paths")
-		}
-
-		logger.Info(fmt.Sprintf("Found xcarchive at %s", xcarchivePath))
-
-		// Locate and process dSYM files in the xcarchive
-		dwarfInfo, tempDir, err = ios.FindDsymsInPath(
-			xcarchivePath,
-			xcarchiveOptions.Shared.IgnoreEmptyDsym,
-			xcarchiveOptions.Shared.IgnoreMissingDwarf,
-			logger,
-		)
-		tempDirs = append(tempDirs, tempDir)
-		if err != nil {
-			return fmt.Errorf("Error locating dSYM files: %w", err)
-		}
-		if len(dwarfInfo) == 0 {
-			return fmt.Errorf("No dSYM files found in: %s", xcarchivePath)
-		}
-		logger.Info(fmt.Sprintf("Found %d dSYM files in %s", len(dwarfInfo), xcarchivePath))
-
-		// Extract API key from Info.plist if available
-		plistPath = filepath.Join(xcarchivePath, "Info.plist")
-		err = ios.ProcessDsymUpload(plistPath, endpoint, xcarchiveOptions.Shared.ProjectRoot, options, dwarfInfo, logger)
-		if err != nil {
-			return fmt.Errorf("Error uploading dSYM files: %w", err)
-		}
+	// Locate the Xcode archive (.xcarchive) path based on the provided options
+	xcarchivePath, err = ios.FindXcarchivePath(options, logger)
+	if err != nil {
+		return err // Return error if the archive path cannot be determined
 	}
-	return nil
+
+	// If no Xcode archive is found, return an error
+	if xcarchivePath == "" {
+		return fmt.Errorf("no Xcode archive found in specified paths")
+	}
+
+	// Log the located Xcode archive path
+	logger.Info(fmt.Sprintf("Found Xcode archive at %s", xcarchivePath))
+
+	// Process and upload the dSYM files extracted from the Xcode archive
+	_, err = ProcessDsymUpload(xcarchivePath, endpoint, options, logger)
+	if err != nil {
+		return err // Return error if the upload fails
+	}
+
+	return nil // Successfully processed and uploaded dSYM files
 }

--- a/pkg/upload/xcode-archive.go
+++ b/pkg/upload/xcode-archive.go
@@ -57,10 +57,8 @@ func ProcessXcodeArchive(options options.CLI, endpoint string, logger log.Logger
 
 				xcarchivePath, err = ios.GetLatestXcodeArchiveForScheme(xcarchiveOptions.Shared.Scheme)
 				if err != nil {
-					return fmt.Errorf("Error locating latest xcarchive: %w", err)
+					logger.Debug(fmt.Sprintf("Error locating latest xcarchive: %s", err))
 				}
-			} else {
-				return fmt.Errorf("No xcarchive found in %s", path)
 			}
 		}
 

--- a/pkg/upload/xcode-build.go
+++ b/pkg/upload/xcode-build.go
@@ -42,7 +42,7 @@ func ProcessXcodeBuild(options options.CLI, endpoint string, logger log.Logger) 
 	// Process paths provided in the CLI options
 	for _, path := range xcodeBuildOptions.Path {
 		if filepath.Ext(path) == ".xcarchive" {
-			logger.Warn(fmt.Sprintf("The specified path %s is an xcarchive. Please use the `xcode-archive` command instead as this functionality will be deprecated in future releases.", path))
+			logger.Warn(fmt.Sprintf("The specified path %s is an Xcode archive. Please use the `xcode-archive` command instead as this functionality will be deprecated in future releases.", path))
 		}
 
 		if ios.IsPathAnXcodeProjectOrWorkspace(path) {


### PR DESCRIPTION
## Goal

Update the dSYM command to check for an Xcode archive first and then for a build in a given directory. 

Example:
`bugsnag-cli upload dsym /path/to/xcode/project`

Output for a build
```
[INFO] Searching for dSYM files to upload
[INFO] Searching for xcarchives in /path/to/xcode/project
[INFO] Setting `--project-root` from Xcode project settings: /path/to/xcode/project
[INFO] No dSYM files found in the xcarchive, searching in the build directory
[INFO] Setting `--project-root` from Xcode project settings: /path/to/xcode/project
[INFO] Uploading 6973FCB0-13E7-3627-A415-82B0EDCCC08F to http://localhost:9339/dsym
[INFO] Uploaded 6973FCB0-13E7-3627-A415-82B0EDCCC08F
[INFO] dSYM files successfully uploaded from the build directory
```

Output for an archive
```
[INFO] Searching for dSYM files to upload
[INFO] Searching for xcarchives in /path/to/xcode/project
[INFO] Setting `--project-root` from Xcode project settings: /path/to/xcode/project
[INFO] Found xcarchive at /path/to/xcode/archive/2025-03-17/dSYM-Example 17-03-2025, 13.39.xcarchive
[INFO] Found 1 dSYM files in /path/to/xcode/archive-03-17/dSYM-Example 17-03-2025, 13.39.xcarchive
[INFO] Uploading 31F205F7-ED73-3117-B943-42AF9DB57E5B to http://localhost:9339/dsym
[INFO] Uploaded 31F205F7-ED73-3117-B943-42AF9DB57E5B
[INFO] dSYM files successfully uploaded from the xcarchive
```

## Testing

CI Tests have been updated to cover the new dSYM command