### PR TITLE
[HOTFIX] Update how the `--project-root` is set for the `upload js` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 - Update the path for AndroidManifest.xml in newer versions of RN [#176](https://github.com/bugsnag/bugsnag-cli/pull/176)
-- Update how the `--projectRoot` is worked out for the `upload js` command [#187](https://github.com/bugsnag/bugsnag-cli/pull/187)
+- Update how the `--project-root` is worked out for the `upload js` command [#187](https://github.com/bugsnag/bugsnag-cli/pull/187)
 
 ## [2.9.2] - 2025-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - Update the path for AndroidManifest.xml in newer versions of RN [#176](https://github.com/bugsnag/bugsnag-cli/pull/176)
+- Update how the `--projectRoot` is worked out for the `upload js` command [#187](https://github.com/bugsnag/bugsnag-cli/pull/187)
 
 ## [2.9.2] - 2025-02-11
 

--- a/features/js/js-webpack4.feature
+++ b/features/js/js-webpack4.feature
@@ -82,14 +82,13 @@ Feature: Webpack 4 js Integration Tests
     When I make the "features/base-fixtures/js-webpack4"
     And I wait for the build to succeed
 
-    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --bundle-url=example.com --project-root=features/base-fixtures/js-webpack4 features/base-fixtures/js-webpack4/dist/main.js.map
+    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com features/base-fixtures/js-webpack4/dist/
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the JS Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
     And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
     And the sourcemap payload field "appVersion" equals "1.2.3"
-    And the sourcemap payload field "minifiedUrl" equals "example.com"
-    And the sourcemap payload field "sourceMap" is valid json
+    And the sourcemap payload field "minifiedUrl" equals "example.com/main.js"
     And the sourcemap payload field "minifiedFile" is not empty
     And the sourcemap payload field "projectRoot" ends with "features/base-fixtures/js-webpack4"
     And the sourcemap payload field "overwrite" equals "true"

--- a/features/js/js-webpack4.feature
+++ b/features/js/js-webpack4.feature
@@ -62,7 +62,7 @@ Feature: Webpack 4 js Integration Tests
     And the sourcemap payload field "minifiedUrl" equals "example.com/main.js"
     And the sourcemap payload field "sourceMap" is valid json
     And the sourcemap payload field "minifiedFile" is not empty
-    And the sourcemap payload field "projectRoot" ends with "bugsnag-cli"
+    And the sourcemap payload field "projectRoot" ends with "js-webpack4"
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Base URL correctly appends the path

--- a/features/js/js-webpack5.feature
+++ b/features/js/js-webpack5.feature
@@ -82,13 +82,13 @@ Feature: Webpack 5 js Integration Tests
     When I make the "features/base-fixtures/js-webpack5"
     And I wait for the build to succeed
 
-    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --bundle-url=example.com --project-root=features/base-fixtures/js-webpack5 features/base-fixtures/js-webpack5/dist/main.js.map
+    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com features/base-fixtures/js-webpack5/dist/
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the JS Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
     And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
     And the sourcemap payload field "appVersion" equals "1.2.3"
-    And the sourcemap payload field "minifiedUrl" equals "example.com"
+    And the sourcemap payload field "minifiedUrl" equals "example.com/main.js"
     And the sourcemap payload field "sourceMap" is valid json
     And the sourcemap payload field "minifiedFile" is not empty
     And the sourcemap payload field "projectRoot" ends with "features/base-fixtures/js-webpack5"

--- a/features/js/js-webpack5.feature
+++ b/features/js/js-webpack5.feature
@@ -62,7 +62,7 @@ Feature: Webpack 5 js Integration Tests
     And the sourcemap payload field "minifiedUrl" equals "example.com/main.js"
     And the sourcemap payload field "sourceMap" is valid json
     And the sourcemap payload field "minifiedFile" is not empty
-    And the sourcemap payload field "projectRoot" ends with "bugsnag-cli"
+    And the sourcemap payload field "projectRoot" ends with "js-webpack5"
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Base URL correctly appends the path

--- a/pkg/upload/js.go
+++ b/pkg/upload/js.go
@@ -38,13 +38,7 @@ func resolveProjectRoot(projectRoot, path string) string {
 	}
 
 	// Workout how many segments to go up
-	segments := 0
-	for _, segment := range strings.Split(checkPath, string(filepath.Separator)) {
-		if segment == "node_modules" {
-			break
-		}
-		segments++
-	}
+	segments := len(strings.Split(checkPath, string(filepath.Separator)))
 
 	for i := 0; i < segments; i++ {
 		if hasProjectRootFile(checkPath) {

--- a/pkg/upload/js.go
+++ b/pkg/upload/js.go
@@ -16,16 +16,71 @@ import (
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
 )
 
-// Resolve the project if it isn't specified using the current working directory
-func resolveProjectRoot(projectRoot string, path string) string {
+// resolveProjectRoot determines the project root directory.
+// If a project root is provided, it returns that value.
+// Otherwise, it defaults to searching up the directory tree.
+//
+// Parameters:
+// - projectRoot: A user-specified project root directory (can be empty).
+// - path: A fallback path in case retrieving the working directory fails.
+//
+// Returns:
+// - The resolved project root directory.
+func resolveProjectRoot(projectRoot, path string) string {
 	if projectRoot != "" {
 		return projectRoot
 	}
-	workingDirectory, err := os.Getwd()
+
+	// Get absolute path
+	checkPath, err := filepath.Abs(path)
 	if err != nil {
 		return path
 	}
-	return workingDirectory
+
+	// Workout how many segments to go up
+	segments := 0
+	for _, segment := range strings.Split(checkPath, string(filepath.Separator)) {
+		if segment == "node_modules" {
+			break
+		}
+		segments++
+	}
+
+	for i := 0; i < segments; i++ {
+		if hasProjectRootFile(checkPath) {
+			return checkPath
+		}
+		parent := filepath.Dir(checkPath)
+		if parent == checkPath { // Stop if we reach the root directory
+			break
+		}
+		checkPath = parent
+	}
+
+	return checkPath
+}
+
+// HasProjectRootFile determines whether the specified directory contains
+// any of the common project root files, indicating it is likely the root of a project.
+//
+// The function checks for the existence of the following files:
+// - "package.json"
+// - "yarn.lock"
+// - "lerna.json"
+//
+// Parameters:
+// - dir: The directory path to check.
+//
+// Returns:
+// - bool: Returns true if any of the project root files are found in the directory; otherwise, false.
+func hasProjectRootFile(dir string) bool {
+	projectFiles := []string{"package.json", "yarn.lock", "lerna.json"}
+	for _, file := range projectFiles {
+		if utils.FileExists(filepath.Join(dir, file)) {
+			return true
+		}
+	}
+	return false
 }
 
 // Attempt to parse information from the package.json file if values aren't provided on the command line


### PR DESCRIPTION
## Goal

Currently, we set the `--project-root` for the `upload js` command based on the directory where the `bugsnag-cli` command is run. This is fine unless you're running it from a directory outside your project. 

Instead, we want to break up the path given to the command and work out what to set the `--project-root` to based on where it can find a relative project file.

For example:

```
/User/Downloads/bugsnag-cli upload js /Path/To/Project
```

Will set the `--project-root` to `/Path/To/Project` rather than `/User/Downloads`

And:

```
/User/Downloads/bugsnag-cli upload js /Path/To/Project/Build/Folder
```

Will set the `--project-root` to `/Path/To/Project` rather than `/User/Downloads` as this is where it would find a relative project file (e.g. package.json/lerna.json/yarn.lock)


## Testing

I've updated a couple of the JS features to properly test this and so that it can be covered by CI runs 