### PR TITLE
Fix Unity Android CI Flakes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
-gem "bugsnag-maze-runner", "~> 9.0"
+gem "bugsnag-maze-runner", "~> 9.36"
 gem 'cocoapods'

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -454,3 +454,8 @@ Given(/^I build the Unity project for iOS$/) do
   @output = `./build_ios.sh`
   Dir.chdir(base_dir)
 end
+
+And(/^I sort the sourcemaps by path$/) do
+  list = Maze::Server.list_for('sourcemap')
+  list.sort_by_request_path!
+end

--- a/features/unity/android.feature
+++ b/features/unity/android.feature
@@ -5,13 +5,14 @@ Feature: Unity Android integration tests
 
     When I run bugsnag-cli with upload unity-android --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --no-upload-il2cpp-mapping platforms-examples/Unity/
     Then I wait to receive 5 sourcemaps
-    Then the sourcemap is valid for the Android Build API
+    Then the sourcemaps are valid for the API
     Then the sourcemaps Content-Type header is valid multipart form-data
-    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
-    And the sourcemap payload field "appId" equals "com.bugsnag.example.unity.android"
-    And the sourcemap payload field "versionCode" equals "1"
-    And the sourcemap payload field "versionName" equals "1.0"
-    And the sourcemap payload field "overwrite" equals "true"
+    Then the sourcemap payload fields should be:
+      | apiKey       | 1234567890ABCDEF1234567890ABCDEF     |
+      | appId        | com.bugsnag.example.unity.android    |
+      | versionCode  | 1                                    |
+      | versionName  | 1.0                                  |
+      | overwrite    | true                                 |
 
   Scenario: Unity Android integration tests passing the aab file
     Given I build the Unity project for Android
@@ -19,13 +20,14 @@ Feature: Unity Android integration tests
 
     When I run bugsnag-cli with upload unity-android --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --no-upload-il2cpp-mapping --aab-path platforms-examples/Unity/UnityExample.aab platforms-examples/Unity/
     Then I wait to receive 5 sourcemaps
-    Then the sourcemap is valid for the Android Build API
+    Then the sourcemaps are valid for the API
     Then the sourcemaps Content-Type header is valid multipart form-data
-    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
-    And the sourcemap payload field "appId" equals "com.bugsnag.example.unity.android"
-    And the sourcemap payload field "versionCode" equals "1"
-    And the sourcemap payload field "versionName" equals "1.0"
-    And the sourcemap payload field "overwrite" equals "true"
+    Then the sourcemap payload fields should be:
+      | apiKey       | 1234567890ABCDEF1234567890ABCDEF     |
+      | appId        | com.bugsnag.example.unity.android    |
+      | versionCode  | 1                                    |
+      | versionName  | 1.0                                  |
+      | overwrite    | true                                 |
 
   Scenario: Unity Android integration test with Unity Line Mappings
     Given I build the Unity project for Android
@@ -33,6 +35,35 @@ Feature: Unity Android integration tests
 
     When I run bugsnag-cli with upload unity-android --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite platforms-examples/Unity/
     Then I wait to receive 6 sourcemaps
+
+    And I sort the sourcemaps by path
+
+    Then the sourcemap is valid for the Android Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "appId" equals "com.bugsnag.example.unity.android"
+    And the sourcemap payload field "versionCode" equals "1"
+    And the sourcemap payload field "versionName" equals "1.0"
+    And the sourcemap payload field "overwrite" equals "true"
+
+    And I discard the oldest sourcemaps
+
+    Then the sourcemap is valid for the Android Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "appId" equals "com.bugsnag.example.unity.android"
+    And the sourcemap payload field "versionCode" equals "1"
+    And the sourcemap payload field "versionName" equals "1.0"
+    And the sourcemap payload field "overwrite" equals "true"
+
+    And I discard the oldest sourcemaps
+
+    Then the sourcemap is valid for the Android Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "appId" equals "com.bugsnag.example.unity.android"
+    And the sourcemap payload field "versionCode" equals "1"
+    And the sourcemap payload field "versionName" equals "1.0"
+    And the sourcemap payload field "overwrite" equals "true"
+
+    And I discard the oldest sourcemaps
 
     Then the sourcemap is valid for the Android Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -55,7 +86,6 @@ Feature: Unity Android integration tests
     Then the sourcemap is valid for the Unity Line Mapping API
     Then the sourcemaps Content-Type header is valid multipart form-data
     And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
-
     And the sourcemap payload field "appVersion" equals "1.0"
     And the sourcemap payload field "appVersionCode" equals "1"
     And the sourcemap payload field "soBuildId" is not null
@@ -69,6 +99,35 @@ Feature: Unity Android integration tests
     When I run bugsnag-cli with upload unity-android --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite platforms-examples/Unity/ --application-id=com.bugsnag.unity.test --version-code=999.99 --version-name=123.456
     Then I wait to receive 6 sourcemaps
 
+    And I sort the sourcemaps by path
+
+    Then the sourcemap is valid for the Android Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "appId" equals "com.bugsnag.unity.test"
+    And the sourcemap payload field "versionCode" equals "999.99"
+    And the sourcemap payload field "versionName" equals "123.456"
+    And the sourcemap payload field "overwrite" equals "true"
+
+    And I discard the oldest sourcemaps
+
+    Then the sourcemap is valid for the Android Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "appId" equals "com.bugsnag.unity.test"
+    And the sourcemap payload field "versionCode" equals "999.99"
+    And the sourcemap payload field "versionName" equals "123.456"
+    And the sourcemap payload field "overwrite" equals "true"
+
+    And I discard the oldest sourcemaps
+
+    Then the sourcemap is valid for the Android Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "appId" equals "com.bugsnag.unity.test"
+    And the sourcemap payload field "versionCode" equals "999.99"
+    And the sourcemap payload field "versionName" equals "123.456"
+    And the sourcemap payload field "overwrite" equals "true"
+
+    And I discard the oldest sourcemaps
+
     Then the sourcemap is valid for the Android Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
     And the sourcemap payload field "appId" equals "com.bugsnag.unity.test"
@@ -90,7 +149,6 @@ Feature: Unity Android integration tests
     Then the sourcemap is valid for the Unity Line Mapping API
     Then the sourcemaps Content-Type header is valid multipart form-data
     And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
-
     And the sourcemap payload field "appVersion" equals "123.456"
     And the sourcemap payload field "appVersionCode" equals "999.99"
     And the sourcemap payload field "soBuildId" is not null


### PR DESCRIPTION
## Goal

Update the Unity Android E2E tests to ensure we can test the sourcemaps and line mapping files uploaded to the mock API

## Testing

Covered by CI