### PR TITLE
[PLAT-14102] Update tests and buildkite for multiagent

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,7 +40,7 @@ steps:
     commands:
       - bundle install
       - chmod +x bin/arm64-macos-bugsnag-cli
-      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) --document-server-port=$((MAZE_RUNNER_PORT + 1)) features/cli
+      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) features/cli
     plugins:
       artifacts#v1.5.0:
         download:
@@ -53,7 +53,7 @@ steps:
     commands:
       - bundle install
       - chmod +x bin/arm64-macos-bugsnag-cli
-      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) --document-server-port=$((MAZE_RUNNER_PORT + 1)) features/android
+      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) features/android
     env:
       JAVA_VERSION: 17
     plugins:
@@ -68,7 +68,7 @@ steps:
     commands:
       - bundle install
       - chmod +x bin/arm64-macos-bugsnag-cli
-      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) --document-server-port=$((MAZE_RUNNER_PORT + 1)) features/dart
+      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) features/dart
     env:
       FLUTTER_BIN: "/opt/flutter/3.19.0/bin/flutter"
     plugins:
@@ -85,7 +85,7 @@ steps:
     commands:
       - bundle install
       - chmod +x bin/arm64-macos-bugsnag-cli
-      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) --document-server-port=$((MAZE_RUNNER_PORT + 1)) features/xcode
+      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) features/xcode
     plugins:
       artifacts#v1.5.0:
         download:
@@ -98,7 +98,7 @@ steps:
     commands:
       - chmod +x bin/arm64-macos-bugsnag-cli
       - bundle install
-      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) --document-server-port=$((MAZE_RUNNER_PORT + 1)) features/js
+      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) features/js
     plugins:
       artifacts#v1.5.0:
         download:
@@ -110,10 +110,12 @@ steps:
     depends_on: build
     env:
       UNITY_VERSION: 6000.0.36f1
+    agents:
+      queue: macos-14-isolated
     commands:
       - chmod +x bin/arm64-macos-bugsnag-cli
       - bundle install
-      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) --document-server-port=$((MAZE_RUNNER_PORT + 1)) features/unity-android
+      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) features/unity-android
     plugins:
       artifacts#v1.5.0:
         download:
@@ -126,7 +128,7 @@ steps:
     commands:
       - chmod +x bin/arm64-macos-bugsnag-cli
       - bundle install
-      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) --document-server-port=$((MAZE_RUNNER_PORT + 1)) features/breakpad
+      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) features/breakpad
     plugins:
       artifacts#v1.5.0:
         download:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,7 +40,7 @@ steps:
     commands:
       - bundle install
       - chmod +x bin/arm64-macos-bugsnag-cli
-      - bundle exec maze-runner features/cli
+      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) --document-server-port=$((MAZE_RUNNER_PORT + 1)) features/cli
     plugins:
       artifacts#v1.5.0:
         download:
@@ -53,7 +53,7 @@ steps:
     commands:
       - bundle install
       - chmod +x bin/arm64-macos-bugsnag-cli
-      - bundle exec maze-runner features/android
+      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) --document-server-port=$((MAZE_RUNNER_PORT + 1)) features/android
     env:
       JAVA_VERSION: 17
     plugins:
@@ -68,7 +68,7 @@ steps:
     commands:
       - bundle install
       - chmod +x bin/arm64-macos-bugsnag-cli
-      - bundle exec maze-runner features/dart
+      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) --document-server-port=$((MAZE_RUNNER_PORT + 1)) features/dart
     env:
       FLUTTER_BIN: "/opt/flutter/3.19.0/bin/flutter"
     plugins:
@@ -85,7 +85,7 @@ steps:
     commands:
       - bundle install
       - chmod +x bin/arm64-macos-bugsnag-cli
-      - bundle exec maze-runner features/xcode
+      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) --document-server-port=$((MAZE_RUNNER_PORT + 1)) features/xcode
     plugins:
       artifacts#v1.5.0:
         download:
@@ -98,7 +98,7 @@ steps:
     commands:
       - chmod +x bin/arm64-macos-bugsnag-cli
       - bundle install
-      - bundle exec maze-runner features/js
+      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) --document-server-port=$((MAZE_RUNNER_PORT + 1)) features/js
     plugins:
       artifacts#v1.5.0:
         download:
@@ -113,7 +113,7 @@ steps:
     commands:
       - chmod +x bin/arm64-macos-bugsnag-cli
       - bundle install
-      - bundle exec maze-runner features/unity-android
+      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) --document-server-port=$((MAZE_RUNNER_PORT + 1)) features/unity-android
     plugins:
       artifacts#v1.5.0:
         download:
@@ -126,7 +126,7 @@ steps:
     commands:
       - chmod +x bin/arm64-macos-bugsnag-cli
       - bundle install
-      - bundle exec maze-runner features/breakpad
+      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) --document-server-port=$((MAZE_RUNNER_PORT + 1)) features/breakpad
     plugins:
       artifacts#v1.5.0:
         download:

--- a/.buildkite/react-native/android.pipeline.yml
+++ b/.buildkite/react-native/android.pipeline.yml
@@ -14,7 +14,7 @@ steps:
     commands:
       - "chmod +x bin/arm64-macos-bugsnag-cli"
       - "bundle install"
-      - "bundle exec maze-runner features/react-native/android.feature"
+      - "bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) --document-server-port=$((MAZE_RUNNER_PORT + 1)) features/react-native/android.feature"
     matrix:
       - "0.70"
       - "0.73"

--- a/.buildkite/react-native/ios.pipeline.yml
+++ b/.buildkite/react-native/ios.pipeline.yml
@@ -14,7 +14,7 @@ steps:
     commands:
       - "chmod +x bin/arm64-macos-bugsnag-cli"
       - "bundle install"
-      - "bundle exec maze-runner features/react-native/ios.feature"
+      - "bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) --document-server-port=$((MAZE_RUNNER_PORT + 1)) features/react-native/ios.feature"
     matrix:
       - "0.70"
       - "0.73"

--- a/features/Unity-Android/unity.feature
+++ b/features/Unity-Android/unity.feature
@@ -3,7 +3,7 @@ Feature: Unity Android integration tests
     Given I build the Unity Android example project
     And I wait for the Unity symbols to generate
 
