### PR TITLE
Add support for Unity iOS and Unity iOS line mappings

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -106,23 +106,42 @@ steps:
         upload:
           - maze_output/**/*
 
-  - label: ":video_game: Unity Android Integration Tests"
-    depends_on: build
-    env:
-      UNITY_VERSION: 6000.0.49f1
-    agents:
-      queue: macos-15-isolated
-    commands:
-      - chmod +x bin/arm64-macos-bugsnag-cli
-      - bundle install
-      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) features/unity
-    plugins:
-      artifacts#v1.5.0:
-        download:
-          - bin/arm64-macos-bugsnag-cli
-        upload:
-          - maze_output/**/*
-  
+  - group: ":video_game: Unity"
+    steps:
+      - label: ":video_game: Unity Android Integration Tests"
+        depends_on: build
+        env:
+          UNITY_VERSION: 6000.0.49f1
+        agents:
+          queue: macos-15-isolated
+        commands:
+          - chmod +x bin/arm64-macos-bugsnag-cli
+          - bundle install
+          - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) features/unity/android.feature
+        plugins:
+          artifacts#v1.5.0:
+            download:
+              - bin/arm64-macos-bugsnag-cli
+            upload:
+              - maze_output/**/*
+
+      - label: ":video_game: Unity iOS Integration Tests"
+        depends_on: build
+        env:
+          UNITY_VERSION: 6000.0.49f1
+        agents:
+          queue: macos-15-isolated
+        commands:
+          - chmod +x bin/arm64-macos-bugsnag-cli
+          - bundle install
+          - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) features/unity/ios.feature
+        plugins:
+          artifacts#v1.5.0:
+            download:
+              - bin/arm64-macos-bugsnag-cli
+            upload:
+              - maze_output/**/*
+
   - label: "Breakpad Integration Tests"
     depends_on: build
     commands:

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -449,3 +449,10 @@ Before('@BuildNestedJS') do
     $nested_js = true
   end
 end
+
+Given(/^I build the Unity project for iOS$/) do
+  @fixture_dir = "#{base_dir}/platforms-examples/Unity"
+  Dir.chdir(@fixture_dir)
+  @output = `./build_ios.sh`
+  Dir.chdir(base_dir)
+end

--- a/features/unity/ios.feature
+++ b/features/unity/ios.feature
@@ -1,0 +1,65 @@
+Feature: Unity iOS integration tests
+  Scenario: Unity iOS integration test
+    Given I build the Unity project for iOS
+    And I wait for the build to succeed
+
+    When I run bugsnag-cli with upload unity-ios --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --no-upload-il-2-cpp-mapping-file platforms-examples/Unity/UnityExample/
+    Then I wait to receive 2 sourcemaps
+    Then the sourcemap is valid for the dSYM Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
+
+  Scenario: Unity iOS integration test with Unity Line Mappings
+    Given I build the Unity project for iOS
+    And I wait for the build to succeed
+
+    When I run bugsnag-cli with upload unity-ios --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite platforms-examples/Unity/UnityExample/
+    Then I wait to receive 3 sourcemaps
+
+    Then the sourcemap is valid for the Unity Line Mapping API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "appVersion" equals "1.0"
+    And the sourcemap payload field "appBundleVersion" equals "1.0"
+    And the sourcemap payload field "dsymUUID" is not null
+    And the sourcemap payload field "appId" equals "com.apple.xcode.dsym.com.unity3d.framework"
+    And the sourcemap payload field "overwrite" equals "true"
+
+    And I discard the oldest sourcemaps
+
+    Then the sourcemap is valid for the dSYM Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
+
+    And I discard the oldest sourcemaps
+
+    Then the sourcemap is valid for the dSYM Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
+
+
+  Scenario: Unity iOS integration test with Unity Line Mappings passing version numbers
+    Given I build the Unity project for iOS
+    And I wait for the build to succeed
+
+    When I run bugsnag-cli with upload unity-ios --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite platforms-examples/Unity/UnityExample/ --application-id=com.bugsnag.unity.test --bundle-version=999.99 --version-name=123.456
+    Then I wait to receive 3 sourcemaps
+
+    Then the sourcemap is valid for the Unity Line Mapping API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "appVersion" equals "123.456"
+    And the sourcemap payload field "appBundleVersion" equals "999.99"
+    And the sourcemap payload field "dsymUUID" is not null
+    And the sourcemap payload field "appId" equals "com.bugsnag.unity.test"
+    And the sourcemap payload field "overwrite" equals "true"
+
+    And I discard the oldest sourcemaps
+
+    Then the sourcemap is valid for the dSYM Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
+
+    And I discard the oldest sourcemaps
+
+    Then the sourcemap is valid for the dSYM Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"

