### PR TITLE
[PLAT-14077] Fix typo in error messages

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -109,7 +109,7 @@ steps:
   - label: ":video_game: Unity Android Integration Tests"
     depends_on: build
     env:
-      UNITY_VERSION: 6000.0.36f1
+      UNITY_VERSION: 6000.0.47f1
     agents:
       queue: macos-14-isolated
     commands:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.0.1] - 2025-04-23
+
+### Fixed
+- Update the command referenced in the missing bundle error message [#178]()
+
 ## [3.0.0] - 2025-04-07
 
 This major release includes some breaking changes – please see our [Upgrading Guide](./UPGRADING.md) for full details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [3.0.1] - 2025-04-23
 
 ### Fixed
-- Update the command referenced in the missing bundle error message [#178]()
+- Update the command referenced in the missing bundle error message [#195](https://github.com/bugsnag/bugsnag-cli/pull/195)
 
 ## [3.0.0] - 2025-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [3.0.1] - 2025-04-23
+## [3.0.1] - 2025-04-29
 
 ### Added
 - Add TypeScript definitions to cli wrapper [#196](https://github.com/bugsnag/bugsnag-cli/pull/196)

--- a/install.sh
+++ b/install.sh
@@ -91,7 +91,7 @@ display_help() {
 EOS
 }
 
-VERSION="3.0.0"
+VERSION="3.0.1"
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
 )
 
-var package_version = "3.0.0"
+var package_version = "3.0.1"
 
 func main() {
 	commands := options.CLI{}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/cli",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "BugSnag CLI",
   "main": "bugsnag-cli-wrapper.js",
   "bin": {

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -53,7 +53,7 @@ func ProcessReactNativeAndroid(options options.CLI, endpoint string, logger log.
 				bundleDirPath = filepath.Join(buildDirPath, "generated", "assets")
 				variantFileFormat = "createBundle%sJsAndAssets"
 			} else {
-				return fmt.Errorf("unable to find index.android.bundle in your project, please specify the path using --bundle-path")
+				return fmt.Errorf("unable to find index.android.bundle in your project, please specify the path using --bundle")
 			}
 
 			if bundleDirPath != "" {

--- a/pkg/upload/react-native-ios.go
+++ b/pkg/upload/react-native-ios.go
@@ -132,7 +132,7 @@ func ProcessReactNativeIos(options options.CLI, endpoint string, logger log.Logg
 
 	// Check that we now have a bundle path
 	if iosOptions.ReactNative.Bundle == "" {
-		return fmt.Errorf("Could not find a bundle file, please specify the path by using --bundle-path")
+		return fmt.Errorf("Could not find a bundle file, please specify the path by using --bundle")
 	}
 
 	// Check that the source map file exists and error out if it doesn't


### PR DESCRIPTION
## Goal

Update the reference for `--bundle-path` to `--bundle` for the `upload react-native-ios` and `upload react-native-android` commands

## Testing

Covered by CI