### PR TITLE
Remove `--overwrite` from the upload dsym commands

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  queue: macos-14
+  queue: macos-15
 
 steps:
   - name: ':copyright: License Audit'
@@ -81,7 +81,7 @@ steps:
   - label: Xcode Integration Tests
     depends_on: build
     env:
-      XCODE_VERSION: 15
+      XCODE_VERSION: 16.3.0
     commands:
       - bundle install
       - chmod +x bin/arm64-macos-bugsnag-cli
@@ -109,9 +109,9 @@ steps:
   - label: ":video_game: Unity Android Integration Tests"
     depends_on: build
     env:
-      UNITY_VERSION: 6000.0.47f1
+      UNITY_VERSION: 6000.0.49f1
     agents:
-      queue: macos-14-isolated
+      queue: macos-15-isolated
     commands:
       - chmod +x bin/arm64-macos-bugsnag-cli
       - bundle install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+## Fixed
+
+- Remove the `--overwrite` option from the `dSYM` related commands as it is not used [#210](https://github.com/bugsnag/bugsnag-cli/pull/210)
+
 ## [3.1.1] - 2025-05-14
 
 ### Fixed

--- a/js/package.json
+++ b/js/package.json
@@ -36,7 +36,7 @@
     "prepublish": "npm run build && cp bin/bugsnag-cli-placeholder bin/bugsnag-cli"
   },
   "devDependencies": {
-    "@types/node": "^22.15.3",
+    "@types/node": "^24.0.1",
     "typescript": "^5.8.3"
   }
 }