-    When I run bugsnag-cli with upload unity-android --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite platforms-examples/Unity/
+    When I run bugsnag-cli with upload unity-android --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite platforms-examples/Unity/
     Then I wait to receive 5 sourcemaps
     Then the sourcemap is valid for the Android Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -18,7 +18,7 @@ Feature: Unity Android integration tests
     And I wait for the Unity symbols to generate
 
     Given I set the NDK path to the Unity bundled version
-    When I run bugsnag-cli with upload unity-android --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite platforms-examples/Unity/
+    When I run bugsnag-cli with upload unity-android --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite platforms-examples/Unity/
     Then I wait to receive 5 sourcemaps
     Then the sourcemap is valid for the Android Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -33,7 +33,7 @@ Feature: Unity Android integration tests
     Given I build the Unity Android example project
     And I wait for the Unity symbols to generate
 
-    When I run bugsnag-cli with upload unity-android --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite  --aab-path platforms-examples/Unity/UnityExample.aab platforms-examples/Unity/
+    When I run bugsnag-cli with upload unity-android --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite  --aab-path platforms-examples/Unity/UnityExample.aab platforms-examples/Unity/
     Then I wait to receive 5 sourcemaps
     Then the sourcemap is valid for the Android Build API
     Then the sourcemaps Content-Type header is valid multipart form-data

--- a/features/android/android-aab.feature
+++ b/features/android/android-aab.feature
@@ -1,7 +1,7 @@
 Feature: Android AAB Integration Test
 
   Scenario: Uploading Android AAB file
-    When I run bugsnag-cli with upload android-aab --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/aab/app-release.aab
+    When I run bugsnag-cli with upload android-aab --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/aab/app-release.aab
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the Android Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -11,7 +11,7 @@ Feature: Android AAB Integration Test
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Uploading Android AAB file with --verbose
-    When I run bugsnag-cli with upload android-aab --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/aab/app-release.aab --verbose
+    When I run bugsnag-cli with upload android-aab --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/aab/app-release.aab --verbose
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the Android Build API
     And "f3112c3dbdd73ae5dee677e407af196f101e97f5" should be used as "build ID"
@@ -22,7 +22,7 @@ Feature: Android AAB Integration Test
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Uploading Android AAB file with Dexguard
-    When I run bugsnag-cli with upload android-aab --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/aab/app-release-dexguard.aab
+    When I run bugsnag-cli with upload android-aab --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/aab/app-release-dexguard.aab
     And I wait to receive 5 sourcemaps
     Then the sourcemap is valid for the Android Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -32,7 +32,7 @@ Feature: Android AAB Integration Test
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Uploading Android AAB file with Dexguard with --verbose
-    When I run bugsnag-cli with upload android-aab --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/aab/app-release-dexguard.aab --verbose
+    When I run bugsnag-cli with upload android-aab --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/aab/app-release-dexguard.aab --verbose
     And I wait to receive 5 sourcemaps
     Then the sourcemap is valid for the Android Build API
     And "fb0d77a7-5df2-4f47-a823-b011f89a2b70" should be used as "build ID"
@@ -46,7 +46,7 @@ Feature: Android AAB Integration Test
     When I make the "features/base-fixtures/android"
     And I wait for the build to succeed
 
-    When I run bugsnag-cli with upload android-aab --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/base-fixtures/android/app/build/outputs/bundle/release/app-release.aab
+    When I run bugsnag-cli with upload android-aab --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/base-fixtures/android/app/build/outputs/bundle/release/app-release.aab
     And I wait to receive 5 sourcemaps
     Then the sourcemap is valid for the Android Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -59,7 +59,7 @@ Feature: Android AAB Integration Test
     When I make the "features/base-fixtures/android"
     And I wait for the build to succeed
 
-    When I run bugsnag-cli with upload android-aab --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/base-fixtures/android/app/build/outputs/bundle/release/app-release.aab --verbose
+    When I run bugsnag-cli with upload android-aab --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/base-fixtures/android/app/build/outputs/bundle/release/app-release.aab --verbose
     And I wait to receive 5 sourcemaps
     Then the sourcemap is valid for the Android Build API
     And "f88f420ede59cd6695cea71aa0c7345eccd594cb" should be used as "build ID"
@@ -70,7 +70,7 @@ Feature: Android AAB Integration Test
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Uploading Android AAB file when command is run from project root
-    When I run bugsnag-cli with upload android-aab --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/ --verbose
+    When I run bugsnag-cli with upload android-aab --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/ --verbose
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the Android Build API
     And "f3112c3dbdd73ae5dee677e407af196f101e97f5" should be used as "build ID"
@@ -81,7 +81,7 @@ Feature: Android AAB Integration Test
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Uploading Android AAB file when command is run from within app directory
-    When I run bugsnag-cli with upload android-aab --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/app/ --verbose
+    When I run bugsnag-cli with upload android-aab --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/app/ --verbose
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the Android Build API
     And "f3112c3dbdd73ae5dee677e407af196f101e97f5" should be used as "build ID"
@@ -92,5 +92,5 @@ Feature: Android AAB Integration Test
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Uploading Android AAB file when more than a single AAB is found
-    When I run bugsnag-cli with upload android-aab --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/aab/
+    When I run bugsnag-cli with upload android-aab --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/aab/
     Then I should see the path ambiguous error

--- a/features/android/android-ndk.feature
+++ b/features/android/android-ndk.feature
@@ -1,7 +1,7 @@
 Feature: Android NDK Integration Test
 
   Scenario: Upload a single Android NDK sourcemap using all CLI flags
