### PR TITLE
Ignore top-level 'node_modules' for the Upload JS command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Changed
+
+- Updated the logic for the `upload js` command to ignore the top level `node_modules` directory when processing source maps. [#251](https://github.com/bugsnag/bugsnag-cli/pull/251)
+
 ## [3.5.1] - 2025-11-13
 
 ### Changed

--- a/js/package.json
+++ b/js/package.json
@@ -39,7 +39,7 @@
     "prepublish": "npm run build && cp bin/bugsnag-cli-placeholder bin/bugsnag-cli"
   },
   "devDependencies": {
-    "@types/node": "^24.0.4",
+    "@types/node": "^25.0.3",
     "typescript": "^5.8.3"
   }
 }

--- a/pkg/upload/js.go
+++ b/pkg/upload/js.go
@@ -129,7 +129,7 @@ func resolveVersion(versionName string, path string, logger log.Logger) string {
 	return ""
 }
 
-// resolveSourceMapPaths attempts to find the source map(s) by walking the build directory
+// ResolveSourceMapPaths attempts to find the source map(s) by walking the build directory
 // if a source map path is not specified.
 //
 // Parameters:
@@ -138,7 +138,7 @@ func resolveVersion(versionName string, path string, logger log.Logger) string {
 //
 // Returns:
 // - list of source map file paths, or an error.
-func resolveSourceMapPaths(sourceMapPath string, outputPath string, logger log.Logger) ([]string, error) {
+func ResolveSourceMapPaths(sourceMapPath string, outputPath string, logger log.Logger) ([]string, error) {
 	if sourceMapPath != "" {
 		if utils.FileExists(sourceMapPath) {
 			logger.Debug(fmt.Sprintf("Using user specified source map file %s", sourceMapPath))
@@ -151,10 +151,12 @@ func resolveSourceMapPaths(sourceMapPath string, outputPath string, logger log.L
 	var sourceMapPaths []string
 	err := filepath.WalkDir(outputPath, func(fullPath string, dirEntry fs.DirEntry, err error) error {
 		if !dirEntry.IsDir() && strings.HasSuffix(dirEntry.Name(), ".map") {
-			if !strings.HasSuffix(dirEntry.Name(), ".css.map") {
-				sourceMapPaths = append(sourceMapPaths, fullPath)
-			} else {
+			if strings.HasSuffix(dirEntry.Name(), ".css.map") {
 				logger.Debug(fmt.Sprintf("Skipping .css.map file %s", fullPath))
+			} else if strings.Contains(fullPath, "node_modules") {
+				logger.Debug(fmt.Sprintf("Skipping source map in node_modules: %s", fullPath))
+			} else {
+				sourceMapPaths = append(sourceMapPaths, fullPath)
 			}
 		}
 		return nil
@@ -163,23 +165,6 @@ func resolveSourceMapPaths(sourceMapPath string, outputPath string, logger log.L
 	if err != nil {
 		return []string{}, err
 	}
-
-	// Filter out source maps inside node_modules directories
-	filtered := []string{}
-	for _, sm := range sourceMapPaths {
-		absSm, err := filepath.Abs(sm)
-		if err != nil {
-			continue
-		}
-		if strings.HasPrefix(absSm, "node_modules"+string(filepath.Separator)) {
-			logger.Debug(fmt.Sprintf("Skipping source map in node_modules: %s", absSm))
-			continue
-		}
-		filtered = append(filtered, sm)
-	}
-
-	sourceMapPaths = filtered
-
 	if len(sourceMapPaths) == 0 {
 		logger.Warn(fmt.Sprintf("No source maps found in: %s", outputPath))
 	} else {
@@ -410,7 +395,7 @@ func ProcessJs(options options.CLI, logger log.Logger) error {
 		jsOptions.VersionName = resolveVersion(jsOptions.VersionName, path, logger)
 
 		// Check that the source map(s) exists and error out if it doesn't
-		sourceMapPaths, err := resolveSourceMapPaths(jsOptions.SourceMap, outputPath, logger)
+		sourceMapPaths, err := ResolveSourceMapPaths(jsOptions.SourceMap, outputPath, logger)
 		if err != nil {
 			return err
 		}

--- a/pkg/upload/js.go
+++ b/pkg/upload/js.go
@@ -159,9 +159,27 @@ func resolveSourceMapPaths(sourceMapPath string, outputPath string, logger log.L
 		}
 		return nil
 	})
+
 	if err != nil {
 		return []string{}, err
 	}
+
+	// Filter out source maps inside node_modules directories
+	filtered := []string{}
+	for _, sm := range sourceMapPaths {
+		absSm, err := filepath.Abs(sm)
+		if err != nil {
+			continue
+		}
+		if strings.HasPrefix(absSm, "node_modules"+string(filepath.Separator)) {
+			logger.Debug(fmt.Sprintf("Skipping source map in node_modules: %s", absSm))
+			continue
+		}
+		filtered = append(filtered, sm)
+	}
+
+	sourceMapPaths = filtered
+
 	if len(sourceMapPaths) == 0 {
 		logger.Warn(fmt.Sprintf("No source maps found in: %s", outputPath))
 	} else {
@@ -395,26 +413,6 @@ func ProcessJs(options options.CLI, logger log.Logger) error {
 		sourceMapPaths, err := resolveSourceMapPaths(jsOptions.SourceMap, outputPath, logger)
 		if err != nil {
 			return err
-		}
-
-		// Filter out source maps inside projectRoot/node_modules
-		if jsOptions.ProjectRoot != "" {
-			nmRoot, err := filepath.Abs(filepath.Join(jsOptions.ProjectRoot, "node_modules"))
-			if err == nil {
-				filtered := []string{}
-				for _, sm := range sourceMapPaths {
-					absSm, err := filepath.Abs(sm)
-					if err != nil {
-						continue
-					}
-					if strings.HasPrefix(absSm, nmRoot+string(filepath.Separator)) {
-						logger.Debug(fmt.Sprintf("Skipping source map in node_modules: %s", absSm))
-						continue
-					}
-					filtered = append(filtered, sm)
-				}
-				sourceMapPaths = filtered
-			}
 		}
 
 		// Check that we now have a source map path

--- a/pkg/upload/js.go
+++ b/pkg/upload/js.go
@@ -397,6 +397,26 @@ func ProcessJs(options options.CLI, logger log.Logger) error {
 			return err
 		}
 
+		// Filter out source maps inside projectRoot/node_modules
+		if jsOptions.ProjectRoot != "" {
+			nmRoot, err := filepath.Abs(filepath.Join(jsOptions.ProjectRoot, "node_modules"))
+			if err == nil {
+				filtered := []string{}
+				for _, sm := range sourceMapPaths {
+					absSm, err := filepath.Abs(sm)
+					if err != nil {
+						continue
+					}
+					if strings.HasPrefix(absSm, nmRoot+string(filepath.Separator)) {
+						logger.Debug(fmt.Sprintf("Skipping source map in node_modules: %s", absSm))
+						continue
+					}
+					filtered = append(filtered, sm)
+				}
+				sourceMapPaths = filtered
+			}
+		}
+
 		// Check that we now have a source map path
 		if len(sourceMapPaths) == 0 {
 			return fmt.Errorf("could not find a source map, please specify the path by using --source-map")

--- a/test/upload/js_test.go
+++ b/test/upload/js_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
-	"github.com/bugsnag/bugsnag-cli/pkg/options"
 	"github.com/bugsnag/bugsnag-cli/pkg/upload"
 )
 
@@ -38,52 +37,44 @@ func TestPopulateSourceMap(t *testing.T) {
 	}
 }
 
-func TestProcessJs_IgnoresNodeModulesSourceMaps(t *testing.T) {
+func TestResolveSourceMapPaths_IgnoresNodeModulesAndCssMaps(t *testing.T) {
 	logger := log.NewLoggerWrapper("debug")
 
-	tmpDir := t.TempDir()
+	// Create a temporary directory structure
+	tempDir := t.TempDir()
 
-	projectRoot := filepath.Join(tmpDir, "project")
-	distDir := filepath.Join(projectRoot, "dist")
-	nodeModulesDir := filepath.Join(projectRoot, "node_modules", "dep")
-
-	if err := os.MkdirAll(distDir, 0o755); err != nil {
-		t.Fatalf("failed to create dist dir: %v", err)
+	// Valid source map
+	validMap := filepath.Join(tempDir, "app.js.map")
+	if err := os.WriteFile(validMap, []byte("{}"), 0644); err != nil {
+		t.Fatalf("failed to write valid source map: %v", err)
 	}
-	if err := os.MkdirAll(nodeModulesDir, 0o755); err != nil {
+
+	// CSS source map (should be ignored)
+	cssMap := filepath.Join(tempDir, "styles.css.map")
+	if err := os.WriteFile(cssMap, []byte("{}"), 0644); err != nil {
+		t.Fatalf("failed to write css source map: %v", err)
+	}
+
+	// node_modules source map (should be ignored)
+	nodeModulesDir := filepath.Join(tempDir, "node_modules", "lib")
+	if err := os.MkdirAll(nodeModulesDir, 0755); err != nil {
 		t.Fatalf("failed to create node_modules dir: %v", err)
 	}
-
-	// Sourcemap that should be kept
-	validMap := filepath.Join(distDir, "app.js.map")
-	if err := os.WriteFile(validMap, []byte(`{"version":3,"sources":[],"names":[],"mappings":""}`), 0o644); err != nil {
-		t.Fatalf("failed to write valid sourcemap: %v", err)
+	nodeModulesMap := filepath.Join(nodeModulesDir, "lib.js.map")
+	if err := os.WriteFile(nodeModulesMap, []byte("{}"), 0644); err != nil {
+		t.Fatalf("failed to write node_modules source map: %v", err)
 	}
 
-	// Sourcemap inside node_modules that should be ignored
-	ignoredMap := filepath.Join(nodeModulesDir, "dep.js.map")
-	if err := os.WriteFile(ignoredMap, []byte(`{"version":3,"sources":[],"names":[],"mappings":""}`), 0o644); err != nil {
-		t.Fatalf("failed to write ignored sourcemap: %v", err)
+	paths, err := upload.ResolveSourceMapPaths("", tempDir, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	opts := options.CLI{
-		Globals: options.Globals{
-			ApiKey: "test-api-key",
-		},
-		Upload: options.Upload{
-			Js: options.Js{
-				Path:        []string{distDir},
-				ProjectRoot: projectRoot,
-				BaseUrl:     "https://example.com/",
-			},
-		},
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 source map, got %d", len(paths))
 	}
 
-	err := upload.ProcessJs(opts, logger)
-
-	// We expect ProcessJs to progress past sourcemap discovery.
-	// Any error here should NOT be due to missing sourcemaps.
-	if err != nil && strings.Contains(err.Error(), "could not find a source map") {
-		t.Fatalf("node_modules sourcemaps were not ignored; no valid sourcemaps detected")
+	if paths[0] != validMap {
+		t.Errorf("expected source map %s, got %s", validMap, paths[0])
 	}
 }

--- a/test/upload/js_test.go
+++ b/test/upload/js_test.go
@@ -1,10 +1,13 @@
 package upload_testing
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
+	"github.com/bugsnag/bugsnag-cli/pkg/options"
 	"github.com/bugsnag/bugsnag-cli/pkg/upload"
 )
 
@@ -32,5 +35,55 @@ func TestPopulateSourceMap(t *testing.T) {
 	}
 	if !strings.Contains(*contents[2], "const element = document.createElement('div');") {
 		t.Error("contents 2 should be populated")
+	}
+}
+
+func TestProcessJs_IgnoresNodeModulesSourceMaps(t *testing.T) {
+	logger := log.NewLoggerWrapper("debug")
+
+	tmpDir := t.TempDir()
+
+	projectRoot := filepath.Join(tmpDir, "project")
+	distDir := filepath.Join(projectRoot, "dist")
+	nodeModulesDir := filepath.Join(projectRoot, "node_modules", "dep")
+
+	if err := os.MkdirAll(distDir, 0o755); err != nil {
+		t.Fatalf("failed to create dist dir: %v", err)
+	}
+	if err := os.MkdirAll(nodeModulesDir, 0o755); err != nil {
+		t.Fatalf("failed to create node_modules dir: %v", err)
+	}
+
+	// Sourcemap that should be kept
+	validMap := filepath.Join(distDir, "app.js.map")
+	if err := os.WriteFile(validMap, []byte(`{"version":3,"sources":[],"names":[],"mappings":""}`), 0o644); err != nil {
+		t.Fatalf("failed to write valid sourcemap: %v", err)
+	}
+
+	// Sourcemap inside node_modules that should be ignored
+	ignoredMap := filepath.Join(nodeModulesDir, "dep.js.map")
+	if err := os.WriteFile(ignoredMap, []byte(`{"version":3,"sources":[],"names":[],"mappings":""}`), 0o644); err != nil {
+		t.Fatalf("failed to write ignored sourcemap: %v", err)
+	}
+
+	opts := options.CLI{
+		Globals: options.Globals{
+			ApiKey: "test-api-key",
+		},
+		Upload: options.Upload{
+			Js: options.Js{
+				Path:        []string{distDir},
+				ProjectRoot: projectRoot,
+				BaseUrl:     "https://example.com/",
+			},
+		},
+	}
+
+	err := upload.ProcessJs(opts, logger)
+
+	// We expect ProcessJs to progress past sourcemap discovery.
+	// Any error here should NOT be due to missing sourcemaps.
+	if err != nil && strings.Contains(err.Error(), "could not find a source map") {
+		t.Fatalf("node_modules sourcemaps were not ignored; no valid sourcemaps detected")
 	}
 }


### PR DESCRIPTION
## Goal

Ensure the upload JS command ignores the top-level node_modules directory. The top-level directory is determined using the --project-root value, which is used to correctly identify and exclude node_modules from the upload.

## Testing

- Added a new unit test to cover this behavior
- Verified by CI