### PR TITLE
[HOTFIX] Find source path relative to the sourcemap path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 - Update the path for AndroidManifest.xml in newer versions of RN [#176](https://github.com/bugsnag/bugsnag-cli/pull/176)
 - Update how the `--project-root` is worked out for the `upload js` command [#187](https://github.com/bugsnag/bugsnag-cli/pull/187)
+- Ensure we resolve the source path relative to the source map path for the JS command [#188](https://github.com/bugsnag/bugsnag-cli/pull/188)
 
 ## [2.9.2] - 2025-02-11
 

--- a/pkg/upload/js.go
+++ b/pkg/upload/js.go
@@ -170,7 +170,7 @@ func ReadSourceMap(path string, logger log.Logger) (map[string]interface{}, erro
 }
 
 // Based on the source map specification https://bit.ly/sourcemap. Returns if the source map was modified.
-func addSourcesContent(section map[string]interface{}, sourceMapPath string, projectRoot string, logger log.Logger) bool {
+func addSourcesContent(section map[string]interface{}, sourceMapPath string, logger log.Logger) bool {
 	untypedSources, hasSources := section["sources"]
 	if !hasSources {
 		logger.Warn(fmt.Sprintf("Cannot find the required sources field in the source map at %s", sourceMapPath))
@@ -247,13 +247,13 @@ func AddSources(sourceMapContents map[string]interface{}, sourceMapPath string, 
 		if sources, ok := sections.([]map[string]interface{}); ok {
 			anyModified := false
 			for _, section := range sources {
-				modified := addSourcesContent(section, sourceMapPath, projectRoot, logger)
+				modified := addSourcesContent(section, sourceMapPath, logger)
 				anyModified = modified || anyModified
 			}
 			return anyModified
 		}
 	} else {
-		return addSourcesContent(sourceMapContents, sourceMapPath, projectRoot, logger)
+		return addSourcesContent(sourceMapContents, sourceMapPath, logger)
 	}
 	return false
 }

--- a/pkg/upload/js.go
+++ b/pkg/upload/js.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -222,8 +221,9 @@ func addSourcesContent(section map[string]interface{}, sourceMapPath string, pro
 				sourcePath = sourcePath[:questionMark-1]
 			}
 		}
-		if !path.IsAbs(sourcePath) {
-			sourcePath = path.Join(projectRoot, sourcePath)
+		if !filepath.IsAbs(sourcePath) {
+			// Resolve the path relative to the source map
+			sourcePath, _ = filepath.Abs(filepath.Join(filepath.Dir(sourceMapPath), sourcePath))
 		}
 		logger.Debug(fmt.Sprintf("Attempting to read the source %s.", sourcePath))
 		content, err := os.ReadFile(sourcePath)

--- a/pkg/upload/js.go
+++ b/pkg/upload/js.go
@@ -241,7 +241,7 @@ func addSourcesContent(section map[string]interface{}, sourceMapPath string, log
 }
 
 // If the source map doesn't have sourcesContent then attempt to add it. Returns true if a modifcation was performed.
-func AddSources(sourceMapContents map[string]interface{}, sourceMapPath string, projectRoot string, logger log.Logger) bool {
+func AddSources(sourceMapContents map[string]interface{}, sourceMapPath string, logger log.Logger) bool {
 	// Sources may be in several sections. See https://bit.ly/sourcemap.
 	if sections, exists := sourceMapContents["sections"]; exists {
 		if sources, ok := sections.([]map[string]interface{}); ok {
@@ -289,7 +289,7 @@ func uploadSingleSourceMap(options options.CLI, jsOptions options.Js, endpoint s
 
 	var sourceMapFile server.FileField
 
-	sourceMapModified := AddSources(sourceMapContents, jsOptions.SourceMap, jsOptions.ProjectRoot, logger)
+	sourceMapModified := AddSources(sourceMapContents, jsOptions.SourceMap, logger)
 	if sourceMapModified {
 		logger.Info(fmt.Sprintf("Added sources content to source map from %s", jsOptions.SourceMap))
 		encodedSourceMap, err := json.Marshal(sourceMapContents)


### PR DESCRIPTION
## Goal

Remove the `Path` package and replace it with the `filepath` package for consistency throughout the repo.

Currently, If the `sourcePath` is an absolute path we attempt to join it with the  `projectRoot`. This would sometimes result in an incorrect path and we'd be unable to read the source file.

Instead, we should find the `sourcePath` relative to the `sourceMapPath` if the `sourcePath` is an absolute path.

## Testing

Covered by CI