-    When I run bugsnag-cli with upload android-ndk --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --application-id="2.0" --app-manifest=features/android/fixtures/app/build/intermediates/merged_manifests/release/AndroidManifest.xml --variant=release --version-code=2 --version-name=2.0 features/android/fixtures/app/build/intermediates/merged_native_libs/release/out/lib/arm64-v8a/libbugsnag-ndk.so
+    When I run bugsnag-cli with upload android-ndk --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --application-id="2.0" --app-manifest=features/android/fixtures/app/build/intermediates/merged_manifests/release/AndroidManifest.xml --variant=release --version-code=2 --version-name=2.0 features/android/fixtures/app/build/intermediates/merged_native_libs/release/out/lib/arm64-v8a/libbugsnag-ndk.so
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the NDK Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -12,7 +12,7 @@ Feature: Android NDK Integration Test
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Upload a single Android NDK sourcemap providing the app-manifest CLI flag
-    When I run bugsnag-cli with upload android-ndk --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --app-manifest=features/android/fixtures/app/build/intermediates/merged_manifests/release/AndroidManifest.xml features/android/fixtures/app/build/intermediates/merged_native_libs/release/out/lib/arm64-v8a/libbugsnag-ndk.so
+    When I run bugsnag-cli with upload android-ndk --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --app-manifest=features/android/fixtures/app/build/intermediates/merged_manifests/release/AndroidManifest.xml features/android/fixtures/app/build/intermediates/merged_native_libs/release/out/lib/arm64-v8a/libbugsnag-ndk.so
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the NDK Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -23,7 +23,7 @@ Feature: Android NDK Integration Test
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Upload a single Android NDK sourcemap providing the app-manifest CLI flag
-    When I run bugsnag-cli with upload android-ndk --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/app/build/intermediates/merged_native_libs/release/out/lib/arm64-v8a/libbugsnag-ndk.so
+    When I run bugsnag-cli with upload android-ndk --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/app/build/intermediates/merged_native_libs/release/out/lib/arm64-v8a/libbugsnag-ndk.so
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the NDK Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -34,7 +34,7 @@ Feature: Android NDK Integration Test
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Upload multiple Android NDK sourcemaps when command is run from within app directory
-    When I run bugsnag-cli with upload android-ndk --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/app
+    When I run bugsnag-cli with upload android-ndk --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/app
     And I wait to receive 16 sourcemaps
     Then the sourcemap is valid for the NDK Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -45,7 +45,7 @@ Feature: Android NDK Integration Test
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Upload multiple Android NDK sourcemaps when command is run from within x86 directory
-    When I run bugsnag-cli with upload android-ndk --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/app/build/intermediates/merged_native_libs/release/out/lib/x86
+    When I run bugsnag-cli with upload android-ndk --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/app/build/intermediates/merged_native_libs/release/out/lib/x86
     And I wait to receive 4 sourcemaps
     Then the sourcemap is valid for the NDK Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -56,7 +56,7 @@ Feature: Android NDK Integration Test
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Upload multiple Android NDK sourcemaps providing no flags to the CLI
-    When I run bugsnag-cli with upload android-ndk --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/
+    When I run bugsnag-cli with upload android-ndk --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/
     And I wait to receive 16 sourcemaps
     Then the sourcemap is valid for the NDK Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -71,7 +71,7 @@ Feature: Android NDK Integration Test
     When I make the "features/base-fixtures/android"
     And I wait for the build to succeed
 
-    When I run bugsnag-cli with upload android-ndk --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/base-fixtures/android
+    When I run bugsnag-cli with upload android-ndk --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/base-fixtures/android
     And I wait to receive 4 sourcemaps
     Then the sourcemap is valid for the NDK Build API
     Then the sourcemaps Content-Type header is valid multipart form-data

--- a/features/android/android-proguard.feature
+++ b/features/android/android-proguard.feature
@@ -1,7 +1,7 @@
 Feature: Android Proguard Integration Test
 
   Scenario: Upload an Android Proguard mapping file using all CLI flags
-    When I run bugsnag-cli with upload android-proguard --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --application-id="com.exampleApp.android" --app-manifest=features/android/fixtures/app/build/intermediates/merged_manifests/release/AndroidManifest.xml --build-uuid=1234567890abcdefghijklmnopqrstuvwxyz --variant=release --version-code=2 --version-name=2.0 features/android/fixtures/app/build/outputs/mapping/release/mapping.txt
+    When I run bugsnag-cli with upload android-proguard --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --application-id="com.exampleApp.android" --app-manifest=features/android/fixtures/app/build/intermediates/merged_manifests/release/AndroidManifest.xml --build-uuid=1234567890abcdefghijklmnopqrstuvwxyz --variant=release --version-code=2 --version-name=2.0 features/android/fixtures/app/build/outputs/mapping/release/mapping.txt
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the Proguard Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -13,7 +13,7 @@ Feature: Android Proguard Integration Test
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Upload an Android Proguard mapping file providing the app-manifest CLI flag
-    When I run bugsnag-cli with upload android-proguard --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --app-manifest=features/android/fixtures/app/build/intermediates/merged_manifests/release/AndroidManifest.xml features/android/fixtures/app/build/outputs/mapping/release/mapping.txt
+    When I run bugsnag-cli with upload android-proguard --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --app-manifest=features/android/fixtures/app/build/intermediates/merged_manifests/release/AndroidManifest.xml features/android/fixtures/app/build/outputs/mapping/release/mapping.txt
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the Proguard Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -25,7 +25,7 @@ Feature: Android Proguard Integration Test
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Upload an Android Proguard mapping file providing no flags to the CLI
-    When I run bugsnag-cli with upload android-proguard --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/
+    When I run bugsnag-cli with upload android-proguard --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/android/fixtures/
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the Proguard Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -40,7 +40,7 @@ Feature: Android Proguard Integration Test
     When I make the "features/base-fixtures/android"
     And I wait for the build to succeed
 
-    When I run bugsnag-cli with upload android-proguard --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/base-fixtures/android
+    When I run bugsnag-cli with upload android-proguard --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/base-fixtures/android
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the Proguard Build API
     Then the sourcemaps Content-Type header is valid multipart form-data

--- a/features/breakpad/breakpad.feature
+++ b/features/breakpad/breakpad.feature
@@ -1,7 +1,7 @@
 Feature: Breakpad Integration Tests
 
     Scenario: Upload a single breakpad .sym using all CLI flags