--- a/main.go
+++ b/main.go
@@ -167,6 +167,18 @@ func main() {
 			logger.Fatal(err.Error())
 		}
 
+	case "upload unity-ios", "upload unity-ios <path>":
+
+		if commands.ApiKey == "" {
+			logger.Fatal("missing api key, please specify using `--api-key`")
+		}
+
+		err := upload.ProcessUnityIos(commands, endpoint, logger)
+
+		if err != nil {
+			logger.Fatal(err.Error())
+		}
+
 	case "upload breakpad <path>":
 		if commands.ApiKey == "" {
 			logger.Fatal("missing api key, please specify using `--api-key`")

--- a/pkg/ios/plist-reader-json.go
+++ b/pkg/ios/plist-reader-json.go
@@ -13,6 +13,7 @@ import (
 // PlistData contains the relevant content of a plist file for uploading to Bugsnag.
 // It extracts the app version, bundle version, and Bugsnag-specific project details.
 type PlistData struct {
+	BundleIdentifier      string                `json:"CFBundleIdentifier"`
 	VersionName           string                `json:"CFBundleShortVersionString"`
 	BundleVersion         string                `json:"CFBundleVersion"`
 	BugsnagProjectDetails bugsnagProjectDetails `json:"bugsnag"`

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -190,6 +190,7 @@ type CLI struct {
 		ReactNativeAndroid ReactNativeAndroid     `cmd:"" help:"Upload source maps for React Native Android"`
 		ReactNativeIos     ReactNativeIos         `cmd:"" help:"Upload source maps for React Native iOS"`
 		UnityAndroid       UnityAndroid           `cmd:"" help:"Upload Android mappings and NDK symbol files from Unity projects"`
+		UnityIos           UnityIos               `cmd:"" help:"Upload iOS mappings and dSYM files from Unity projects"`
 		Breakpad           Breakpad               `cmd:"" help:"Upload breakpad .sym files"`
 	} `cmd:"" help:"Upload symbol/mapping files"`
 }

--- a/pkg/options/unity.go
+++ b/pkg/options/unity.go
@@ -20,5 +20,16 @@ type UnityAndroid struct {
 	VersionName   string      `help:"The version of the application"`
 	Overwrite     bool        `help:"Whether to ignore and overwrite existing uploads with same identifier, rather than failing if a matching file exists"`
 
-	Shared UnityLineMapping `embed:""`
+	UnityShared UnityLineMapping `embed:""`
+}
+
+type UnityIos struct {
+	Path          utils.Paths `arg:"" name:"path" help:"The path to the Unity symbols (.zip) file to upload (or directory containing it)" type:"path" default:"."`
+	ApplicationId string      `help:"A unique application ID, usually the package name, of the application"`
+	BundleVersion string      `help:"The bundle version of this build of the application (Apple platforms only)"`
+	VersionName   string      `help:"The version of the application"`
+	Overwrite     bool        `help:"Whether to ignore and overwrite existing uploads with same identifier, rather than failing if a matching file exists"`
+
+	UnityShared UnityLineMapping `embed:""`
+	DsymShared  DsymShared       `embed:""`
 }

--- a/pkg/unity/find-line-mappings.go
+++ b/pkg/unity/find-line-mappings.go
@@ -48,3 +48,42 @@ func GetAndroidLineMapping(path string, buildDir string) (string, error) {
 
 	return "", fmt.Errorf("Unable to fine line mapping file in your project: %s ", buildDir)
 }
+
+// GetiOSLineMapping locates the LineNumberMappings.json file for iOS builds.
+//
+// This function attempts to resolve the path to the IL2CPP line number mapping file,
+// used for symbolication or debugging in iOS builds. The resolution follows this order:
+//
+//  1. If the input 'path' is non-empty, it is returned as-is.
+//  2. It checks the default path: Library/Bee/artifacts/iOS/il2cppOutput/cpp/Symbols/LineNumberMappings.json.
+//  3. If not found, it searches under a backup folder (ending with "_xcode" inside 'projectRoot') at:
+//     Il2CppOutputProject/Source/il2cppOutput/Symbols/LineNumberMappings.json.
+//
+// Parameters:
+//
+//	path        - an optional explicit path to the mapping file. If provided, it is returned directly.
+//	projectRoot - the root path of the Unity project, used to search for backup artifacts.
+//
+// Returns:
+//
+//	mappingPath - the resolved path to LineNumberMappings.json.
+//	error       - non-nil if the file cannot be found or the backup folder is missing.
+func GetiOSLineMapping(path string, projectRoot string) (string, error) {
+	if path != "" {
+		return path, nil
+	}
+
+	// Check default artifacts path
+	defaultPath := filepath.Join("Library", "Bee", "artifacts", "iOS", "il2cppOutput", "cpp", "Symbols", "LineNumberMappings.json")
+	if utils.FileExists(defaultPath) {
+		return defaultPath, nil
+	}
+
+	// Try fallback: backup directory
+	backupPath := filepath.Join(projectRoot, "Il2CppOutputProject", "Source", "il2cppOutput", "Symbols", "LineNumberMappings.json")
+	if utils.FileExists(backupPath) {
+		return backupPath, nil
+	}
+
+	return "", fmt.Errorf("unable to find line mapping file in your project: %s", projectRoot)
+}

--- a/pkg/unity/process-line-mappings.go
+++ b/pkg/unity/process-line-mappings.go
@@ -43,3 +43,39 @@ func UploadAndroidLineMappings(
 		logger,
 	)
 }
+
+func UploadIosLineMappings(
+	lineMappingFile string,
+	dsymUuid string,
+	endpoint string,
+	options options.CLI,
+	logger log.Logger,
+) error {
+	opts := utils.UnityLineMappingOptions{
+		APIKey:           options.ApiKey,
+		AppID:            options.Upload.UnityIos.ApplicationId,
+		AppVersion:       options.Upload.UnityIos.VersionName,
+		AppBundleVersion: options.Upload.UnityIos.BundleVersion,
+		DSYMUUUID:        dsymUuid,
+		ProjectRoot:      options.Upload.UnityIos.DsymShared.ProjectRoot,
+		Overwrite:        options.Upload.UnityIos.Overwrite,
+	}
+
+	fileFieldData := map[string]server.FileField{
+		"mappingFile": server.LocalFile(lineMappingFile),
+	}
+
+	uploadOptions, err := utils.BuildUnityLineMappingUploadOptions(opts)
+	if err != nil {
+		return err
+	}
+
+	return server.ProcessFileRequest(
+		endpoint+"/unity-line-mappings",
+		uploadOptions,
+		fileFieldData,
+		lineMappingFile,
+		options,
+		logger,
+	)
+}

--- a/pkg/upload/unity-android.go
+++ b/pkg/upload/unity-android.go
@@ -102,10 +102,10 @@ func ProcessUnityAndroid(globalOptions options.CLI, endpoint string, logger log.
 			return err
 		}
 
-		if unityOptions.Shared.NoUploadIl2cppMappingFile {
+		if unityOptions.UnityShared.NoUploadIl2cppMappingFile {
 			logger.Debug("Skipping the upload of the LineNumberMappings.json file")
 		} else {
-			lineMappingFile, err = unity.GetAndroidLineMapping(string(unityOptions.Shared.UploadIl2cppMappingFile), buildDirectory)
+			lineMappingFile, err = unity.GetAndroidLineMapping(string(unityOptions.UnityShared.UploadIl2cppMappingFile), buildDirectory)
 			if err != nil {
 				return err
 			}
@@ -124,7 +124,7 @@ func ProcessUnityAndroid(globalOptions options.CLI, endpoint string, logger log.
 				}
 
 				// If we're uploading a libil2cpp.so file, we want to extract the build ID so that we can upload the linemapping file
-				if filepath.Base(file) == "libil2cpp.so" && !unityOptions.Shared.NoUploadIl2cppMappingFile {
+				if filepath.Base(file) == "libil2cpp.so" && !unityOptions.UnityShared.NoUploadIl2cppMappingFile {
 					buildId, err := elf.GetBuildId(file)
 					if err != nil {
 						return fmt.Errorf("failed to get build ID from %s: %w", file, err)

--- a/pkg/upload/unity-ios.go
+++ b/pkg/upload/unity-ios.go
@@ -1,0 +1,148 @@
+package upload
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/bugsnag/bugsnag-cli/pkg/ios"
+	"github.com/bugsnag/bugsnag-cli/pkg/log"
+	"github.com/bugsnag/bugsnag-cli/pkg/options"
+	"github.com/bugsnag/bugsnag-cli/pkg/unity"
+	"github.com/bugsnag/bugsnag-cli/pkg/utils"
+)
+
+func ProcessUnityIos(globalOptions options.CLI, endpoint string, logger log.Logger) error {
+	unityOptions := globalOptions.Upload.UnityIos
+	var tempDirs []string
+
+	defer func() {
+		for _, dir := range tempDirs {
+			_ = os.RemoveAll(dir)
+		}
+	}()
+
+	for _, path := range unityOptions.Path {
+		var (
+			err             error
+			pathToCheck     string
+			dsyms           []*ios.DwarfInfo
+			tempDir         string
+			lineMappingFile string
+			plistData       *ios.PlistData
+		)
+
+		if unityOptions.DsymShared.Scheme == "" {
+			unityOptions.DsymShared.Scheme = "Unity-iPhone"
+			logger.Info(fmt.Sprintf("Using scheme: %s", unityOptions.DsymShared.Scheme))
+		}
+
+		// Handle Xcode project detection
+		if ios.IsPathAnXcodeProjectOrWorkspace(path) {
+			globalOptions.Upload.XcodeArchive = options.XcodeArchive{
+				Path:   utils.Paths{path},
+				Shared: unityOptions.DsymShared,
+			}
+
+			xcarchivePath, err := ios.FindXcarchivePath(globalOptions, logger)
+			if err != nil {
+				return fmt.Errorf("failed to find Xcode archive path: %w", err)
+			}
+			if xcarchivePath == "" {
+				return fmt.Errorf("no Xcode archive found in specified paths")
+			}
+
+			logger.Info(fmt.Sprintf("Found Xcode archive at %s", xcarchivePath))
+			pathToCheck = xcarchivePath
+		} else {
+			pathToCheck = path
+		}
+
+		dsyms, tempDir, err = ios.FindDsymsInPath(
+			pathToCheck,
+			unityOptions.DsymShared.IgnoreEmptyDsym,
+			unityOptions.DsymShared.IgnoreMissingDwarf,
+			logger,
+		)
+		tempDirs = append(tempDirs, tempDir)
+
+		if err != nil {
+			return fmt.Errorf("error locating dSYM files: %w", err)
+		}
+		if len(dsyms) == 0 {
+			return fmt.Errorf("no dSYM files found in: %s", pathToCheck)
+		}
+
+		logger.Info(fmt.Sprintf("Found %d dSYM files in: %s", len(dsyms), pathToCheck))
+
+		// Resolve plist path if not explicitly provided
+		plistPath := string(unityOptions.DsymShared.Plist)
+		if plistPath == "" {
+			plistPath = filepath.Join(dsyms[0].Location, "..", "..", "Info.plist")
+		}
+
+		if !utils.FileExists(plistPath) {
+			return fmt.Errorf("plist file not found at: %s", plistPath)
+		}
+		logger.Info(fmt.Sprintf("Using plist path: %s", plistPath))
+
+		plistData, err = ios.GetPlistData(plistPath)
+		if err != nil {
+			return fmt.Errorf("failed to read plist: %w", err)
+		}
+
+		if plistData != nil {
+			if globalOptions.Upload.UnityIos.VersionName == "" {
+				globalOptions.Upload.UnityIos.VersionName = plistData.VersionName
+			}
+
+			if globalOptions.Upload.UnityIos.BundleVersion == "" {
+				globalOptions.Upload.UnityIos.BundleVersion = plistData.BundleVersion
+			}
+
+			if globalOptions.Upload.UnityIos.ApplicationId == "" {
+				globalOptions.Upload.UnityIos.ApplicationId = plistData.BundleIdentifier
+			}
+		}
+
+		// Optionally process line mapping file
+		if unityOptions.UnityShared.NoUploadIl2cppMappingFile {
+			logger.Debug("Skipping the upload of the LineNumberMappings.json file")
+		} else {
+			lineMappingFile, err = unity.GetiOSLineMapping(
+				string(unityOptions.UnityShared.UploadIl2cppMappingFile),
+				path,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to get line mapping file: %w", err)
+			}
+			logger.Info(fmt.Sprintf("Found line mapping file: %s", lineMappingFile))
+		}
+
+		// Log dSYM details
+		for _, dsym := range dsyms {
+			if dsym.Name == "UnityFramework" && lineMappingFile != "" {
+				logger.Info(fmt.Sprintf("Uploading %s for dSYM %s, withID %s", lineMappingFile, dsym.Name, dsym.UUID))
+				err = unity.UploadIosLineMappings(
+					lineMappingFile,
+					dsym.UUID,
+					endpoint,
+					globalOptions,
+					logger,
+				)
+
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		// Upload dSYMs and plist
+		err = UploadDsyms(dsyms, plistPath, endpoint, globalOptions, logger)
+		if err != nil {
+			return fmt.Errorf("failed to upload dSYMs: %w", err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Goal

- Refactor the Xcode build function to allow the Unity iOS command to use parts of it to find the dsyms.
- Add functionality to find the line mappings for an iOS build.
- Add the `unity-ios` command for finding dsyms and line mapping files as part of an Xcode build phase and standalone.
- Add tests to cover the new Unity iOS command.

## Testing

Covered by CI