### PR TITLE
v3.6.0 Release

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -155,6 +155,19 @@ steps:
         upload:
           - maze_output/**/*
 
+  - label: "Node.js Integration Tests"
+    depends_on: build
+    commands:
+      - chmod +x bin/arm64-macos-bugsnag-cli
+      - bundle install
+      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) features/node
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - bin/arm64-macos-bugsnag-cli
+        upload:
+          - maze_output/**/*
+
   - group: ":react: React Native"
     steps:
       - label: ":large_blue_circle: :large_blue_circle: :large_blue_circle: REACT NATIVE ANDROID STEPS :large_blue_circle: :large_blue_circle: :large_blue_circle:"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -166,7 +166,8 @@ steps:
         download:
           - bin/arm64-macos-bugsnag-cli
         upload:
-          - maze_output/**/*
+          - maze_output/maze_output.zip
+          - maze_output/failed/*
 
   - group: ":react: React Native"
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Updated the logic for the `upload js` command to ignore the top level `node_modules` directory when processing source maps. [#251](https://github.com/bugsnag/bugsnag-cli/pull/251)
+- Add proxy support to the NPM package. [#252](https://github.com/bugsnag/bugsnag-cli/pull/252)
 
 ## [3.5.1] - 2025-11-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Changed
+
+- Updated the logic for the `upload js` command to ignore the top level `node_modules` directory when processing source maps. [#251](https://github.com/bugsnag/bugsnag-cli/pull/251)
+
 ## [3.5.1] - 2025-11-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Add a fallback path for AndroidManifest.xml when processing Proguard uploads []()
+- Add a fallback path for AndroidManifest.xml when processing Proguard uploads [#249](https://github.com/bugsnag/bugsnag-cli/pull/249)
 
 ## [3.5.1] - 2025-11-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Changed
+
+- Add a fallback path for AndroidManifest.xml when processing Proguard uploads []()
+
 ## [3.5.1] - 2025-11-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## unreleased
+## [3.6.0] - 2026-01-06
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Add a fallback path for AndroidManifest.xml when processing Proguard uploads [#249](https://github.com/bugsnag/bugsnag-cli/pull/249)
+- Add a fallback path for AndroidManifest.xml when processing Android related uploads (Proguard, NDK and React Native) [#249](https://github.com/bugsnag/bugsnag-cli/pull/249)
 
 ## [3.5.1] - 2025-11-13
 

--- a/features/node/fixtures/.gitignore
+++ b/features/node/fixtures/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+dist/

--- a/features/node/fixtures/build.js
+++ b/features/node/fixtures/build.js
@@ -1,0 +1,26 @@
+const esbuild = require("esbuild");
+const path = require("node:path");
+
+async function run() {
+    try {
+        await esbuild.build({
+            entryPoints: {
+                index: path.join(__dirname, "src/index.js"),
+                utils: path.join(__dirname, "src/utils/index.js"),
+            },
+            outdir: path.join(__dirname, "dist"),
+            bundle: true,
+            sourcemap: true,
+            platform: "node",
+            format: "cjs",
+            target: "node18",
+        });
+
+        console.log("Build complete. Sourcemap generated.");
+    } catch (err) {
+        console.error(err);
+        process.exit(1);
+    }
+}
+
+run();

--- a/features/node/fixtures/package.json
+++ b/features/node/fixtures/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "fixture",
+  "private": true,
+  "dependencies": {
+    "esbuild": "^0.21.0"
+  },
+  "scripts": {
+    "clean": "rm -rf dist"
+  }
+}

--- a/features/node/fixtures/src/index.js
+++ b/features/node/fixtures/src/index.js
@@ -1,0 +1,5 @@
+export function hello(name) {
+    return `Hello, ${name}!`;
+}
+
+console.log(hello("world"));

--- a/features/node/fixtures/src/utils/index.js
+++ b/features/node/fixtures/src/utils/index.js
@@ -1,0 +1,5 @@
+export function hello(name) {
+    return `Hello, ${name}!`;
+}
+
+console.log(hello("world"));

--- a/features/node/node.feature
+++ b/features/node/node.feature
@@ -1,0 +1,35 @@
+Feature: Node.js Integration Tests
+  @CleanAndBuildNodeJs
+  Scenario: Upload Node.js sourcemaps providing a directory
+    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --base-url=example.com --version-name=2.3.4 features/node/fixtures/dist
+    And I wait to receive 2 sourcemaps
+    Then the sourcemaps are valid for the API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
+    And the sourcemap payload field "appVersion" equals "2.3.4"
+    And the sourcemap payload field "minifiedUrl" equals "example.com/index.js"
+    And the sourcemap payload field "sourceMap" is valid json
+    And the sourcemap payload field "minifiedFile" is not empty
+    And the sourcemap payload field "projectRoot" ends with "features/node/fixtures"
+
+    And I discard the oldest sourcemaps
+
+    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
+    And the sourcemap payload field "appVersion" equals "2.3.4"
+    And the sourcemap payload field "minifiedUrl" equals "example.com/utils.js"
+    And the sourcemap payload field "sourceMap" is valid json
+    And the sourcemap payload field "minifiedFile" is not empty
+    And the sourcemap payload field "projectRoot" ends with "features/node/fixtures"
+
+  @CleanAndBuildNodeJs
+  Scenario: Upload a single Node.js sourcemap using all CLI flags
+    When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --bundle-url=example.com --version-name=2.3.4 --source-map=features/node/fixtures/dist/index.js.map --bundle=features/node/fixtures/dist/index.js --project-root=features/node/fixtures features/node/fixtures/dist
+    And I wait to receive 1 sourcemaps
+    Then the sourcemaps are valid for the API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
+    And the sourcemap payload field "appVersion" equals "2.3.4"
+    And the sourcemap payload field "minifiedUrl" equals "example.com"
+    And the sourcemap payload field "sourceMap" is valid json
+    And the sourcemap payload field "minifiedFile" is not empty
+    And the sourcemap payload field "projectRoot" ends with "features/node/fixtures"

--- a/features/node/node.feature
+++ b/features/node/node.feature
@@ -1,5 +1,7 @@
 Feature: Node.js Integration Tests
-  @CleanAndBuildNodeJs
+  Background:
+    Given the NodeJS fixture is built
+
   Scenario: Upload Node.js sourcemaps providing a directory
     When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --base-url=example.com --version-name=2.3.4 features/node/fixtures/dist
     And I wait to receive 2 sourcemaps
@@ -21,7 +23,6 @@ Feature: Node.js Integration Tests
     And the sourcemap payload field "minifiedFile" is not empty
     And the sourcemap payload field "projectRoot" ends with "features/node/fixtures"
 
-  @CleanAndBuildNodeJs
   Scenario: Upload a single Node.js sourcemap using all CLI flags
     When I run bugsnag-cli with upload js --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --bundle-url=example.com --version-name=2.3.4 --source-map=features/node/fixtures/dist/index.js.map --bundle=features/node/fixtures/dist/index.js --project-root=features/node/fixtures features/node/fixtures/dist
     And I wait to receive 1 sourcemaps

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -188,6 +188,10 @@ And(/^I wait for the build to succeed$/) do
   Maze.check.not_include(run_output, "Error 1")
 end
 
+And(/^I wait for the Node\.js sourcemaps to generate$/) do
+  Maze.check.include(`ls #{@fixture_dir}/dist`, 'index.js.map')
+end
+
 When(/^I make the "([^"]*)"$/) do |arg|
   @output = `make #{arg} 2>&1`
 end
@@ -463,3 +467,15 @@ And(/^I sort the sourcemaps by path$/) do
   list = Maze::Server.list_for('sourcemap')
   list.sort_by_request_path!
 end
+
+Before('@CleanAndBuildNodeJs') do
+  @fixture_dir = "#{base_dir}/features/node/fixtures/"
+  Dir.chdir(@fixture_dir)
+  @output =`npm run clean && npm ci && node build.js`
+  Dir.chdir(base_dir)
+
+  steps %(
+    And I wait for the Node.js sourcemaps to generate
+  )
+end
+

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -471,7 +471,7 @@ end
 Before('@CleanAndBuildNodeJs') do
   @fixture_dir = "#{base_dir}/features/node/fixtures/"
   Dir.chdir(@fixture_dir)
-  @output =`npm run clean && npm ci && node build.js`
+  @output =`npm run clean && npm i && node build.js`
   Dir.chdir(base_dir)
 
   steps %(

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -188,10 +188,6 @@ And(/^I wait for the build to succeed$/) do
   Maze.check.not_include(run_output, "Error 1")
 end
 
-And(/^I wait for the Node\.js sourcemaps to generate$/) do
-  Maze.check.include(`ls #{@fixture_dir}/dist`, 'index.js.map')
-end
-
 When(/^I make the "([^"]*)"$/) do |arg|
   @output = `make #{arg} 2>&1`
 end
@@ -468,14 +464,11 @@ And(/^I sort the sourcemaps by path$/) do
   list.sort_by_request_path!
 end
 
-Before('@CleanAndBuildNodeJs') do
+# NodeJS fixture build step
+Given('the NodeJS fixture is built') do
   @fixture_dir = "#{base_dir}/features/node/fixtures/"
   Dir.chdir(@fixture_dir)
-  @output =`npm run clean && npm i && node build.js`
+  @output = `npm run clean && npm i && node build.js`
   Dir.chdir(base_dir)
-
-  steps %(
-    And I wait for the Node.js sourcemaps to generate
-  )
+  Maze.check.include(`ls #{@fixture_dir}/dist`, 'index.js.map')
 end
-

--- a/install.sh
+++ b/install.sh
@@ -91,7 +91,7 @@ display_help() {
 EOS
 }
 
-VERSION="3.5.1"
+VERSION="3.6.0"
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in

--- a/js/package.json
+++ b/js/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/bugsnag/bugsnag-cli#readme",
   "dependencies": {
+    "proxy-agent": "^6.5.0",
     "yaml": "^2.7.0"
   },
   "files": [

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/cli",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "description": "BugSnag CLI",
   "main": "dist/bugsnag-cli-wrapper.js",
   "types": "dist/bugsnag-cli-wrapper.d.ts",

--- a/js/package.json
+++ b/js/package.json
@@ -39,7 +39,7 @@
     "prepublish": "npm run build && cp bin/bugsnag-cli-placeholder bin/bugsnag-cli"
   },
   "devDependencies": {
-    "@types/node": "^24.0.4",
+    "@types/node": "^25.0.3",
     "typescript": "^5.8.3"
   }
 }

--- a/js/postinstall.js
+++ b/js/postinstall.js
@@ -4,7 +4,7 @@ const { createWriteStream } = require('fs')
 const path = require('path')
 const os = require('os')
 const YAML = require('yaml')
-const ProxyAgent = require('proxy-agent')   // ✅ NEW
+const ProxyAgent = require('proxy-agent')
 const packageJson = require('./package.json')
 
 const supportedPlatformsConfig = fs.readFileSync(
@@ -58,11 +58,10 @@ const downloadBinaryFromGitHub = async (downloadUrl, outputPath) => {
             fs.mkdirSync(binDir, { recursive: true })
         }
 
-        // ✅ Create a proxy-aware agent
         const agent = new ProxyAgent()
 
         const resp = await fetch(downloadUrl, {
-            dispatcher: agent   // ✅ Undici / Node fetch hook
+            dispatcher: agent
         })
 
         if (resp.ok && resp.body) {

--- a/js/postinstall.js
+++ b/js/postinstall.js
@@ -4,6 +4,7 @@ const { createWriteStream } = require('fs')
 const path = require('path')
 const os = require('os')
 const YAML = require('yaml')
+const ProxyAgent = require('proxy-agent')   // ✅ NEW
 const packageJson = require('./package.json')
 
 const supportedPlatformsConfig = fs.readFileSync(
@@ -57,7 +58,12 @@ const downloadBinaryFromGitHub = async (downloadUrl, outputPath) => {
             fs.mkdirSync(binDir, { recursive: true })
         }
 
-        const resp = await fetch(downloadUrl)
+        // ✅ Create a proxy-aware agent
+        const agent = new ProxyAgent()
+
+        const resp = await fetch(downloadUrl, {
+            dispatcher: agent   // ✅ Undici / Node fetch hook
+        })
 
         if (resp.ok && resp.body) {
             const writer = createWriteStream(outputPath)

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/bugsnag/bugsnag-cli/pkg/upload"
 )
 
-var package_version = "3.5.1"
+var package_version = "3.6.0"
 
 func main() {
 	commands := options.CLI{}

--- a/pkg/android/find-android-manifest.go
+++ b/pkg/android/find-android-manifest.go
@@ -1,6 +1,7 @@
 package android
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
@@ -14,25 +15,37 @@ import (
 // on disk.
 //
 // Parameters:
-//   - path: The Android merged_manifests directory.
+//   - buildFolder: The root build directory where Android build outputs are located.
 //   - variant: The build variant (e.g., "debug", "release") whose manifest paths
 //     should be searched.
 //
 // Returns:
 //   - string: The resolved manifest path if found, otherwise an empty string.
-func FindAndroidManifest(path string, variant string) string {
+//   - error: Non-nil if the manifest cannot be found.
+func FindAndroidManifest(buildFolder string, variant string) (string, error) {
+	var err error
 
-	primaryAppManifestPath := filepath.Join(path, variant, "AndroidManifest.xml")
+	mergedManifestPath := filepath.Join(buildFolder, "intermediates", "merged_manifests")
 
-	fallbackAppManifestPath := filepath.Join(path, variant, "process"+variant+"Manifest", "AndroidManifest.xml")
+	if variant == "" {
+		variant, err = GetVariantDirectory(mergedManifestPath)
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	primaryAppManifestPath := filepath.Join(mergedManifestPath, variant, "AndroidManifest.xml")
+
+	fallbackAppManifestPath := filepath.Join(mergedManifestPath, variant, "process"+variant+"Manifest", "AndroidManifest.xml")
 
 	paths := []string{primaryAppManifestPath, fallbackAppManifestPath}
 
 	for _, path := range paths {
 		if utils.FileExists(path) {
-			return path
+			return path, nil
 		}
 	}
 
-	return ""
+	return "", fmt.Errorf("unable to locate AndroidManifest.xml for variant %s", variant)
 }

--- a/pkg/android/find-android-manifest.go
+++ b/pkg/android/find-android-manifest.go
@@ -15,17 +15,17 @@ import (
 // on disk.
 //
 // Parameters:
-//   - buildFolder: The root build directory where Android build outputs are located.
+//   - appBuildPath: The root build directory where Android build outputs are located.
 //   - variant: The build variant (e.g., "debug", "release") whose manifest paths
 //     should be searched.
 //
 // Returns:
 //   - string: The resolved manifest path if found, otherwise an empty string.
 //   - error: Non-nil if the manifest cannot be found.
-func FindAndroidManifest(buildFolder string, variant string) (string, error) {
+func FindAndroidManifest(appBuildPath string, variant string) (string, error) {
 	var err error
 
-	mergedManifestPath := filepath.Join(buildFolder, "intermediates", "merged_manifests")
+	mergedManifestPath := filepath.Join(appBuildPath, "intermediates", "merged_manifests")
 
 	if variant == "" {
 		variant, err = GetVariantDirectory(mergedManifestPath)

--- a/pkg/android/find-android-manifest.go
+++ b/pkg/android/find-android-manifest.go
@@ -1,19 +1,33 @@
 package android
 
-import "github.com/bugsnag/bugsnag-cli/pkg/utils"
+import (
+	"path/filepath"
 
-// FindAndroidManifest locates and returns the first existing AndroidManifest.xml path.
+	"github.com/bugsnag/bugsnag-cli/pkg/utils"
+)
+
+// FindAndroidManifest locates and returns the first existing AndroidManifest.xml
+// for a given build directory and variant.
 //
-// This function iterates through a list of candidate file paths and returns the
-// first one that exists on disk. This is useful when Android build outputs may
-// place the manifest in multiple variant-specific directories.
+// This function constructs and checks multiple potential manifest locations that
+// vary based on Android build outputs. It returns the first manifest file found
+// on disk.
 //
 // Parameters:
-//   - paths: A slice of possible manifest file locations.
+//   - path: The Android merged_manifests directory.
+//   - variant: The build variant (e.g., "debug", "release") whose manifest paths
+//     should be searched.
 //
 // Returns:
-//   - string: The first existing manifest path, or an empty string if none are found.
-func FindAndroidManifest(paths []string) string {
+//   - string: The resolved manifest path if found, otherwise an empty string.
+func FindAndroidManifest(path string, variant string) string {
+
+	primaryAppManifestPath := filepath.Join(path, variant, "AndroidManifest.xml")
+
+	fallbackAppManifestPath := filepath.Join(path, variant, "process"+variant+"Manifest", "AndroidManifest.xml")
+
+	paths := []string{primaryAppManifestPath, fallbackAppManifestPath}
+
 	for _, path := range paths {
 		if utils.FileExists(path) {
 			return path

--- a/pkg/android/find-android-manifest.go
+++ b/pkg/android/find-android-manifest.go
@@ -1,0 +1,24 @@
+package android
+
+import "github.com/bugsnag/bugsnag-cli/pkg/utils"
+
+// FindAndroidManifest locates and returns the first existing AndroidManifest.xml path.
+//
+// This function iterates through a list of candidate file paths and returns the
+// first one that exists on disk. This is useful when Android build outputs may
+// place the manifest in multiple variant-specific directories.
+//
+// Parameters:
+//   - paths: A slice of possible manifest file locations.
+//
+// Returns:
+//   - string: The first existing manifest path, or an empty string if none are found.
+func FindAndroidManifest(paths []string) string {
+	for _, path := range paths {
+		if utils.FileExists(path) {
+			return path
+		}
+	}
+
+	return ""
+}

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -35,18 +35,16 @@ func resolveMergedLibPath(input string) (string, error) {
 //   - libPath: resolved path to merged_native_libs.
 //   - logger: logger used to emit debug output.
 func resolveAppManifestIfNeeded(ndkOpts *options.AndroidNdkMapping, libPath string, logger log.Logger) error {
+	var err error
 	if ndkOpts.AppManifest != "" {
 		return nil
 	}
-	buildFolder := filepath.Join(libPath, "..")
-	manifestPath, err := android.FindAndroidManifest(buildFolder, ndkOpts.Variant)
+	appBuildPath := filepath.Join(libPath, "..")
+	ndkOpts.AppManifest, err = android.FindAndroidManifest(appBuildPath, ndkOpts.Variant)
 	if err != nil {
 		return err
 	}
-	if utils.FileExists(manifestPath) {
-		ndkOpts.AppManifest = manifestPath
-		logger.Debug(fmt.Sprintf("Found AndroidManifest.xml at %s", ndkOpts.AppManifest))
-	}
+	logger.Debug(fmt.Sprintf("Found AndroidManifest.xml at %s", ndkOpts.AppManifest))
 	return nil
 }
 

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -39,7 +39,7 @@ func resolveAppManifestIfNeeded(ndkOpts *options.AndroidNdkMapping, libPath stri
 	if ndkOpts.AppManifest != "" {
 		return nil
 	}
-	appBuildPath := filepath.Join(libPath, "..")
+	appBuildPath := filepath.Join(libPath, "..", "..")
 	ndkOpts.AppManifest, err = android.FindAndroidManifest(appBuildPath, ndkOpts.Variant)
 	if err != nil {
 		return err

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -34,15 +34,20 @@ func resolveMergedLibPath(input string) (string, error) {
 //   - ndkOpts: AndroidNdkMapping options struct (will be mutated).
 //   - libPath: resolved path to merged_native_libs.
 //   - logger: logger used to emit debug output.
-func resolveAppManifestIfNeeded(ndkOpts *options.AndroidNdkMapping, libPath string, logger log.Logger) {
+func resolveAppManifestIfNeeded(ndkOpts *options.AndroidNdkMapping, libPath string, logger log.Logger) error {
 	if ndkOpts.AppManifest != "" {
-		return
+		return nil
 	}
-	manifestPath := filepath.Join(libPath, "..", "merged_manifests", ndkOpts.Variant, "AndroidManifest.xml")
+	buildFolder := filepath.Join(libPath, "..")
+	manifestPath, err := android.FindAndroidManifest(buildFolder, ndkOpts.Variant)
+	if err != nil {
+		return err
+	}
 	if utils.FileExists(manifestPath) {
 		ndkOpts.AppManifest = manifestPath
 		logger.Debug(fmt.Sprintf("Found AndroidManifest.xml at %s", ndkOpts.AppManifest))
 	}
+	return nil
 }
 
 // resolveProjectRootIfNeeded sets the project root directory in ndkOpts if it hasn't already been set.
@@ -165,7 +170,10 @@ func ProcessAndroidNDK(opts options.CLI, logger log.Logger) error {
 					return err
 				}
 			}
-			resolveAppManifestIfNeeded(&ndkOpts, libPath, logger)
+			err := resolveAppManifestIfNeeded(&ndkOpts, libPath, logger)
+			if err != nil {
+				return err
+			}
 			resolveProjectRootIfNeeded(&ndkOpts, libPath)
 		}
 

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -28,8 +28,6 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 	proguardOptions := options.Upload.AndroidProguard
 
 	var mappingFile string
-	var primaryAppManifestPath string
-	var fallbackAppManifestPath string
 	var err error
 
 	for _, path := range proguardOptions.Path {
@@ -58,11 +56,8 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 
 			// Attempt to locate AndroidManifest.xml for the variant if not set
 			if proguardOptions.AppManifest == "" {
-				primaryAppManifestPath = filepath.Join(path, "app", "build", "intermediates", "merged_manifests", proguardOptions.Variant, "AndroidManifest.xml")
-
-				fallbackAppManifestPath = filepath.Join(path, "app", "build", "intermediates", "merged_manifests", proguardOptions.Variant, "process"+proguardOptions.Variant+"Manifest", "AndroidManifest.xml")
-
-				proguardOptions.AppManifest = android.FindAndroidManifest([]string{primaryAppManifestPath, fallbackAppManifestPath})
+				mergedManifestPath := filepath.Join(path, "app", "build", "intermediates", "merged_manifests")
+				proguardOptions.AppManifest = android.FindAndroidManifest(mergedManifestPath, proguardOptions.Variant)
 
 				if proguardOptions.AppManifest == "" {
 					logger.Info("Unable to locate AndroidManifest.xml for variant; proceeding without manifest path")
@@ -79,11 +74,7 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 				if filepath.Base(mergedManifestPath) == "merged_manifests" {
 					proguardOptions.Variant, err = android.GetVariantDirectory(mergedManifestPath)
 					if err == nil {
-						primaryAppManifestPath = filepath.Join(mergedManifestPath, proguardOptions.Variant, "AndroidManifest.xml")
-
-						fallbackAppManifestPath = filepath.Join(mergedManifestPath, proguardOptions.Variant, "process"+proguardOptions.Variant+"Manifest", "AndroidManifest.xml")
-
-						proguardOptions.AppManifest = android.FindAndroidManifest([]string{primaryAppManifestPath, fallbackAppManifestPath})
+						proguardOptions.AppManifest = android.FindAndroidManifest(mergedManifestPath, proguardOptions.Variant)
 
 						if proguardOptions.AppManifest == "" {
 							logger.Info("Unable to locate AndroidManifest.xml for variant; proceeding without manifest path")

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -56,9 +56,11 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 
 			// Attempt to locate AndroidManifest.xml for the variant if not set
 			if proguardOptions.AppManifest == "" {
-				mergedManifestPath := filepath.Join(path, "app", "build", "intermediates", "merged_manifests")
-				proguardOptions.AppManifest = android.FindAndroidManifest(mergedManifestPath, proguardOptions.Variant)
-
+				buildFolder := filepath.Join(path, "app", "build")
+				proguardOptions.AppManifest, err = android.FindAndroidManifest(buildFolder, proguardOptions.Variant)
+				if err != nil {
+					return err
+				}
 				if proguardOptions.AppManifest == "" {
 					logger.Info("Unable to locate AndroidManifest.xml for variant; proceeding without manifest path")
 				}
@@ -70,15 +72,14 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 
 			// Try to find manifest and variant if missing
 			if proguardOptions.AppManifest == "" && proguardOptions.Variant == "" {
-				mergedManifestPath := filepath.Join(path, "..", "..", "..", "..", "intermediates", "merged_manifests")
-				if filepath.Base(mergedManifestPath) == "merged_manifests" {
-					proguardOptions.Variant, err = android.GetVariantDirectory(mergedManifestPath)
-					if err == nil {
-						proguardOptions.AppManifest = android.FindAndroidManifest(mergedManifestPath, proguardOptions.Variant)
-
-						if proguardOptions.AppManifest == "" {
-							logger.Info("Unable to locate AndroidManifest.xml for variant; proceeding without manifest path")
-						}
+				buildFolder := filepath.Join(path, "..", "..", "..", "..")
+				if filepath.Base(buildFolder) == "build" {
+					proguardOptions.AppManifest, err = android.FindAndroidManifest(buildFolder, proguardOptions.Variant)
+					if err != nil {
+						return err
+					}
+					if proguardOptions.AppManifest == "" {
+						logger.Info("Unable to locate AndroidManifest.xml for variant; proceeding without manifest path")
 					}
 				}
 			}

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -56,8 +56,8 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 
 			// Attempt to locate AndroidManifest.xml for the variant if not set
 			if proguardOptions.AppManifest == "" {
-				buildFolder := filepath.Join(path, "app", "build")
-				proguardOptions.AppManifest, err = android.FindAndroidManifest(buildFolder, proguardOptions.Variant)
+				appBuildPath := filepath.Join(path, "app", "build")
+				proguardOptions.AppManifest, err = android.FindAndroidManifest(appBuildPath, proguardOptions.Variant)
 				if err != nil {
 					return err
 				}
@@ -72,9 +72,9 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 
 			// Try to find manifest and variant if missing
 			if proguardOptions.AppManifest == "" && proguardOptions.Variant == "" {
-				buildFolder := filepath.Join(path, "..", "..", "..", "..")
-				if filepath.Base(buildFolder) == "build" {
-					proguardOptions.AppManifest, err = android.FindAndroidManifest(buildFolder, proguardOptions.Variant)
+				appBuildPath := filepath.Join(path, "..", "..", "..", "..")
+				if filepath.Base(appBuildPath) == "build" {
+					proguardOptions.AppManifest, err = android.FindAndroidManifest(appBuildPath, proguardOptions.Variant)
 					if err != nil {
 						return err
 					}

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -28,7 +28,8 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 	proguardOptions := options.Upload.AndroidProguard
 
 	var mappingFile string
-	var appManifestPathExpected string
+	var primaryAppManifestPath string
+	var fallbackAppManifestPath string
 	var err error
 
 	for _, path := range proguardOptions.Path {
@@ -57,10 +58,14 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 
 			// Attempt to locate AndroidManifest.xml for the variant if not set
 			if proguardOptions.AppManifest == "" {
-				appManifestPathExpected = filepath.Join(path, "app", "build", "intermediates", "merged_manifests", proguardOptions.Variant, "AndroidManifest.xml")
-				if utils.FileExists(appManifestPathExpected) {
-					proguardOptions.AppManifest = appManifestPathExpected
-					logger.Info(fmt.Sprintf("Found app manifest at: %s", proguardOptions.AppManifest))
+				primaryAppManifestPath = filepath.Join(path, "app", "build", "intermediates", "merged_manifests", proguardOptions.Variant, "AndroidManifest.xml")
+
+				fallbackAppManifestPath = filepath.Join(path, "app", "build", "intermediates", "merged_manifests", proguardOptions.Variant, "process"+proguardOptions.Variant+"Manifest", "AndroidManifest.xml")
+
+				proguardOptions.AppManifest = android.FindAndroidManifest([]string{primaryAppManifestPath, fallbackAppManifestPath})
+
+				if proguardOptions.AppManifest == "" {
+					logger.Info("Unable to locate AndroidManifest.xml for variant; proceeding without manifest path")
 				}
 			}
 
@@ -74,10 +79,14 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 				if filepath.Base(mergedManifestPath) == "merged_manifests" {
 					proguardOptions.Variant, err = android.GetVariantDirectory(mergedManifestPath)
 					if err == nil {
-						appManifestPathExpected = filepath.Join(mergedManifestPath, proguardOptions.Variant, "AndroidManifest.xml")
-						if utils.FileExists(appManifestPathExpected) {
-							proguardOptions.AppManifest = appManifestPathExpected
-							logger.Info(fmt.Sprintf("Found app manifest at: %s", proguardOptions.AppManifest))
+						primaryAppManifestPath = filepath.Join(mergedManifestPath, proguardOptions.Variant, "AndroidManifest.xml")
+
+						fallbackAppManifestPath = filepath.Join(mergedManifestPath, proguardOptions.Variant, "process"+proguardOptions.Variant+"Manifest", "AndroidManifest.xml")
+
+						proguardOptions.AppManifest = android.FindAndroidManifest([]string{primaryAppManifestPath, fallbackAppManifestPath})
+
+						if proguardOptions.AppManifest == "" {
+							logger.Info("Unable to locate AndroidManifest.xml for variant; proceeding without manifest path")
 						}
 					}
 				}

--- a/pkg/upload/js.go
+++ b/pkg/upload/js.go
@@ -129,7 +129,7 @@ func resolveVersion(versionName string, path string, logger log.Logger) string {
 	return ""
 }
 
-// resolveSourceMapPaths attempts to find the source map(s) by walking the build directory
+// ResolveSourceMapPaths attempts to find the source map(s) by walking the build directory
 // if a source map path is not specified.
 //
 // Parameters:
@@ -138,7 +138,7 @@ func resolveVersion(versionName string, path string, logger log.Logger) string {
 //
 // Returns:
 // - list of source map file paths, or an error.
-func resolveSourceMapPaths(sourceMapPath string, outputPath string, logger log.Logger) ([]string, error) {
+func ResolveSourceMapPaths(sourceMapPath string, outputPath string, logger log.Logger) ([]string, error) {
 	if sourceMapPath != "" {
 		if utils.FileExists(sourceMapPath) {
 			logger.Debug(fmt.Sprintf("Using user specified source map file %s", sourceMapPath))
@@ -151,10 +151,12 @@ func resolveSourceMapPaths(sourceMapPath string, outputPath string, logger log.L
 	var sourceMapPaths []string
 	err := filepath.WalkDir(outputPath, func(fullPath string, dirEntry fs.DirEntry, err error) error {
 		if !dirEntry.IsDir() && strings.HasSuffix(dirEntry.Name(), ".map") {
-			if !strings.HasSuffix(dirEntry.Name(), ".css.map") {
-				sourceMapPaths = append(sourceMapPaths, fullPath)
-			} else {
+			if strings.HasSuffix(dirEntry.Name(), ".css.map") {
 				logger.Debug(fmt.Sprintf("Skipping .css.map file %s", fullPath))
+			} else if strings.Contains(fullPath, "node_modules") {
+				logger.Debug(fmt.Sprintf("Skipping source map in node_modules: %s", fullPath))
+			} else {
+				sourceMapPaths = append(sourceMapPaths, fullPath)
 			}
 		}
 		return nil
@@ -163,23 +165,6 @@ func resolveSourceMapPaths(sourceMapPath string, outputPath string, logger log.L
 	if err != nil {
 		return []string{}, err
 	}
-
-	// Filter out source maps inside node_modules directories
-	filtered := []string{}
-	for _, sm := range sourceMapPaths {
-		absSm, err := filepath.Abs(sm)
-		if err != nil {
-			continue
-		}
-		if strings.HasPrefix(absSm, "node_modules"+string(filepath.Separator)) {
-			logger.Debug(fmt.Sprintf("Skipping source map in node_modules: %s", absSm))
-			continue
-		}
-		filtered = append(filtered, sm)
-	}
-
-	sourceMapPaths = filtered
-
 	if len(sourceMapPaths) == 0 {
 		logger.Warn(fmt.Sprintf("No source maps found in: %s", outputPath))
 	} else {
@@ -410,7 +395,7 @@ func ProcessJs(options options.CLI, logger log.Logger) error {
 		jsOptions.VersionName = resolveVersion(jsOptions.VersionName, path, logger)
 
 		// Check that the source map(s) exists and error out if it doesn't
-		sourceMapPaths, err := resolveSourceMapPaths(jsOptions.SourceMap, outputPath, logger)
+		sourceMapPaths, err := ResolveSourceMapPaths(jsOptions.SourceMap, outputPath, logger)
 		if err != nil {
 			return err
 		}

--- a/pkg/upload/js.go
+++ b/pkg/upload/js.go
@@ -159,9 +159,27 @@ func resolveSourceMapPaths(sourceMapPath string, outputPath string, logger log.L
 		}
 		return nil
 	})
+
 	if err != nil {
 		return []string{}, err
 	}
+
+	// Filter out source maps inside node_modules directories
+	filtered := []string{}
+	for _, sm := range sourceMapPaths {
+		absSm, err := filepath.Abs(sm)
+		if err != nil {
+			continue
+		}
+		if strings.HasPrefix(absSm, "node_modules"+string(filepath.Separator)) {
+			logger.Debug(fmt.Sprintf("Skipping source map in node_modules: %s", absSm))
+			continue
+		}
+		filtered = append(filtered, sm)
+	}
+
+	sourceMapPaths = filtered
+
 	if len(sourceMapPaths) == 0 {
 		logger.Warn(fmt.Sprintf("No source maps found in: %s", outputPath))
 	} else {
@@ -395,26 +413,6 @@ func ProcessJs(options options.CLI, logger log.Logger) error {
 		sourceMapPaths, err := resolveSourceMapPaths(jsOptions.SourceMap, outputPath, logger)
 		if err != nil {
 			return err
-		}
-
-		// Filter out source maps inside projectRoot/node_modules
-		if jsOptions.ProjectRoot != "" {
-			nmRoot, err := filepath.Abs(filepath.Join(jsOptions.ProjectRoot, "node_modules"))
-			if err == nil {
-				filtered := []string{}
-				for _, sm := range sourceMapPaths {
-					absSm, err := filepath.Abs(sm)
-					if err != nil {
-						continue
-					}
-					if strings.HasPrefix(absSm, nmRoot+string(filepath.Separator)) {
-						logger.Debug(fmt.Sprintf("Skipping source map in node_modules: %s", absSm))
-						continue
-					}
-					filtered = append(filtered, sm)
-				}
-				sourceMapPaths = filtered
-			}
 		}
 
 		// Check that we now have a source map path

--- a/pkg/upload/js.go
+++ b/pkg/upload/js.go
@@ -397,6 +397,26 @@ func ProcessJs(options options.CLI, logger log.Logger) error {
 			return err
 		}
 
+		// Filter out source maps inside projectRoot/node_modules
+		if jsOptions.ProjectRoot != "" {
+			nmRoot, err := filepath.Abs(filepath.Join(jsOptions.ProjectRoot, "node_modules"))
+			if err == nil {
+				filtered := []string{}
+				for _, sm := range sourceMapPaths {
+					absSm, err := filepath.Abs(sm)
+					if err != nil {
+						continue
+					}
+					if strings.HasPrefix(absSm, nmRoot+string(filepath.Separator)) {
+						logger.Debug(fmt.Sprintf("Skipping source map in node_modules: %s", absSm))
+						continue
+					}
+					filtered = append(filtered, sm)
+				}
+				sourceMapPaths = filtered
+			}
+		}
+
 		// Check that we now have a source map path
 		if len(sourceMapPaths) == 0 {
 			return fmt.Errorf("could not find a source map, please specify the path by using --source-map")

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -119,20 +119,14 @@ func ProcessReactNativeAndroid(globalOptions options.CLI, logger log.Logger) err
 		}
 
 		if androidOptions.Android.AppManifest == "" {
-			// RN versions <= 0.74 intermediates/merged_manifests/<androidOptions.Android.Variant>/AndroidManifest.xml"
-			appManifestPathExpected = filepath.Join(buildDirPath, "intermediates", "merged_manifests", androidOptions.Android.Variant, "AndroidManifest.xml")
-			if utils.FileExists(appManifestPathExpected) {
-				androidOptions.Android.AppManifest = appManifestPathExpected
+			androidOptions.Android.AppManifest, err = android.FindAndroidManifest(buildDirPath, androidOptions.Android.Variant)
+			if err != nil {
+				return err
+			}
+			if androidOptions.Android.AppManifest != "" {
 				logger.Debug(fmt.Sprintf("Found app manifest at: %s", androidOptions.Android.AppManifest))
 			} else {
-				// RN versions > 0.74 "intermediates/merged_manifests/androidOptions.Android.Variant, <androidOptions.Android.Variant>/AndroidManifest.xml"
-				appManifestPathExpected = filepath.Join(buildDirPath, "intermediates", "merged_manifests", androidOptions.Android.Variant, "process"+cases.Title(language.English).String(androidOptions.Android.Variant)+"Manifest", "AndroidManifest.xml")
-				if utils.FileExists(appManifestPathExpected) {
-					androidOptions.Android.AppManifest = appManifestPathExpected
-					logger.Debug(fmt.Sprintf("Found app manifest at: %s", androidOptions.Android.AppManifest))
-				} else {
-					logger.Debug(fmt.Sprintf("No app manifest found at: %s", appManifestPathExpected))
-				}
+				logger.Debug(fmt.Sprintf("No app manifest found at: %s", appManifestPathExpected))
 			}
 		}
 

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -35,11 +35,11 @@ func ProcessReactNativeAndroid(globalOptions options.CLI, logger log.Logger) err
 
 	for _, path := range androidOptions.Path {
 
-		buildDirPath := filepath.Join(path, "android", "app", "build")
+		appBuildPath := filepath.Join(path, "android", "app", "build")
 		rootDirPath = path
-		if !utils.FileExists(buildDirPath) {
-			buildDirPath = filepath.Join(path, "app", "build")
-			if utils.FileExists(buildDirPath) {
+		if !utils.FileExists(appBuildPath) {
+			appBuildPath = filepath.Join(path, "app", "build")
+			if utils.FileExists(appBuildPath) {
 				rootDirPath = filepath.Join(path, "..")
 			} else if androidOptions.ReactNative.Bundle == "" || androidOptions.ReactNative.SourceMap == "" {
 				return fmt.Errorf("unable to find bundle files or source maps in within %s", path)
@@ -51,16 +51,16 @@ func ProcessReactNativeAndroid(globalOptions options.CLI, logger log.Logger) err
 		}
 
 		if androidOptions.ReactNative.Bundle == "" {
-			if utils.IsDir(filepath.Join(buildDirPath, "generated", "assets", "react")) {
+			if utils.IsDir(filepath.Join(appBuildPath, "generated", "assets", "react")) {
 				// RN version < 0.70 - generated/assets/react/<androidOptions.Android.Variant>/index.android.bundle
-				bundleDirPath = filepath.Join(buildDirPath, "generated", "assets", "react")
-			} else if utils.IsDir(filepath.Join(buildDirPath, "ASSETS")) {
+				bundleDirPath = filepath.Join(appBuildPath, "generated", "assets", "react")
+			} else if utils.IsDir(filepath.Join(appBuildPath, "ASSETS")) {
 				// RN versions < 0.72 - ASSETS/createBundle<androidOptions.Android.Variant>JsAndAssets/index.android.bundle
-				bundleDirPath = filepath.Join(buildDirPath, "ASSETS")
+				bundleDirPath = filepath.Join(appBuildPath, "ASSETS")
 				variantFileFormat = "createBundle%sJsAndAssets"
-			} else if utils.IsDir(filepath.Join(buildDirPath, "generated", "assets")) {
+			} else if utils.IsDir(filepath.Join(appBuildPath, "generated", "assets")) {
 				// RN versions >= 0.72 - generated/assets/<androidOptions.Android.Variant>/index.android.bundle
-				bundleDirPath = filepath.Join(buildDirPath, "generated", "assets")
+				bundleDirPath = filepath.Join(appBuildPath, "generated", "assets")
 				variantFileFormat = "createBundle%sJsAndAssets"
 			} else {
 				return fmt.Errorf("unable to find index.android.bundle in your project, please specify the path using --bundle")
@@ -90,7 +90,7 @@ func ProcessReactNativeAndroid(globalOptions options.CLI, logger log.Logger) err
 		}
 
 		if androidOptions.ReactNative.SourceMap == "" {
-			sourceMapDirPath := filepath.Join(buildDirPath, "generated", "sourcemaps", "react")
+			sourceMapDirPath := filepath.Join(appBuildPath, "generated", "sourcemaps", "react")
 
 			if androidOptions.Android.Variant == "" {
 				androidOptions.Android.Variant, err = android.GetVariantDirectory(sourceMapDirPath)
@@ -119,7 +119,7 @@ func ProcessReactNativeAndroid(globalOptions options.CLI, logger log.Logger) err
 		}
 
 		if androidOptions.Android.AppManifest == "" {
-			androidOptions.Android.AppManifest, err = android.FindAndroidManifest(buildDirPath, androidOptions.Android.Variant)
+			androidOptions.Android.AppManifest, err = android.FindAndroidManifest(appBuildPath, androidOptions.Android.Variant)
 			if err != nil {
 				return err
 			}

--- a/test/upload/js_test.go
+++ b/test/upload/js_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
-	"github.com/bugsnag/bugsnag-cli/pkg/options"
 	"github.com/bugsnag/bugsnag-cli/pkg/upload"
 )
 
@@ -38,52 +37,44 @@ func TestPopulateSourceMap(t *testing.T) {
 	}
 }
 
-func TestProcessJs_IgnoresNodeModulesSourceMaps(t *testing.T) {
+func TestResolveSourceMapPaths_IgnoresNodeModulesAndCssMaps(t *testing.T) {
 	logger := log.NewLoggerWrapper("debug")
 
-	tmpDir := t.TempDir()
+	// Create a temporary directory structure
+	tempDir := t.TempDir()
 
-	projectRoot := filepath.Join(tmpDir, "project")
-	distDir := filepath.Join(projectRoot, "dist")
-	nodeModulesDir := filepath.Join(projectRoot, "node_modules", "dep")
-
-	if err := os.MkdirAll(distDir, 0o755); err != nil {
-		t.Fatalf("failed to create dist dir: %v", err)
+	// Valid source map
+	validMap := filepath.Join(tempDir, "app.js.map")
+	if err := os.WriteFile(validMap, []byte("{}"), 0644); err != nil {
+		t.Fatalf("failed to write valid source map: %v", err)
 	}
-	if err := os.MkdirAll(nodeModulesDir, 0o755); err != nil {
+
+	// CSS source map (should be ignored)
+	cssMap := filepath.Join(tempDir, "styles.css.map")
+	if err := os.WriteFile(cssMap, []byte("{}"), 0644); err != nil {
+		t.Fatalf("failed to write css source map: %v", err)
+	}
+
+	// node_modules source map (should be ignored)
+	nodeModulesDir := filepath.Join(tempDir, "node_modules", "lib")
+	if err := os.MkdirAll(nodeModulesDir, 0755); err != nil {
 		t.Fatalf("failed to create node_modules dir: %v", err)
 	}
-
-	// Sourcemap that should be kept
-	validMap := filepath.Join(distDir, "app.js.map")
-	if err := os.WriteFile(validMap, []byte(`{"version":3,"sources":[],"names":[],"mappings":""}`), 0o644); err != nil {
-		t.Fatalf("failed to write valid sourcemap: %v", err)
+	nodeModulesMap := filepath.Join(nodeModulesDir, "lib.js.map")
+	if err := os.WriteFile(nodeModulesMap, []byte("{}"), 0644); err != nil {
+		t.Fatalf("failed to write node_modules source map: %v", err)
 	}
 
-	// Sourcemap inside node_modules that should be ignored
-	ignoredMap := filepath.Join(nodeModulesDir, "dep.js.map")
-	if err := os.WriteFile(ignoredMap, []byte(`{"version":3,"sources":[],"names":[],"mappings":""}`), 0o644); err != nil {
-		t.Fatalf("failed to write ignored sourcemap: %v", err)
+	paths, err := upload.ResolveSourceMapPaths("", tempDir, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	opts := options.CLI{
-		Globals: options.Globals{
-			ApiKey: "test-api-key",
-		},
-		Upload: options.Upload{
-			Js: options.Js{
-				Path:        []string{distDir},
-				ProjectRoot: projectRoot,
-				BaseUrl:     "https://example.com/",
-			},
-		},
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 source map, got %d", len(paths))
 	}
 
-	err := upload.ProcessJs(opts, logger)
-
-	// We expect ProcessJs to progress past sourcemap discovery.
-	// Any error here should NOT be due to missing sourcemaps.
-	if err != nil && strings.Contains(err.Error(), "could not find a source map") {
-		t.Fatalf("node_modules sourcemaps were not ignored; no valid sourcemaps detected")
+	if paths[0] != validMap {
+		t.Errorf("expected source map %s, got %s", validMap, paths[0])
 	}
 }

--- a/test/upload/js_test.go
+++ b/test/upload/js_test.go
@@ -1,10 +1,13 @@
 package upload_testing
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
+	"github.com/bugsnag/bugsnag-cli/pkg/options"
 	"github.com/bugsnag/bugsnag-cli/pkg/upload"
 )
 
@@ -32,5 +35,55 @@ func TestPopulateSourceMap(t *testing.T) {
 	}
 	if !strings.Contains(*contents[2], "const element = document.createElement('div');") {
 		t.Error("contents 2 should be populated")
+	}
+}
+
+func TestProcessJs_IgnoresNodeModulesSourceMaps(t *testing.T) {
+	logger := log.NewLoggerWrapper("debug")
+
+	tmpDir := t.TempDir()
+
+	projectRoot := filepath.Join(tmpDir, "project")
+	distDir := filepath.Join(projectRoot, "dist")
+	nodeModulesDir := filepath.Join(projectRoot, "node_modules", "dep")
+
+	if err := os.MkdirAll(distDir, 0o755); err != nil {
+		t.Fatalf("failed to create dist dir: %v", err)
+	}
+	if err := os.MkdirAll(nodeModulesDir, 0o755); err != nil {
+		t.Fatalf("failed to create node_modules dir: %v", err)
+	}
+
+	// Sourcemap that should be kept
+	validMap := filepath.Join(distDir, "app.js.map")
+	if err := os.WriteFile(validMap, []byte(`{"version":3,"sources":[],"names":[],"mappings":""}`), 0o644); err != nil {
+		t.Fatalf("failed to write valid sourcemap: %v", err)
+	}
+
+	// Sourcemap inside node_modules that should be ignored
+	ignoredMap := filepath.Join(nodeModulesDir, "dep.js.map")
+	if err := os.WriteFile(ignoredMap, []byte(`{"version":3,"sources":[],"names":[],"mappings":""}`), 0o644); err != nil {
+		t.Fatalf("failed to write ignored sourcemap: %v", err)
+	}
+
+	opts := options.CLI{
+		Globals: options.Globals{
+			ApiKey: "test-api-key",
+		},
+		Upload: options.Upload{
+			Js: options.Js{
+				Path:        []string{distDir},
+				ProjectRoot: projectRoot,
+				BaseUrl:     "https://example.com/",
+			},
+		},
+	}
+
+	err := upload.ProcessJs(opts, logger)
+
+	// We expect ProcessJs to progress past sourcemap discovery.
+	// Any error here should NOT be due to missing sourcemaps.
+	if err != nil && strings.Contains(err.Error(), "could not find a source map") {
+		t.Fatalf("node_modules sourcemaps were not ignored; no valid sourcemaps detected")
 	}
 }


### PR DESCRIPTION
### Changed

- Updated the logic for the `upload js` command to ignore the top level `node_modules` directory when processing source maps. [#251](https://github.com/bugsnag/bugsnag-cli/pull/251)
- Add proxy support to the NPM package. [#252](https://github.com/bugsnag/bugsnag-cli/pull/252)
- Add a fallback path for AndroidManifest.xml when processing Android related uploads (Proguard, NDK and React Native) [#249](https://github.com/bugsnag/bugsnag-cli/pull/249)