-        When I run bugsnag-cli with upload breakpad features/breakpad/fixtures/breakpad-symbols.sym --upload-api-root-url=http://localhost:9339 --project-root="/features/breakpad/fixtures/breakpad-symbols.sym" --debug-file="/features/breakpad/fixtures/breakpad-symbols.sym" --code-file="/features/breakpad/fixtures/breakpad-symbols.sym" --version-name="2" --cpu-arch="x86_64" --os-name="Linux" --debug-identifier="1234567890ABCDEF1234567890ABCDEF" --product-name="test-product" --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite
+        When I run bugsnag-cli with upload breakpad features/breakpad/fixtures/breakpad-symbols.sym --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --project-root="/features/breakpad/fixtures/breakpad-symbols.sym" --debug-file="/features/breakpad/fixtures/breakpad-symbols.sym" --code-file="/features/breakpad/fixtures/breakpad-symbols.sym" --version-name="2" --cpu-arch="x86_64" --os-name="Linux" --debug-identifier="1234567890ABCDEF1234567890ABCDEF" --product-name="test-product" --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite
         And I wait to receive 1 sourcemaps
         Then the sourcemap is valid for the Breakpad Build API
         Then the sourcemaps Content-Type header is valid multipart form-data

--- a/features/cli/create-build.feature
+++ b/features/cli/create-build.feature
@@ -8,7 +8,7 @@ Feature: Bugsnag CLI create-build behavior
     Then I should see the missing app version error
 
   Scenario: Starting bugsnag-cli create-build on mac with app-version
-    When I run bugsnag-cli with create-build --build-api-root-url=http://localhost:9339/builds --api-key=1234567890ABCDEF1234567890ABCDEF --version-name=1.2.3
+    When I run bugsnag-cli with create-build --build-api-root-url=http://localhost:$MAZE_RUNNER_PORT/builds --api-key=1234567890ABCDEF1234567890ABCDEF --version-name=1.2.3
     And I wait to receive 1 builds
     Then the build is valid for the Builds API
     And the builds payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
@@ -16,7 +16,7 @@ Feature: Bugsnag CLI create-build behavior
     And the builds payload field "sourceControl.repository" equals "https://github.com/bugsnag/bugsnag-cli.git"
 
   Scenario: Starting bugsnag-cli create-build and passing an AAB file
-    When I run bugsnag-cli with create-build --build-api-root-url=http://localhost:9339/builds --api-key=1234567890ABCDEF1234567890ABCDEF --android-aab=features/android/fixtures/aab/app-release.aab
+    When I run bugsnag-cli with create-build --build-api-root-url=http://localhost:$MAZE_RUNNER_PORT/builds --api-key=1234567890ABCDEF1234567890ABCDEF --android-aab=features/android/fixtures/aab/app-release.aab
     And I wait to receive 1 builds
     Then the build is valid for the Builds API
     And the builds payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
@@ -24,7 +24,7 @@ Feature: Bugsnag CLI create-build behavior
     And the builds payload field "sourceControl.repository" equals "https://github.com/bugsnag/bugsnag-cli.git"
 
   Scenario: Starting bugsnag-cli create-build and passing an Android manifest file
-    When I run bugsnag-cli with create-build --build-api-root-url=http://localhost:9339/builds --app-manifest=features/android/fixtures/app/build/intermediates/merged_manifests/release/AndroidManifest.xml
+    When I run bugsnag-cli with create-build --build-api-root-url=http://localhost:$MAZE_RUNNER_PORT/builds --app-manifest=features/android/fixtures/app/build/intermediates/merged_manifests/release/AndroidManifest.xml
     And I wait to receive 1 builds
     Then the build is valid for the Builds API
     And the builds payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
@@ -32,14 +32,14 @@ Feature: Bugsnag CLI create-build behavior
     And the builds payload field "sourceControl.repository" equals "https://github.com/bugsnag/bugsnag-cli.git"
 
   Scenario: Starting bugsnag-cli create-build with invalid source control provider
-    When I run bugsnag-cli with create-build --build-api-root-url=http://localhost:9339/builds --api-key=1234567890ABCDEF1234567890ABCDEF --version-name=1.2.3 --provider=test
+    When I run bugsnag-cli with create-build --build-api-root-url=http://localhost:$MAZE_RUNNER_PORT/builds --api-key=1234567890ABCDEF1234567890ABCDEF --version-name=1.2.3 --provider=test
     Then I should see the not an accepted value for the source control provider error
 
   Scenario: Starting bugsnag-cli create-build with no source control provider
-    When I run bugsnag-cli with create-build --build-api-root-url=http://localhost:9339/builds --api-key=1234567890ABCDEF1234567890ABCDEF --version-name=1.2.3 --provider=
+    When I run bugsnag-cli with create-build --build-api-root-url=http://localhost:$MAZE_RUNNER_PORT/builds --api-key=1234567890ABCDEF1234567890ABCDEF --version-name=1.2.3 --provider=
     Then I should see the missing source control provider error
 
   Scenario: Starting bugsnag-cli create-build and passing an Android manifest file with dry-run and verbose
-    When I run bugsnag-cli with create-build --build-api-root-url=http://localhost:9339/builds --app-manifest=features/android/fixtures/app/build/intermediates/merged_manifests/release/AndroidManifest.xml --dry-run --verbose
+    When I run bugsnag-cli with create-build --build-api-root-url=http://localhost:$MAZE_RUNNER_PORT/builds --app-manifest=features/android/fixtures/app/build/intermediates/merged_manifests/release/AndroidManifest.xml --dry-run --verbose
     Then I should see the build payload
     And I wait to receive 0 builds

--- a/features/dart/dart.feature
+++ b/features/dart/dart.feature
@@ -1,7 +1,7 @@
 Feature: Dart Integration Tests
 
   Scenario: Upload a single Android Dart sourcemap using all CLI flags