--- a/pkg/android/process-uploads.go
+++ b/pkg/android/process-uploads.go
@@ -18,6 +18,7 @@ func UploadAndroidNdk(
 	projectRoot string,
 	endpoint string,
 	options options.CLI,
+	overwrite bool,
 	logger log.Logger,
 ) error {
 	fileFieldData := make(map[string]server.FileField)
@@ -30,7 +31,7 @@ func UploadAndroidNdk(
 	}
 
 	for _, file := range fileList {
-		uploadOptions, err := utils.BuildAndroidNDKUploadOptions(apiKey, applicationId, versionName, versionCode, projectRoot, filepath.Base(file), options.Upload.Overwrite)
+		uploadOptions, err := utils.BuildAndroidNDKUploadOptions(apiKey, applicationId, versionName, versionCode, projectRoot, filepath.Base(file), overwrite)
 
 		if err != nil {
 			return err

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -17,6 +17,7 @@ type Globals struct {
 type DiscoverAndUploadAny struct {
 	Path          utils.Paths       `arg:"" name:"path" help:"(required) Path to directory or file to upload" type:"path"`
 	UploadOptions map[string]string `help:"Additional arguments to pass to the upload request" mapsep:","`
+	Overwrite     bool              `help:"Whether to ignore and overwrite existing uploads with same identifier, rather than failing if a matching file exists"`
 }
 
 type AndroidAabMapping struct {
@@ -27,6 +28,7 @@ type AndroidAabMapping struct {
 	ProjectRoot   string      `help:"The path to strip from the beginning of source file names referenced in stacktraces on the BugSnag dashboard" type:"path"`
 	VersionCode   string      `help:"The version code of this build of the application"`
 	VersionName   string      `help:"The version of the application"`
+	Overwrite     bool        `help:"Whether to ignore and overwrite existing uploads with same identifier, rather than failing if a matching file exists"`
 }
 
 type AndroidNdkMapping struct {
@@ -38,6 +40,7 @@ type AndroidNdkMapping struct {
 	Variant        string      `help:"The build type/flavor (e.g. debug, release) used to disambiguate the between built files when searching the project directory"`
 	VersionCode    string      `help:"The version code of this build of the application"`
 	VersionName    string      `help:"The version of the application"`
+	Overwrite      bool        `help:"Whether to ignore and overwrite existing uploads with same identifier, rather than failing if a matching file exists"`
 }
 
 type AndroidProguardMapping struct {
@@ -50,6 +53,7 @@ type AndroidProguardMapping struct {
 	Variant       string      `help:"The build type/flavor (e.g. debug, release) used to disambiguate the between built files when searching the project directory"`
 	VersionCode   string      `help:"The version code of this build of the application"`
 	VersionName   string      `help:"The version of the application"`
+	Overwrite     bool        `help:"Whether to ignore and overwrite existing uploads with same identifier, rather than failing if a matching file exists"`
 }
 
 type DartSymbol struct {
@@ -58,6 +62,7 @@ type DartSymbol struct {
 	IosAppPath    utils.Path  `help:"The path to the iOS application binary, used to determine a unique build ID." type:"path"`
 	VersionName   string      `help:"The version of the application." xor:"app-version,version-name"`
 	VersionCode   string      `help:"The version code of this build of the application (Android only)" xor:"app-version-code,version-code"`
+	Overwrite     bool        `help:"Whether to ignore and overwrite existing uploads with same identifier, rather than failing if a matching file exists"`
 }
 
 type Dsym struct {
@@ -94,6 +99,7 @@ type Js struct {
 	SourceMap    string      `help:"Path to the source map file. This usually has the .min.js extension." type:"path"`
 	VersionName  string      `help:"The version of the app that the source map applies to. Defaults to the version in the package.json file (if found)."`
 	CodeBundleId string      `help:"A unique identifier for the JavaScript bundle"`
+	Overwrite    bool        `help:"Whether to ignore and overwrite existing uploads with same identifier, rather than failing if a matching file exists"`
 }
 
 type ReactNative struct {
@@ -102,6 +108,7 @@ type ReactNative struct {
 	Shared          ReactNativeShared          `embed:""`
 	AndroidSpecific ReactNativeAndroidSpecific `embed:"" prefix:"android-"`
 	IosSpecific     ReactNativeIosSpecific     `embed:"" prefix:"ios-"`
+	Overwrite       bool                       `help:"Whether to ignore and overwrite existing uploads with same identifier, rather than failing if a matching file exists"`
 }
 
 type ReactNativeAndroidSpecific struct {
@@ -116,6 +123,7 @@ type ReactNativeAndroid struct {
 
 	ReactNative ReactNativeShared          `embed:""`
 	Android     ReactNativeAndroidSpecific `embed:""`
+	Overwrite   bool                       `help:"Whether to ignore and overwrite existing uploads with same identifier, rather than failing if a matching file exists"`
 }
 
 type ReactNativeShared struct {
@@ -140,6 +148,7 @@ type ReactNativeIos struct {
 
 	ReactNative ReactNativeShared      `embed:""`
 	Ios         ReactNativeIosSpecific `embed:""`
+	Overwrite   bool                   `help:"Whether to ignore and overwrite existing uploads with same identifier, rather than failing if a matching file exists"`
 }
 
 type UnityAndroid struct {
@@ -151,6 +160,7 @@ type UnityAndroid struct {
 	ProjectRoot   string      `help:"The path to strip from the beginning of source file names referenced in stacktraces on the BugSnag dashboard" type:"path"`
 	VersionCode   string      `help:"The version code of this build of the application"`
 	VersionName   string      `help:"The version of the application"`
+	Overwrite     bool        `help:"Whether to ignore and overwrite existing uploads with same identifier, rather than failing if a matching file exists"`
 }
 type Breakpad struct {
 	Path            utils.Paths `arg:"" name:"path" help:"The path to the symbol files (.sym) to upload (or directory containing them)" type:"path"`
@@ -162,6 +172,7 @@ type Breakpad struct {
 	ProjectRoot     string      `help:"The path to strip from the beginning of source file names referenced in stacktraces on the BugSnag dashboard" type:"path"`
 	OsName          string      `help:"The name of the operating system that the module was built for"`
 	VersionName     string      `help:"The version of the application"`
+	Overwrite       bool        `help:"Whether to ignore and overwrite existing uploads with same identifier, rather than failing if a matching file exists"`
 }
 
 // Unique CLI options
@@ -172,7 +183,6 @@ type CLI struct {
 	CreateBuild          CreateBuild          `cmd:"" help:"Provide extra information whenever you build, release, or deploy your application"`
 	Upload               struct {
 		// shared options
-		Overwrite        bool   `help:"Whether to ignore and overwrite existing uploads with same identifier, rather than failing if a matching file exists"`
 		Retries          int    `help:"The number of retry attempts before failing an upload request" default:"0"`
 		Timeout          int    `help:"The number of seconds to wait before failing an upload request" default:"300"`
 		UploadAPIRootUrl string `help:"The upload server hostname, optionally containing port number" default:"https://upload.bugsnag.com"`

--- a/pkg/upload/all.go
+++ b/pkg/upload/all.go
@@ -21,7 +21,7 @@ func All(options options.CLI, endpoint string, logger log.Logger,
 
 	uploadOptions["apiKey"] = options.ApiKey
 
-	if options.Upload.Overwrite {
+	if allOptions.Overwrite {
 		uploadOptions["overwrite"] = "true"
 	}
 

--- a/pkg/upload/android-aab.go
+++ b/pkg/upload/android-aab.go
@@ -73,6 +73,7 @@ func ProcessAndroidAab(globalOptions options.CLI, endpoint string, logger log.Lo
 				ProjectRoot:   aabOptions.ProjectRoot,
 				VersionCode:   manifestData["versionCode"],
 				VersionName:   manifestData["versionName"],
+				Overwrite:     aabOptions.Overwrite,
 			}
 			globalOptions.ApiKey = manifestData["apiKey"]
 			err = ProcessAndroidNDK(globalOptions, endpoint, logger)
@@ -99,6 +100,7 @@ func ProcessAndroidAab(globalOptions options.CLI, endpoint string, logger log.Lo
 			Path:          []string{mappingFilePath},
 			VersionCode:   manifestData["versionCode"],
 			VersionName:   manifestData["versionName"],
+			Overwrite:     aabOptions.Overwrite,
 		}
 		globalOptions.ApiKey = manifestData["apiKey"]
 		err = ProcessAndroidProguard(globalOptions, endpoint, logger)

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -177,6 +177,7 @@ func ProcessAndroidNDK(options options.CLI, endpoint string, logger log.Logger) 
 		ndkOptions.ProjectRoot,
 		endpoint,
 		options,
+		ndkOptions.Overwrite,
 		logger,
 	)
 

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -162,7 +162,7 @@ func ProcessAndroidProguard(options options.CLI, endpoint string, logger log.Log
 			return err
 		}
 
-		uploadOptions, err := utils.BuildAndroidProguardUploadOptions(options.ApiKey, proguardOptions.ApplicationId, proguardOptions.VersionName, proguardOptions.VersionCode, proguardOptions.BuildUuid, options.Upload.Overwrite)
+		uploadOptions, err := utils.BuildAndroidProguardUploadOptions(options.ApiKey, proguardOptions.ApplicationId, proguardOptions.VersionName, proguardOptions.VersionCode, proguardOptions.BuildUuid, proguardOptions.Overwrite)
 
 		if err != nil {
 			return err

--- a/pkg/upload/breakpad.go
+++ b/pkg/upload/breakpad.go
@@ -50,7 +50,7 @@ func ProcessBreakpad(globalOptions options.CLI, endpoint string, logger log.Logg
 
 		queryParams := fmt.Sprintf("?api_key=%s&overwrite=%t&project_root=%s",
 			strings.ReplaceAll(apiKey, " ", "%20"),
-			globalOptions.Upload.Overwrite,
+			breakpadOptions.Overwrite,
 			strings.ReplaceAll(projectRoot, " ", "%20"),
 		)
 

--- a/pkg/upload/dart.go
+++ b/pkg/upload/dart.go
@@ -44,7 +44,7 @@ func Dart(options options.CLI, endpoint string, logger log.Logger) error {
 			}
 
 			// Build Upload options
-			uploadOptions := utils.BuildDartUploadOptions(options.ApiKey, buildId, "android", options.Upload.Overwrite, dartOptions.VersionName, dartOptions.VersionCode)
+			uploadOptions := utils.BuildDartUploadOptions(options.ApiKey, buildId, "android", dartOptions.Overwrite, dartOptions.VersionName, dartOptions.VersionCode)
 
 			fileFieldData := make(map[string]server.FileField)
 			fileFieldData["symbolFile"] = server.LocalFile(file)
@@ -85,7 +85,7 @@ func Dart(options options.CLI, endpoint string, logger log.Logger) error {
 			}
 
 			// Build Upload options
-			uploadOptions := utils.BuildDartUploadOptions(options.ApiKey, buildId, "ios", options.Upload.Overwrite, dartOptions.VersionName, dartOptions.BundleVersion)
+			uploadOptions := utils.BuildDartUploadOptions(options.ApiKey, buildId, "ios", dartOptions.Overwrite, dartOptions.VersionName, dartOptions.BundleVersion)
 
 			fileFieldData := make(map[string]server.FileField)
 			fileFieldData["symbolFile"] = server.LocalFile(file)

--- a/pkg/upload/js.go
+++ b/pkg/upload/js.go
@@ -303,7 +303,7 @@ func uploadSingleSourceMap(sourceMapPath string, bundlePath string, bundleUrl st
 		sourceMapFile = server.LocalFile(sourceMapPath)
 	}
 
-	uploadOptions, err := utils.BuildJsUploadOptions(options.ApiKey, versionName, codeBundleId, bundleUrl, projectRoot, options.Upload.Overwrite)
+	uploadOptions, err := utils.BuildJsUploadOptions(options.ApiKey, versionName, codeBundleId, bundleUrl, projectRoot, options.Upload.Js.Overwrite)
 
 	if err != nil {
 		return fmt.Errorf("failed to build upload options: %s", err.Error())

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -157,7 +157,7 @@ func ProcessReactNativeAndroid(options options.CLI, endpoint string, logger log.
 			}
 		}
 
-		uploadOptions, err = utils.BuildReactNativeUploadOptions(options.ApiKey, androidOptions.ReactNative.VersionName, androidOptions.Android.VersionCode, androidOptions.ReactNative.CodeBundleId, androidOptions.ReactNative.Dev, androidOptions.ProjectRoot, options.Upload.Overwrite, "android")
+		uploadOptions, err = utils.BuildReactNativeUploadOptions(options.ApiKey, androidOptions.ReactNative.VersionName, androidOptions.Android.VersionCode, androidOptions.ReactNative.CodeBundleId, androidOptions.ReactNative.Dev, androidOptions.ProjectRoot, androidOptions.Overwrite, "android")
 
 		if err != nil {
 			return err

--- a/pkg/upload/react-native-ios.go
+++ b/pkg/upload/react-native-ios.go
@@ -190,7 +190,7 @@ func ProcessReactNativeIos(options options.CLI, endpoint string, logger log.Logg
 
 	}
 
-	uploadOptions, err := utils.BuildReactNativeUploadOptions(options.ApiKey, iosOptions.ReactNative.VersionName, iosOptions.Ios.BundleVersion, iosOptions.ReactNative.CodeBundleId, iosOptions.ReactNative.Dev, iosOptions.ProjectRoot, options.Upload.Overwrite, "ios")
+	uploadOptions, err := utils.BuildReactNativeUploadOptions(options.ApiKey, iosOptions.ReactNative.VersionName, iosOptions.Ios.BundleVersion, iosOptions.ReactNative.CodeBundleId, iosOptions.ReactNative.Dev, iosOptions.ProjectRoot, iosOptions.Overwrite, "ios")
 
 	if err != nil {
 		return err

--- a/pkg/upload/unity-android.go
+++ b/pkg/upload/unity-android.go
@@ -121,6 +121,7 @@ func ProcessUnityAndroid(globalOptions options.CLI, endpoint string, logger log.
 			unityOptions.ProjectRoot,
 			endpoint,
 			globalOptions,
+			unityOptions.Overwrite,
 			logger,
 		)
 


### PR DESCRIPTION
## Goal

Remove the `--overwrite` option from the dSYM related commands as this option is not used by the API

## Testing

Covered by CI