### PR TITLE
add fallback path for androidmanifest.xml android proguard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Add a fallback path for AndroidManifest.xml when processing Proguard uploads []()
+- Add a fallback path for AndroidManifest.xml when processing Proguard uploads [#249](https://github.com/bugsnag/bugsnag-cli/pull/249)
 
 ## [3.5.1] - 2025-11-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Changed
+
+- Add a fallback path for AndroidManifest.xml when processing Proguard uploads []()
+
 ## [3.5.1] - 2025-11-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Add a fallback path for AndroidManifest.xml when processing Proguard uploads [#249](https://github.com/bugsnag/bugsnag-cli/pull/249)
+- Add a fallback path for AndroidManifest.xml when processing Android related uploads (Proguard, NDK and React Native) [#249](https://github.com/bugsnag/bugsnag-cli/pull/249)
 
 ## [3.5.1] - 2025-11-13
 

--- a/pkg/android/find-android-manifest.go
+++ b/pkg/android/find-android-manifest.go
@@ -1,6 +1,7 @@
 package android
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
@@ -14,25 +15,37 @@ import (
 // on disk.
 //
 // Parameters:
-//   - path: The Android merged_manifests directory.
+//   - buildFolder: The root build directory where Android build outputs are located.
 //   - variant: The build variant (e.g., "debug", "release") whose manifest paths
 //     should be searched.
 //
 // Returns:
 //   - string: The resolved manifest path if found, otherwise an empty string.
-func FindAndroidManifest(path string, variant string) string {
+//   - error: Non-nil if the manifest cannot be found.
+func FindAndroidManifest(buildFolder string, variant string) (string, error) {
+	var err error
 
-	primaryAppManifestPath := filepath.Join(path, variant, "AndroidManifest.xml")
+	mergedManifestPath := filepath.Join(buildFolder, "intermediates", "merged_manifests")
 
-	fallbackAppManifestPath := filepath.Join(path, variant, "process"+variant+"Manifest", "AndroidManifest.xml")
+	if variant == "" {
+		variant, err = GetVariantDirectory(mergedManifestPath)
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	primaryAppManifestPath := filepath.Join(mergedManifestPath, variant, "AndroidManifest.xml")
+
+	fallbackAppManifestPath := filepath.Join(mergedManifestPath, variant, "process"+variant+"Manifest", "AndroidManifest.xml")
 
 	paths := []string{primaryAppManifestPath, fallbackAppManifestPath}
 
 	for _, path := range paths {
 		if utils.FileExists(path) {
-			return path
+			return path, nil
 		}
 	}
 
-	return ""
+	return "", fmt.Errorf("unable to locate AndroidManifest.xml for variant %s", variant)
 }

--- a/pkg/android/find-android-manifest.go
+++ b/pkg/android/find-android-manifest.go
@@ -15,17 +15,17 @@ import (
 // on disk.
 //
 // Parameters:
-//   - buildFolder: The root build directory where Android build outputs are located.
+//   - appBuildPath: The root build directory where Android build outputs are located.
 //   - variant: The build variant (e.g., "debug", "release") whose manifest paths
 //     should be searched.
 //
 // Returns:
 //   - string: The resolved manifest path if found, otherwise an empty string.
 //   - error: Non-nil if the manifest cannot be found.
-func FindAndroidManifest(buildFolder string, variant string) (string, error) {
+func FindAndroidManifest(appBuildPath string, variant string) (string, error) {
 	var err error
 
-	mergedManifestPath := filepath.Join(buildFolder, "intermediates", "merged_manifests")
+	mergedManifestPath := filepath.Join(appBuildPath, "intermediates", "merged_manifests")
 
 	if variant == "" {
 		variant, err = GetVariantDirectory(mergedManifestPath)

--- a/pkg/android/find-android-manifest.go
+++ b/pkg/android/find-android-manifest.go
@@ -1,19 +1,33 @@
 package android
 
-import "github.com/bugsnag/bugsnag-cli/pkg/utils"
+import (
+	"path/filepath"
 
-// FindAndroidManifest locates and returns the first existing AndroidManifest.xml path.
+	"github.com/bugsnag/bugsnag-cli/pkg/utils"
+)
+
+// FindAndroidManifest locates and returns the first existing AndroidManifest.xml
+// for a given build directory and variant.
 //
-// This function iterates through a list of candidate file paths and returns the
-// first one that exists on disk. This is useful when Android build outputs may
-// place the manifest in multiple variant-specific directories.
+// This function constructs and checks multiple potential manifest locations that
+// vary based on Android build outputs. It returns the first manifest file found
+// on disk.
 //
 // Parameters:
-//   - paths: A slice of possible manifest file locations.
+//   - path: The Android merged_manifests directory.
+//   - variant: The build variant (e.g., "debug", "release") whose manifest paths
+//     should be searched.
 //
 // Returns:
-//   - string: The first existing manifest path, or an empty string if none are found.
-func FindAndroidManifest(paths []string) string {
+//   - string: The resolved manifest path if found, otherwise an empty string.
+func FindAndroidManifest(path string, variant string) string {
+
+	primaryAppManifestPath := filepath.Join(path, variant, "AndroidManifest.xml")
+
+	fallbackAppManifestPath := filepath.Join(path, variant, "process"+variant+"Manifest", "AndroidManifest.xml")
+
+	paths := []string{primaryAppManifestPath, fallbackAppManifestPath}
+
 	for _, path := range paths {
 		if utils.FileExists(path) {
 			return path

--- a/pkg/android/find-android-manifest.go
+++ b/pkg/android/find-android-manifest.go
@@ -1,0 +1,24 @@
+package android
+
+import "github.com/bugsnag/bugsnag-cli/pkg/utils"
+
+// FindAndroidManifest locates and returns the first existing AndroidManifest.xml path.
+//
+// This function iterates through a list of candidate file paths and returns the
+// first one that exists on disk. This is useful when Android build outputs may
+// place the manifest in multiple variant-specific directories.
+//
+// Parameters:
+//   - paths: A slice of possible manifest file locations.
+//
+// Returns:
+//   - string: The first existing manifest path, or an empty string if none are found.
+func FindAndroidManifest(paths []string) string {
+	for _, path := range paths {
+		if utils.FileExists(path) {
+			return path
+		}
+	}
+
+	return ""
+}

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -35,18 +35,16 @@ func resolveMergedLibPath(input string) (string, error) {
 //   - libPath: resolved path to merged_native_libs.
 //   - logger: logger used to emit debug output.
 func resolveAppManifestIfNeeded(ndkOpts *options.AndroidNdkMapping, libPath string, logger log.Logger) error {
+	var err error
 	if ndkOpts.AppManifest != "" {
 		return nil
 	}
-	buildFolder := filepath.Join(libPath, "..")
-	manifestPath, err := android.FindAndroidManifest(buildFolder, ndkOpts.Variant)
+	appBuildPath := filepath.Join(libPath, "..")
+	ndkOpts.AppManifest, err = android.FindAndroidManifest(appBuildPath, ndkOpts.Variant)
 	if err != nil {
 		return err
 	}
-	if utils.FileExists(manifestPath) {
-		ndkOpts.AppManifest = manifestPath
-		logger.Debug(fmt.Sprintf("Found AndroidManifest.xml at %s", ndkOpts.AppManifest))
-	}
+	logger.Debug(fmt.Sprintf("Found AndroidManifest.xml at %s", ndkOpts.AppManifest))
 	return nil
 }
 

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -39,7 +39,7 @@ func resolveAppManifestIfNeeded(ndkOpts *options.AndroidNdkMapping, libPath stri
 	if ndkOpts.AppManifest != "" {
 		return nil
 	}
-	appBuildPath := filepath.Join(libPath, "..")
+	appBuildPath := filepath.Join(libPath, "..", "..")
 	ndkOpts.AppManifest, err = android.FindAndroidManifest(appBuildPath, ndkOpts.Variant)
 	if err != nil {
 		return err

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -34,15 +34,20 @@ func resolveMergedLibPath(input string) (string, error) {
 //   - ndkOpts: AndroidNdkMapping options struct (will be mutated).
 //   - libPath: resolved path to merged_native_libs.
 //   - logger: logger used to emit debug output.
-func resolveAppManifestIfNeeded(ndkOpts *options.AndroidNdkMapping, libPath string, logger log.Logger) {
+func resolveAppManifestIfNeeded(ndkOpts *options.AndroidNdkMapping, libPath string, logger log.Logger) error {
 	if ndkOpts.AppManifest != "" {
-		return
+		return nil
 	}
-	manifestPath := filepath.Join(libPath, "..", "merged_manifests", ndkOpts.Variant, "AndroidManifest.xml")
+	buildFolder := filepath.Join(libPath, "..")
+	manifestPath, err := android.FindAndroidManifest(buildFolder, ndkOpts.Variant)
+	if err != nil {
+		return err
+	}
 	if utils.FileExists(manifestPath) {
 		ndkOpts.AppManifest = manifestPath
 		logger.Debug(fmt.Sprintf("Found AndroidManifest.xml at %s", ndkOpts.AppManifest))
 	}
+	return nil
 }
 
 // resolveProjectRootIfNeeded sets the project root directory in ndkOpts if it hasn't already been set.
@@ -165,7 +170,10 @@ func ProcessAndroidNDK(opts options.CLI, logger log.Logger) error {
 					return err
 				}
 			}
-			resolveAppManifestIfNeeded(&ndkOpts, libPath, logger)
+			err := resolveAppManifestIfNeeded(&ndkOpts, libPath, logger)
+			if err != nil {
+				return err
+			}
 			resolveProjectRootIfNeeded(&ndkOpts, libPath)
 		}
 

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -28,8 +28,6 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 	proguardOptions := options.Upload.AndroidProguard
 
 	var mappingFile string
-	var primaryAppManifestPath string
-	var fallbackAppManifestPath string
 	var err error
 
 	for _, path := range proguardOptions.Path {
@@ -58,11 +56,8 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 
 			// Attempt to locate AndroidManifest.xml for the variant if not set
 			if proguardOptions.AppManifest == "" {
-				primaryAppManifestPath = filepath.Join(path, "app", "build", "intermediates", "merged_manifests", proguardOptions.Variant, "AndroidManifest.xml")
-
-				fallbackAppManifestPath = filepath.Join(path, "app", "build", "intermediates", "merged_manifests", proguardOptions.Variant, "process"+proguardOptions.Variant+"Manifest", "AndroidManifest.xml")
-
-				proguardOptions.AppManifest = android.FindAndroidManifest([]string{primaryAppManifestPath, fallbackAppManifestPath})
+				mergedManifestPath := filepath.Join(path, "app", "build", "intermediates", "merged_manifests")
+				proguardOptions.AppManifest = android.FindAndroidManifest(mergedManifestPath, proguardOptions.Variant)
 
 				if proguardOptions.AppManifest == "" {
 					logger.Info("Unable to locate AndroidManifest.xml for variant; proceeding without manifest path")
@@ -79,11 +74,7 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 				if filepath.Base(mergedManifestPath) == "merged_manifests" {
 					proguardOptions.Variant, err = android.GetVariantDirectory(mergedManifestPath)
 					if err == nil {
-						primaryAppManifestPath = filepath.Join(mergedManifestPath, proguardOptions.Variant, "AndroidManifest.xml")
-
-						fallbackAppManifestPath = filepath.Join(mergedManifestPath, proguardOptions.Variant, "process"+proguardOptions.Variant+"Manifest", "AndroidManifest.xml")
-
-						proguardOptions.AppManifest = android.FindAndroidManifest([]string{primaryAppManifestPath, fallbackAppManifestPath})
+						proguardOptions.AppManifest = android.FindAndroidManifest(mergedManifestPath, proguardOptions.Variant)
 
 						if proguardOptions.AppManifest == "" {
 							logger.Info("Unable to locate AndroidManifest.xml for variant; proceeding without manifest path")

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -56,9 +56,11 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 
 			// Attempt to locate AndroidManifest.xml for the variant if not set
 			if proguardOptions.AppManifest == "" {
-				mergedManifestPath := filepath.Join(path, "app", "build", "intermediates", "merged_manifests")
-				proguardOptions.AppManifest = android.FindAndroidManifest(mergedManifestPath, proguardOptions.Variant)
-
+				buildFolder := filepath.Join(path, "app", "build")
+				proguardOptions.AppManifest, err = android.FindAndroidManifest(buildFolder, proguardOptions.Variant)
+				if err != nil {
+					return err
+				}
 				if proguardOptions.AppManifest == "" {
 					logger.Info("Unable to locate AndroidManifest.xml for variant; proceeding without manifest path")
 				}
@@ -70,15 +72,14 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 
 			// Try to find manifest and variant if missing
 			if proguardOptions.AppManifest == "" && proguardOptions.Variant == "" {
-				mergedManifestPath := filepath.Join(path, "..", "..", "..", "..", "intermediates", "merged_manifests")
-				if filepath.Base(mergedManifestPath) == "merged_manifests" {
-					proguardOptions.Variant, err = android.GetVariantDirectory(mergedManifestPath)
-					if err == nil {
-						proguardOptions.AppManifest = android.FindAndroidManifest(mergedManifestPath, proguardOptions.Variant)
-
-						if proguardOptions.AppManifest == "" {
-							logger.Info("Unable to locate AndroidManifest.xml for variant; proceeding without manifest path")
-						}
+				buildFolder := filepath.Join(path, "..", "..", "..", "..")
+				if filepath.Base(buildFolder) == "build" {
+					proguardOptions.AppManifest, err = android.FindAndroidManifest(buildFolder, proguardOptions.Variant)
+					if err != nil {
+						return err
+					}
+					if proguardOptions.AppManifest == "" {
+						logger.Info("Unable to locate AndroidManifest.xml for variant; proceeding without manifest path")
 					}
 				}
 			}

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -56,8 +56,8 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 
 			// Attempt to locate AndroidManifest.xml for the variant if not set
 			if proguardOptions.AppManifest == "" {
-				buildFolder := filepath.Join(path, "app", "build")
-				proguardOptions.AppManifest, err = android.FindAndroidManifest(buildFolder, proguardOptions.Variant)
+				appBuildPath := filepath.Join(path, "app", "build")
+				proguardOptions.AppManifest, err = android.FindAndroidManifest(appBuildPath, proguardOptions.Variant)
 				if err != nil {
 					return err
 				}
@@ -72,9 +72,9 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 
 			// Try to find manifest and variant if missing
 			if proguardOptions.AppManifest == "" && proguardOptions.Variant == "" {
-				buildFolder := filepath.Join(path, "..", "..", "..", "..")
-				if filepath.Base(buildFolder) == "build" {
-					proguardOptions.AppManifest, err = android.FindAndroidManifest(buildFolder, proguardOptions.Variant)
+				appBuildPath := filepath.Join(path, "..", "..", "..", "..")
+				if filepath.Base(appBuildPath) == "build" {
+					proguardOptions.AppManifest, err = android.FindAndroidManifest(appBuildPath, proguardOptions.Variant)
 					if err != nil {
 						return err
 					}

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -28,7 +28,8 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 	proguardOptions := options.Upload.AndroidProguard
 
 	var mappingFile string
-	var appManifestPathExpected string
+	var primaryAppManifestPath string
+	var fallbackAppManifestPath string
 	var err error
 
 	for _, path := range proguardOptions.Path {
@@ -57,10 +58,14 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 
 			// Attempt to locate AndroidManifest.xml for the variant if not set
 			if proguardOptions.AppManifest == "" {
-				appManifestPathExpected = filepath.Join(path, "app", "build", "intermediates", "merged_manifests", proguardOptions.Variant, "AndroidManifest.xml")
-				if utils.FileExists(appManifestPathExpected) {
-					proguardOptions.AppManifest = appManifestPathExpected
-					logger.Info(fmt.Sprintf("Found app manifest at: %s", proguardOptions.AppManifest))
+				primaryAppManifestPath = filepath.Join(path, "app", "build", "intermediates", "merged_manifests", proguardOptions.Variant, "AndroidManifest.xml")
+
+				fallbackAppManifestPath = filepath.Join(path, "app", "build", "intermediates", "merged_manifests", proguardOptions.Variant, "process"+proguardOptions.Variant+"Manifest", "AndroidManifest.xml")
+
+				proguardOptions.AppManifest = android.FindAndroidManifest([]string{primaryAppManifestPath, fallbackAppManifestPath})
+
+				if proguardOptions.AppManifest == "" {
+					logger.Info("Unable to locate AndroidManifest.xml for variant; proceeding without manifest path")
 				}
 			}
 
@@ -74,10 +79,14 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 				if filepath.Base(mergedManifestPath) == "merged_manifests" {
 					proguardOptions.Variant, err = android.GetVariantDirectory(mergedManifestPath)
 					if err == nil {
-						appManifestPathExpected = filepath.Join(mergedManifestPath, proguardOptions.Variant, "AndroidManifest.xml")
-						if utils.FileExists(appManifestPathExpected) {
-							proguardOptions.AppManifest = appManifestPathExpected
-							logger.Info(fmt.Sprintf("Found app manifest at: %s", proguardOptions.AppManifest))
+						primaryAppManifestPath = filepath.Join(mergedManifestPath, proguardOptions.Variant, "AndroidManifest.xml")
+
+						fallbackAppManifestPath = filepath.Join(mergedManifestPath, proguardOptions.Variant, "process"+proguardOptions.Variant+"Manifest", "AndroidManifest.xml")
+
+						proguardOptions.AppManifest = android.FindAndroidManifest([]string{primaryAppManifestPath, fallbackAppManifestPath})
+
+						if proguardOptions.AppManifest == "" {
+							logger.Info("Unable to locate AndroidManifest.xml for variant; proceeding without manifest path")
 						}
 					}
 				}

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -119,20 +119,14 @@ func ProcessReactNativeAndroid(globalOptions options.CLI, logger log.Logger) err
 		}
 
 		if androidOptions.Android.AppManifest == "" {
-			// RN versions <= 0.74 intermediates/merged_manifests/<androidOptions.Android.Variant>/AndroidManifest.xml"
-			appManifestPathExpected = filepath.Join(buildDirPath, "intermediates", "merged_manifests", androidOptions.Android.Variant, "AndroidManifest.xml")
-			if utils.FileExists(appManifestPathExpected) {
-				androidOptions.Android.AppManifest = appManifestPathExpected
+			androidOptions.Android.AppManifest, err = android.FindAndroidManifest(buildDirPath, androidOptions.Android.Variant)
+			if err != nil {
+				return err
+			}
+			if androidOptions.Android.AppManifest != "" {
 				logger.Debug(fmt.Sprintf("Found app manifest at: %s", androidOptions.Android.AppManifest))
 			} else {
-				// RN versions > 0.74 "intermediates/merged_manifests/androidOptions.Android.Variant, <androidOptions.Android.Variant>/AndroidManifest.xml"
-				appManifestPathExpected = filepath.Join(buildDirPath, "intermediates", "merged_manifests", androidOptions.Android.Variant, "process"+cases.Title(language.English).String(androidOptions.Android.Variant)+"Manifest", "AndroidManifest.xml")
-				if utils.FileExists(appManifestPathExpected) {
-					androidOptions.Android.AppManifest = appManifestPathExpected
-					logger.Debug(fmt.Sprintf("Found app manifest at: %s", androidOptions.Android.AppManifest))
-				} else {
-					logger.Debug(fmt.Sprintf("No app manifest found at: %s", appManifestPathExpected))
-				}
+				logger.Debug(fmt.Sprintf("No app manifest found at: %s", appManifestPathExpected))
 			}
 		}
 

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -35,11 +35,11 @@ func ProcessReactNativeAndroid(globalOptions options.CLI, logger log.Logger) err
 
 	for _, path := range androidOptions.Path {
 
-		buildDirPath := filepath.Join(path, "android", "app", "build")
+		appBuildPath := filepath.Join(path, "android", "app", "build")
 		rootDirPath = path
-		if !utils.FileExists(buildDirPath) {
-			buildDirPath = filepath.Join(path, "app", "build")
-			if utils.FileExists(buildDirPath) {
+		if !utils.FileExists(appBuildPath) {
+			appBuildPath = filepath.Join(path, "app", "build")
+			if utils.FileExists(appBuildPath) {
 				rootDirPath = filepath.Join(path, "..")
 			} else if androidOptions.ReactNative.Bundle == "" || androidOptions.ReactNative.SourceMap == "" {
 				return fmt.Errorf("unable to find bundle files or source maps in within %s", path)
@@ -51,16 +51,16 @@ func ProcessReactNativeAndroid(globalOptions options.CLI, logger log.Logger) err
 		}
 
 		if androidOptions.ReactNative.Bundle == "" {
-			if utils.IsDir(filepath.Join(buildDirPath, "generated", "assets", "react")) {
+			if utils.IsDir(filepath.Join(appBuildPath, "generated", "assets", "react")) {
 				// RN version < 0.70 - generated/assets/react/<androidOptions.Android.Variant>/index.android.bundle
-				bundleDirPath = filepath.Join(buildDirPath, "generated", "assets", "react")
-			} else if utils.IsDir(filepath.Join(buildDirPath, "ASSETS")) {
+				bundleDirPath = filepath.Join(appBuildPath, "generated", "assets", "react")
+			} else if utils.IsDir(filepath.Join(appBuildPath, "ASSETS")) {
 				// RN versions < 0.72 - ASSETS/createBundle<androidOptions.Android.Variant>JsAndAssets/index.android.bundle
-				bundleDirPath = filepath.Join(buildDirPath, "ASSETS")
+				bundleDirPath = filepath.Join(appBuildPath, "ASSETS")
 				variantFileFormat = "createBundle%sJsAndAssets"
-			} else if utils.IsDir(filepath.Join(buildDirPath, "generated", "assets")) {
+			} else if utils.IsDir(filepath.Join(appBuildPath, "generated", "assets")) {
 				// RN versions >= 0.72 - generated/assets/<androidOptions.Android.Variant>/index.android.bundle
-				bundleDirPath = filepath.Join(buildDirPath, "generated", "assets")
+				bundleDirPath = filepath.Join(appBuildPath, "generated", "assets")
 				variantFileFormat = "createBundle%sJsAndAssets"
 			} else {
 				return fmt.Errorf("unable to find index.android.bundle in your project, please specify the path using --bundle")
@@ -90,7 +90,7 @@ func ProcessReactNativeAndroid(globalOptions options.CLI, logger log.Logger) err
 		}
 
 		if androidOptions.ReactNative.SourceMap == "" {
-			sourceMapDirPath := filepath.Join(buildDirPath, "generated", "sourcemaps", "react")
+			sourceMapDirPath := filepath.Join(appBuildPath, "generated", "sourcemaps", "react")
 
 			if androidOptions.Android.Variant == "" {
 				androidOptions.Android.Variant, err = android.GetVariantDirectory(sourceMapDirPath)
@@ -119,7 +119,7 @@ func ProcessReactNativeAndroid(globalOptions options.CLI, logger log.Logger) err
 		}
 
 		if androidOptions.Android.AppManifest == "" {
-			androidOptions.Android.AppManifest, err = android.FindAndroidManifest(buildDirPath, androidOptions.Android.Variant)
+			androidOptions.Android.AppManifest, err = android.FindAndroidManifest(appBuildPath, androidOptions.Android.Variant)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Goal

Update how we check for the AndroidManifest.xml file for the `upload android-proguard` command by checking a fallback path if it is not present in the  default location.

## Testing
Covered by CI