-    When I run bugsnag-cli with upload dart --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --version-name=2.0 --version-code=1.0 features/dart/fixtures/app-debug-info/app.android-arm64.symbols
+    When I run bugsnag-cli with upload dart --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --version-name=2.0 --version-code=1.0 features/dart/fixtures/app-debug-info/app.android-arm64.symbols
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the Dart Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -12,7 +12,7 @@ Feature: Dart Integration Tests
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Upload a single iOS Dart sourcemap using all CLI flags
-    When I run bugsnag-cli with upload dart --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --ios-app-path=features/dart/fixtures/build/ios/iphoneos/Runner.app/Frameworks/App.framework/App --version-name=2.0 --bundle-version=1.0 features/dart/fixtures/app-debug-info/app.ios-arm64.symbols
+    When I run bugsnag-cli with upload dart --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --ios-app-path=features/dart/fixtures/build/ios/iphoneos/Runner.app/Frameworks/App.framework/App --version-name=2.0 --bundle-version=1.0 features/dart/fixtures/app-debug-info/app.ios-arm64.symbols
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the Dart Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -23,7 +23,7 @@ Feature: Dart Integration Tests
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Upload multiple Dart sourcemaps providing no flags to the CLI
-    When I run bugsnag-cli with upload dart --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/dart/fixtures/app-debug-info
+    When I run bugsnag-cli with upload dart --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/dart/fixtures/app-debug-info
     And I wait to receive 4 sourcemaps
     Then the sourcemap is valid for the Dart Build API
     Then the sourcemaps Content-Type header is valid multipart form-data

--- a/features/js/js-multiple-maps-nested.feature
+++ b/features/js/js-multiple-maps-nested.feature
@@ -2,7 +2,7 @@ Feature: Js integration tests multiple nested source maps
 
   @BuildNestedJS
   Scenario: Searches in the dist folder automatically
-    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com features/base-fixtures/js/out/
+    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com features/base-fixtures/js/out/
     And I wait to receive 4 sourcemaps
     Then the sourcemap is valid for the JS Build API
     Then the sourcemaps Content-Type header is valid multipart form-data

--- a/features/js/js-multiple-maps.feature
+++ b/features/js/js-multiple-maps.feature
@@ -1,7 +1,7 @@
 Feature: Js integration tests multiple source maps
 
   Scenario: Searches in the dist folder automatically
-    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com --project-root=features/js/fixtures/js-multiple-maps features/js/fixtures/js-multiple-maps/dist/
+    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com --project-root=features/js/fixtures/js-multiple-maps features/js/fixtures/js-multiple-maps/dist/
     And I wait to receive 2 sourcemaps
     Then the sourcemap is valid for the JS Build API
     Then the sourcemaps Content-Type header is valid multipart form-data

--- a/features/js/js-webpack4.feature
+++ b/features/js/js-webpack4.feature
@@ -1,7 +1,7 @@
 Feature: Webpack 4 js Integration Tests
 
   Scenario: Upload a single js sourcemap using all CLI flags
-    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --bundle-url=example.com --version-name=2.3.4 --source-map=features/js/fixtures/js-webpack4/dist/main.js.map --bundle=features/js/fixtures/js-webpack4/dist/main.js --project-root=features/js/fixtures/js-webpack4 features/js/fixtures/js-webpack4/dist
+    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --bundle-url=example.com --version-name=2.3.4 --source-map=features/js/fixtures/js-webpack4/dist/main.js.map --bundle=features/js/fixtures/js-webpack4/dist/main.js --project-root=features/js/fixtures/js-webpack4 features/js/fixtures/js-webpack4/dist
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the JS Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -14,7 +14,7 @@ Feature: Webpack 4 js Integration Tests
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Automatically resolves the version number based on the package.json
-    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com --project-root=features/js/fixtures/js-webpack4 features/js/fixtures/js-webpack4/dist
+    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com --project-root=features/js/fixtures/js-webpack4 features/js/fixtures/js-webpack4/dist
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the JS Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -27,7 +27,7 @@ Feature: Webpack 4 js Integration Tests
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Resolves the path specified as the map
-    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --bundle-url=example.com --project-root=features/js/fixtures/js-webpack4 features/js/fixtures/js-webpack4/dist/main.js.map
+    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --bundle-url=example.com --project-root=features/js/fixtures/js-webpack4 features/js/fixtures/js-webpack4/dist/main.js.map
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the JS Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -40,7 +40,7 @@ Feature: Webpack 4 js Integration Tests
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Searches in the dist folder automatically
-    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com --project-root=features/js/fixtures/js-webpack4 features/js/fixtures/js-webpack4/
+    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com --project-root=features/js/fixtures/js-webpack4 features/js/fixtures/js-webpack4/
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the JS Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -53,7 +53,7 @@ Feature: Webpack 4 js Integration Tests
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Uses the working directory as project root
-    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com features/js/fixtures/js-webpack4/dist
+    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com features/js/fixtures/js-webpack4/dist
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the JS Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -66,7 +66,7 @@ Feature: Webpack 4 js Integration Tests
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Base URL correctly appends the path
-    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com --project-root=features/js/fixtures/js-webpack4 features/js/fixtures/js-webpack4/dist
+    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com --project-root=features/js/fixtures/js-webpack4 features/js/fixtures/js-webpack4/dist
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the JS Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -82,7 +82,7 @@ Feature: Webpack 4 js Integration Tests
     When I make the "features/base-fixtures/js-webpack4"
     And I wait for the build to succeed
 
-    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com features/base-fixtures/js-webpack4/dist/
+    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com features/base-fixtures/js-webpack4/dist/
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the JS Build API
     Then the sourcemaps Content-Type header is valid multipart form-data

--- a/features/js/js-webpack5.feature
+++ b/features/js/js-webpack5.feature
@@ -1,7 +1,7 @@
 Feature: Webpack 5 js Integration Tests
 
   Scenario: Upload a single js sourcemap using all CLI flags
