### PR TITLE
Add proxy support to the NPM package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Updated the logic for the `upload js` command to ignore the top level `node_modules` directory when processing source maps. [#251](https://github.com/bugsnag/bugsnag-cli/pull/251)
+- Add proxy support to the NPM package. [#252](https://github.com/bugsnag/bugsnag-cli/pull/252)
 
 ## [3.5.1] - 2025-11-13
 

--- a/js/package.json
+++ b/js/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/bugsnag/bugsnag-cli#readme",
   "dependencies": {
+    "proxy-agent": "^6.5.0",
     "yaml": "^2.7.0"
   },
   "files": [

--- a/js/postinstall.js
+++ b/js/postinstall.js
@@ -4,7 +4,7 @@ const { createWriteStream } = require('fs')
 const path = require('path')
 const os = require('os')
 const YAML = require('yaml')
-const ProxyAgent = require('proxy-agent')   // ✅ NEW
+const ProxyAgent = require('proxy-agent')
 const packageJson = require('./package.json')
 
 const supportedPlatformsConfig = fs.readFileSync(
@@ -58,11 +58,10 @@ const downloadBinaryFromGitHub = async (downloadUrl, outputPath) => {
             fs.mkdirSync(binDir, { recursive: true })
         }
 
-        // ✅ Create a proxy-aware agent
         const agent = new ProxyAgent()
 
         const resp = await fetch(downloadUrl, {
-            dispatcher: agent   // ✅ Undici / Node fetch hook
+            dispatcher: agent
         })
 
         if (resp.ok && resp.body) {

--- a/js/postinstall.js
+++ b/js/postinstall.js
@@ -4,6 +4,7 @@ const { createWriteStream } = require('fs')
 const path = require('path')
 const os = require('os')
 const YAML = require('yaml')
+const ProxyAgent = require('proxy-agent')   // ✅ NEW
 const packageJson = require('./package.json')
 
 const supportedPlatformsConfig = fs.readFileSync(
@@ -57,7 +58,12 @@ const downloadBinaryFromGitHub = async (downloadUrl, outputPath) => {
             fs.mkdirSync(binDir, { recursive: true })
         }
 
-        const resp = await fetch(downloadUrl)
+        // ✅ Create a proxy-aware agent
+        const agent = new ProxyAgent()
+
+        const resp = await fetch(downloadUrl, {
+            dispatcher: agent   // ✅ Undici / Node fetch hook
+        })
 
         if (resp.ok && resp.body) {
             const writer = createWriteStream(outputPath)


### PR DESCRIPTION
## Goal

Add `proxy-agent` to the NPM package to allow installation of the package behind corporate networks.

## Testing

Covered by CI