### PR TITLE
Update react-native-ios.go

### DIFF
--- a/pkg/upload/react-native-ios.go
+++ b/pkg/upload/react-native-ios.go
@@ -70,7 +70,12 @@ func ProcessReactNativeIos(options options.CLI, endpoint string, logger log.Logg
 				}
 
 				if iosOptions.Ios.Scheme != "" {
-					buildSettings, err = ios.GetXcodeBuildSettings(iosOptions.Ios.XcodeProject, iosOptions.Ios.Scheme, "")
+					buildType := "Release"
+					if iosOptions.ReactNative.Dev {
+						buildType = "Debug"
+					}
+					
+					buildSettings, err = ios.GetXcodeBuildSettings(iosOptions.Ios.XcodeProject, iosOptions.Ios.Scheme, buildType)
 					if err != nil {
 						logger.Warn(err.Error())
 					}


### PR DESCRIPTION
## Goal
When a custom scheme is passed, it will currently pickup the "Debug" build settings. This passes the configuration based on the `dev` flag