-    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --bundle-url=example.com --version-name=2.3.4 --source-map=features/js/fixtures/js-webpack5/dist/main.js.map --bundle=features/js/fixtures/js-webpack5/dist/main.js --project-root=features/js/fixtures/js-webpack5 features/js/fixtures/js-webpack5/dist
+    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --bundle-url=example.com --version-name=2.3.4 --source-map=features/js/fixtures/js-webpack5/dist/main.js.map --bundle=features/js/fixtures/js-webpack5/dist/main.js --project-root=features/js/fixtures/js-webpack5 features/js/fixtures/js-webpack5/dist
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the JS Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -14,7 +14,7 @@ Feature: Webpack 5 js Integration Tests
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Automatically resolves the version number based on the package.json
-    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com --project-root=features/js/fixtures/js-webpack5 features/js/fixtures/js-webpack5/dist
+    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com --project-root=features/js/fixtures/js-webpack5 features/js/fixtures/js-webpack5/dist
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the JS Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -27,7 +27,7 @@ Feature: Webpack 5 js Integration Tests
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Resolves the path specified as the map
-    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --bundle-url=example.com --project-root=features/js/fixtures/js-webpack5 features/js/fixtures/js-webpack5/dist/main.js.map
+    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --bundle-url=example.com --project-root=features/js/fixtures/js-webpack5 features/js/fixtures/js-webpack5/dist/main.js.map
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the JS Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -40,7 +40,7 @@ Feature: Webpack 5 js Integration Tests
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Searches in the dist folder automatically
-    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com --project-root=features/js/fixtures/js-webpack5 features/js/fixtures/js-webpack5/
+    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com --project-root=features/js/fixtures/js-webpack5 features/js/fixtures/js-webpack5/
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the JS Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -53,7 +53,7 @@ Feature: Webpack 5 js Integration Tests
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Uses the working directory as project root
-    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com features/js/fixtures/js-webpack5/dist
+    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com features/js/fixtures/js-webpack5/dist
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the JS Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -66,7 +66,7 @@ Feature: Webpack 5 js Integration Tests
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Base URL correctly appends the path
-    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com --project-root=features/js/fixtures/js-webpack5 features/js/fixtures/js-webpack5/dist
+    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com --project-root=features/js/fixtures/js-webpack5 features/js/fixtures/js-webpack5/dist
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the JS Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -82,7 +82,7 @@ Feature: Webpack 5 js Integration Tests
     When I make the "features/base-fixtures/js-webpack5"
     And I wait for the build to succeed
 
-    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com features/base-fixtures/js-webpack5/dist/
+    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --base-url=example.com features/base-fixtures/js-webpack5/dist/
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the JS Build API
     Then the sourcemaps Content-Type header is valid multipart form-data

--- a/features/react-native/android.feature
+++ b/features/react-native/android.feature
@@ -6,7 +6,7 @@
 @BuildRNAndroid
 Feature: React Native Android Integration Tests
   Scenario: Upload a single React Native Android sourcemap using all escape hatches
-    When I run bugsnag-cli with upload react-native-android --upload-api-root-url=http://localhost:9339 --bundle=$BUNDLE_PATH --source-map=$SOURCE_MAP_PATH --app-manifest=$APP_MANIFEST_PATH --version-name=2.0 --variant=release --version-code=2 --overwrite
+    When I run bugsnag-cli with upload react-native-android --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --bundle=$BUNDLE_PATH --source-map=$SOURCE_MAP_PATH --app-manifest=$APP_MANIFEST_PATH --version-name=2.0 --variant=release --version-code=2 --overwrite
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the React Native Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -17,7 +17,7 @@ Feature: React Native Android Integration Tests
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Upload a single React Native Android sourcemap, only passing bundle, sourcemap and manifest options
-    When I run bugsnag-cli with upload react-native-android --upload-api-root-url=http://localhost:9339 --bundle=$BUNDLE_PATH --source-map=$SOURCE_MAP_PATH --app-manifest=$APP_MANIFEST_PATH --overwrite features/react-native/fixtures/generated/old-arch/$RN_VERSION
+    When I run bugsnag-cli with upload react-native-android --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --bundle=$BUNDLE_PATH --source-map=$SOURCE_MAP_PATH --app-manifest=$APP_MANIFEST_PATH --overwrite features/react-native/fixtures/generated/old-arch/$RN_VERSION
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the React Native Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -28,7 +28,7 @@ Feature: React Native Android Integration Tests
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Upload a single React Native Android sourcemap
-    When I run bugsnag-cli with upload react-native-android --upload-api-root-url=http://localhost:9339 --overwrite features/react-native/fixtures/generated/old-arch/$RN_VERSION
+    When I run bugsnag-cli with upload react-native-android --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --overwrite features/react-native/fixtures/generated/old-arch/$RN_VERSION
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the React Native Build API
     Then the sourcemaps Content-Type header is valid multipart form-data

--- a/features/react-native/ios.feature
+++ b/features/react-native/ios.feature
@@ -1,7 +1,7 @@
 Feature: React Native iOS Integration Tests
   @BuildRNiOS
   Scenario: Upload a single React Native iOS sourcemap
-    When I run bugsnag-cli with upload react-native-ios --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/react-native/fixtures/generated/old-arch/$RN_VERSION
+    When I run bugsnag-cli with upload react-native-ios --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite features/react-native/fixtures/generated/old-arch/$RN_VERSION
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the React Native Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -13,7 +13,7 @@ Feature: React Native iOS Integration Tests
 
   @BuildExportRNiOS
   Scenario: Upload a single React Native iOS sourcemap using escape hatches
-    When I run bugsnag-cli with upload react-native-ios --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --bundle=features/react-native/fixtures/generated/old-arch/$RN_VERSION/reactnative.xcarchive/Products/Applications/reactnative.app/main.jsbundle --source-map=features/react-native/fixtures/generated/old-arch/$RN_VERSION/ios/build/sourcemaps/main.jsbundle.map --plist=features/react-native/fixtures/generated/old-arch/$RN_VERSION/reactnative.xcarchive/Products/Applications/reactnative.app/Info.plist --xcode-project=features/react-native/fixtures/generated/old-arch/$RN_VERSION/ios/reactnative.xcodeproj --scheme=reactnative  --bundle-version=2 --version-name=2.0
+    When I run bugsnag-cli with upload react-native-ios --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --bundle=features/react-native/fixtures/generated/old-arch/$RN_VERSION/reactnative.xcarchive/Products/Applications/reactnative.app/main.jsbundle --source-map=features/react-native/fixtures/generated/old-arch/$RN_VERSION/ios/build/sourcemaps/main.jsbundle.map --plist=features/react-native/fixtures/generated/old-arch/$RN_VERSION/reactnative.xcarchive/Products/Applications/reactnative.app/Info.plist --xcode-project=features/react-native/fixtures/generated/old-arch/$RN_VERSION/ios/reactnative.xcodeproj --scheme=reactnative  --bundle-version=2 --version-name=2.0
     Then the sourcemap is valid for the React Native Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
     And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
