### PR TITLE
Throw new Error in bugsnag-cli-placeholder instead of console.log

### DIFF
--- a/js/bin/bugsnag-cli-placeholder
+++ b/js/bin/bugsnag-cli-placeholder
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-console.log("error - bugsnag-cli binary has not been installed successfully")
+throw new Error("error - bugsnag-cli binary has not been installed successfully")


### PR DESCRIPTION
## Goal

Simply logging an error message in the `bugsnag-cli-placeholder` can make it easier to miss the issue if the CLI fails to be installed properly. Throwing an error here instead will make it more obvious.

## Design

Designed to error out instead of just log a warning if the CLI is not installed properly.

## Changeset

`console.log` in `bugsnag-cli/js/bin/bugsnag-cli-placeholder` is now `throw new Error`

## Testing

Ran the `bugsnag-cli-placeholder` file with a test `console.log` after the error. This now throws an error and stops execution, and should give a stack trace.