### PR TITLE
Remove `--fail-on-upload-error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Ensure we resolve the source path relative to the source map path for the JS command [#188](https://github.com/bugsnag/bugsnag-cli/pull/188)
 - Preserve folder structure or the bundle URL during upload for the JS command [#189](https://github.com/bugsnag/bugsnag-cli/pull/189)
 
+### Removed
+- Remove the deprecated option `--fail-on-upload-error` [#191](https://github.com/bugsnag/bugsnag-cli/pull/191)
+
 ## [2.9.2] - 2025-02-11
 
 ### Fixed

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,14 @@
 # Upgrading Guide
 
+## v2.x to v3.x
+
+The following options have been removed from the CLI:
+
+| Command                       | Removed                  | Replacement        |
+|-------------------------------|--------------------------| ------------------ |
+| `upload`                       | `--fail-on-upload-error` |   | 
+
+
 ## v1.x to v2.x
 
 ### Deprecated options

--- a/main.go
+++ b/main.go
@@ -49,10 +49,6 @@ func main() {
 		logger.Info("Performing dry run - no data will be sent to BugSnag")
 	}
 
-	if commands.FailOnUploadError {
-		logger.Warn("The `--fail-on-upload-error` flag is deprecated and will be removed in a future release. All commands now fail if the upload is unsuccessful.")
-	}
-
 	switch kongCtx.Command() {
 
 	case "upload all <path>":

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -6,13 +6,12 @@ import (
 
 // Global CLI options
 type Globals struct {
-	ApiKey            string            `help:"The BugSnag API key for the application"`
-	DryRun            bool              `help:"Performs a dry-run of the command without sending any information to BugSnag"`
-	FailOnUploadError bool              `help:"Stops the upload when a file fails to upload successfully" default:"false"`
-	LogLevel          string            `help:"Sets the level of logging to debug, info, warn or fatal" default:"info"`
-	Port              int               `help:"The port number for the BugSnag upload server" default:"443"`
-	Verbose           bool              `name:"verbose" help:"Sets the level of the logging to its highest."`
-	Version           utils.VersionFlag `name:"version" help:"Prints the version information for this CLI"`
+	ApiKey   string            `help:"The BugSnag API key for the application"`
+	DryRun   bool              `help:"Performs a dry-run of the command without sending any information to BugSnag"`
+	LogLevel string            `help:"Sets the level of logging to debug, info, warn or fatal" default:"info"`
+	Port     int               `help:"The port number for the BugSnag upload server" default:"443"`
+	Verbose  bool              `name:"verbose" help:"Sets the level of the logging to its highest."`
+	Version  utils.VersionFlag `name:"version" help:"Prints the version information for this CLI"`
 }
 
 type DiscoverAndUploadAny struct {


### PR DESCRIPTION
## Goal

Remove the deprecated `--fail-on-upload-error` option from the CLI

## Testing

Covered by CI