@@ -23,7 +23,7 @@ Feature: React Native iOS Integration Tests
     And the sourcemap payload field "overwrite" equals "true"
 
   Scenario: Upload a single React Native iOS sourcemap using escape hatches
-    When I run bugsnag-cli with upload react-native-ios --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --bundle=features/react-native/fixtures/generated/old-arch/$RN_VERSION/reactnative.xcarchive/Products/Applications/reactnative.app/main.jsbundle --source-map=features/react-native/fixtures/generated/old-arch/$RN_VERSION/ios/build/sourcemaps/main.jsbundle.map --plist=features/react-native/fixtures/generated/old-arch/$RN_VERSION/reactnative.xcarchive/Products/Applications/reactnative.app/Info.plist --xcode-project=features/react-native/fixtures/generated/old-arch/$RN_VERSION/ios/reactnative.xcodeproj --scheme=reactnative
+    When I run bugsnag-cli with upload react-native-ios --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --bundle=features/react-native/fixtures/generated/old-arch/$RN_VERSION/reactnative.xcarchive/Products/Applications/reactnative.app/main.jsbundle --source-map=features/react-native/fixtures/generated/old-arch/$RN_VERSION/ios/build/sourcemaps/main.jsbundle.map --plist=features/react-native/fixtures/generated/old-arch/$RN_VERSION/reactnative.xcarchive/Products/Applications/reactnative.app/Info.plist --xcode-project=features/react-native/fixtures/generated/old-arch/$RN_VERSION/ios/reactnative.xcodeproj --scheme=reactnative
     Then the sourcemap is valid for the React Native Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
     And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"

--- a/features/xcode/dsym.feature
+++ b/features/xcode/dsym.feature
@@ -1,7 +1,7 @@
 Feature: dSYM Integration Tests
   @CleanAndBuildDsym
   Scenario: Upload a dsym from an Xcode Build
-    When I run bugsnag-cli with upload dsym --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/dsym/
+    When I run bugsnag-cli with upload dsym --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/dsym/
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the dSYM Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -9,7 +9,7 @@ Feature: dSYM Integration Tests
 
   @CleanAndArchiveDsym
   Scenario: Upload a dsym from an Xcode Archive
-    When I run bugsnag-cli with upload dsym --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/dsym/
+    When I run bugsnag-cli with upload dsym --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/dsym/
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the dSYM Build API
     Then the sourcemaps Content-Type header is valid multipart form-data

--- a/features/xcode/expected_err_and_warn_scenarios.feature
+++ b/features/xcode/expected_err_and_warn_scenarios.feature
@@ -1,25 +1,25 @@
 Feature: dSYM Expected Error and Warning scenario Integration Tests
 
   Scenario: If --ignore-empty-dsym is set to true, then the log message returned should be [WARN]
-    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/path/to/project/root --scheme=test --ignore-empty-dsym=true features/xcode/fixtures/ZeroByteDsym
+    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/path/to/project/root --scheme=test --ignore-empty-dsym=true features/xcode/fixtures/ZeroByteDsym
     Then I should see a log level of "[FATAL]" when no dSYM files could be found
 
   Scenario: If --ignore-empty-dsym is not set, then the log message returned should be [ERROR]
-    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/path/to/project/root --scheme=test features/xcode/fixtures/ZeroByteDsym
+    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/path/to/project/root --scheme=test features/xcode/fixtures/ZeroByteDsym
     Then I should see a log level of "[FATAL]" when no dSYM files could be found
 
   Scenario: If --ignore-missing-dwarf is set to true, then the log message returned should be [WARN]
-    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/path/to/project/root --scheme=test --ignore-missing-dwarf=true features/xcode/fixtures/MissingDWARFdSYM
+    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/path/to/project/root --scheme=test --ignore-missing-dwarf=true features/xcode/fixtures/MissingDWARFdSYM
     Then I should see a log level of "[FATAL]" when no dSYM files could be found
 
   Scenario: If --ignore-missing-dwarf is not set, then the log message returned should be [ERROR]
-    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/path/to/project/root --scheme=test features/xcode/fixtures/MissingDWARFdSYM
+    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/path/to/project/root --scheme=test features/xcode/fixtures/MissingDWARFdSYM
     Then I should see a log level of "[FATAL]" when no dSYM files could be found
 
   Scenario: If --ignore-missing-dwarf is set to true, then the log message returned should be [WARN]
-    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/path/to/project/root --scheme=test --ignore-missing-dwarf=true features/xcode/fixtures/MissingDWARFdSYM
+    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/path/to/project/root --scheme=test --ignore-missing-dwarf=true features/xcode/fixtures/MissingDWARFdSYM
     Then I should see a log level of "[FATAL]" when no dSYM files could be found
 
   Scenario: If --ignore-missing-dwarf is not set, then the log message returned should be [ERROR]
-    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/path/to/project/root --scheme=test features/xcode/fixtures/MissingDWARFdSYM
+    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/path/to/project/root --scheme=test features/xcode/fixtures/MissingDWARFdSYM
     Then I should see a log level of "[FATAL]" when no dSYM files could be found

--- a/features/xcode/swift_package_manager.feature
+++ b/features/xcode/swift_package_manager.feature
@@ -4,7 +4,7 @@
 #    When I make the "features/base-fixtures/swift-package-manager"
 #    Then I wait for the build to succeed
 #
-#    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --project-root=/my/project/root/ --plist=features/base-fixtures/swift-package-manager/swift-package-manager/Info.plist --scheme=swift-package-manager features/base-fixtures/swift-package-manager
+#    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --project-root=/my/project/root/ --plist=features/base-fixtures/swift-package-manager/swift-package-manager/Info.plist --scheme=swift-package-manager features/base-fixtures/swift-package-manager
 #    And I wait to receive 1 sourcemaps
 #    Then the sourcemap is valid for the dSYM Build API
 #    Then the sourcemaps Content-Type header is valid multipart form-data
@@ -15,7 +15,7 @@
 #    When I make the "features/base-fixtures/swift-package-manager"
 #    Then I wait for the build to succeed
 #
-#    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/swift-package-manager
+#    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/swift-package-manager
 #    And I wait to receive 1 sourcemaps
 #    Then the sourcemap is valid for the dSYM Build API
 #    Then the sourcemaps Content-Type header is valid multipart form-data
@@ -25,7 +25,7 @@
 #    When I make the "features/base-fixtures/swift-package-manager"
 #    Then I wait for the build to succeed
 #
-#    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/swift-package-manager/swift-package-manager.xcodeproj
+#    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/swift-package-manager/swift-package-manager.xcodeproj
 #    And I wait to receive 1 sourcemaps
 #    Then the sourcemap is valid for the dSYM Build API
 #    Then the sourcemaps Content-Type header is valid multipart form-data
@@ -35,7 +35,7 @@
 #    When I make the "features/base-fixtures/swift-package-manager"
 #    Then I wait for the build to succeed
 #
-#    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:9339 --scheme=swift-package-manager --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/swift-package-manager
+#    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --scheme=swift-package-manager --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/swift-package-manager
 #    And I wait to receive 1 sourcemaps
 #    Then the sourcemap is valid for the dSYM Build API
 #    Then the sourcemaps Content-Type header is valid multipart form-data
@@ -45,7 +45,7 @@
 #    When I make the "features/base-fixtures/swift-package-manager"
 #    Then I wait for the build to succeed
 #
-#    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:9339 --plist=features/base-fixtures/swift-package-manager/swift-package-manager/Info.plist features/base-fixtures/swift-package-manager
+#    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --plist=features/base-fixtures/swift-package-manager/swift-package-manager/Info.plist features/base-fixtures/swift-package-manager
 #    And I wait to receive 1 sourcemaps
 #    Then the sourcemap is valid for the dSYM Build API
 #    Then the sourcemaps Content-Type header is valid multipart form-data

--- a/features/xcode/xcode-archive.feature
+++ b/features/xcode/xcode-archive.feature
@@ -1,6 +1,6 @@
 Feature: Xcode Archive Integration Tests
   Scenario: Uploading an .xcarchive containing commas and special characters
-    When I run bugsnag-cli with upload xcode-archive --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF "features/xcode/fixtures/bugsnag-example 14-05-2021,,, 11.27éøœåñü#.xcarchive"
+    When I run bugsnag-cli with upload xcode-archive --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF "features/xcode/fixtures/bugsnag-example 14-05-2021,,, 11.27éøœåñü#.xcarchive"
     And I wait to receive 2 sourcemaps
     Then the sourcemap is valid for the dSYM Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -9,7 +9,7 @@ Feature: Xcode Archive Integration Tests
   Scenario: Archive and upload an .xcarchive
     When I make the "features/base-fixtures/dsym/archive"
     Then I wait for the build to succeed
-    When I run bugsnag-cli with upload xcode-archive --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/dsym/
+    When I run bugsnag-cli with upload xcode-archive --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/dsym/
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the dSYM Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -18,7 +18,7 @@ Feature: Xcode Archive Integration Tests
   Scenario: Archive and export a .xcarchive
     When I make the "features/base-fixtures/dsym/archive/export"
     Then I wait for the build to succeed
-    When I run bugsnag-cli with upload xcode-archive --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/dsym/dsym.xcarchive
+    When I run bugsnag-cli with upload xcode-archive --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/dsym/dsym.xcarchive
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the dSYM Build API
     Then the sourcemaps Content-Type header is valid multipart form-data

--- a/features/xcode/xcode-build.feature
+++ b/features/xcode/xcode-build.feature
@@ -1,42 +1,42 @@
 Feature: Xcode Build Integration Tests
 
   Scenario: Upload a single dSYM sourcemap using path containing one dSYM
-    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/my/project/root/ features/xcode/fixtures/single-dsym
+    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/my/project/root/ features/xcode/fixtures/single-dsym
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the dSYM Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
     And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
 
   Scenario: Upload multiple dSYM sourcemaps using path containing multiple dSYMs
-    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/my/project/root/ features/xcode/fixtures/dsyms
+    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/my/project/root/ features/xcode/fixtures/dsyms
     And I wait to receive 2 sourcemaps
     Then the sourcemap is valid for the dSYM Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
     And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
 
   Scenario: Upload a single dSYM sourcemap using zip file containing one dSYM
-    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/my/project/root/ features/xcode/fixtures/single-dsym.zip
+    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/my/project/root/ features/xcode/fixtures/single-dsym.zip
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the dSYM Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
     And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
 
   Scenario: Upload multiple dSYM sourcemaps using zip file containing multiple dSYMs
-    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/my/project/root/ features/xcode/fixtures/dsyms.zip
+    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/my/project/root/ features/xcode/fixtures/dsyms.zip
     And I wait to receive 2 sourcemaps
     Then the sourcemap is valid for the dSYM Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
     And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
 
   Scenario: Uploading a zip file containing directory of dSYM files that was compressed with macOS Archive Utility
-    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/my/project/root/ features/xcode/fixtures/macos-compressed-dsyms.zip
+    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/my/project/root/ features/xcode/fixtures/macos-compressed-dsyms.zip
     And I wait to receive 2 sourcemaps
     Then the sourcemap is valid for the dSYM Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
     And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
 
   Scenario: Upload symbols from an AppCenter zip
-    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/my/project/root/ "features/xcode/fixtures/app-center/symbols.zip"
+    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/my/project/root/ "features/xcode/fixtures/app-center/symbols.zip"
     And I wait to receive 2 sourcemaps
     Then the sourcemap is valid for the dSYM Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -46,7 +46,7 @@ Feature: Xcode Build Integration Tests
     When I make the "features/base-fixtures/dsym"
     Then I wait for the build to succeed
 
-    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:9339 --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/my/project/root/ features/base-fixtures/dsym/
+    When I run bugsnag-cli with upload xcode-build --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/my/project/root/ features/base-fixtures/dsym/
     And I wait to receive 1 sourcemaps
     Then the sourcemap is valid for the dSYM Build API
     Then the sourcemaps Content-Type header is valid multipart form-data


### PR DESCRIPTION
## Goal

Pull the MR port from the CI environment
Move Unity tests to the isolated queue

## Testing

Covered by CI