### PR TITLE
v3.6.1 Release

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,7 +40,26 @@ steps:
     commands:
       - bundle install
       - chmod +x bin/arm64-macos-bugsnag-cli
-      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) features/cli
+      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) --exclude features/cli/installation.feature features/cli
+    plugins:
+      artifacts#v1.5.0:
+        download:
+          - bin/arm64-macos-bugsnag-cli
+        upload:
+          - maze_output/**/*
+
+  - label: "Node {{matrix}} Package Installation Tests"
+    depends_on: build
+    matrix:
+      - "18"
+      - "20"
+      - "22"
+    env:
+      NODE_VERSION: "{{matrix}}"
+    commands:
+      - bundle install
+      - chmod +x bin/arm64-macos-bugsnag-cli
+      - bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) features/cli/installation.feature
     plugins:
       artifacts#v1.5.0:
         download:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Fixed
+
+- Fix proxy support in the Node package by replacing proxy-agent with undici.ProxyAgent. [#254](https://github.com/bugsnag/bugsnag-cli/pull/254)
+
 ## [3.6.0] - 2026-01-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## unreleased
+## [3.6.1] - 2026-01-07
 
 ### Fixed
 

--- a/features/cli/installation.feature
+++ b/features/cli/installation.feature
@@ -4,7 +4,9 @@ Feature: CLI Installation
   Scenario: Install the bugsnag-cli via NPM
     When I install the bugsnag-cli via 'npm' in a new directory
     Then the 'node_modules/.bin' directory should contain "bugsnag-cli"
+    And it should return the help text when I run "npx bugsnag-cli --help"
 
   Scenario: Install the bugsnag-cli via YARN
     When I install the bugsnag-cli via 'yarn' in a new directory
     Then the 'node_modules/.bin' directory should contain "bugsnag-cli"
+    And it should return the help text when I run "yarn bugsnag-cli --help"

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -225,12 +225,17 @@ When('I install the bugsnag-cli via {string} in a new directory') do |package_ma
     @init_output = `pnpm init -y`
     @install_output = `pnpm add #{@bugsnag_cli_package_path}`
   end
-
-  Dir.chdir(base_dir)
 end
 
 Then('the {string} directory should contain {string}') do |directory, package|
   Maze.check.include(`ls #{@fixture_dir}/#{directory}`, package)
+end
+
+And('it should return the help text when I run {string}') do |command|
+  Dir.chdir(@fixture_dir)
+  @output = `#{command}`
+  Maze.check.include(@output, "Usage: #{binary} <command>")
+  Dir.chdir(base_dir)
 end
 
 Given('I build the Unity project for Android') do

--- a/install.sh
+++ b/install.sh
@@ -91,7 +91,7 @@ display_help() {
 EOS
 }
 
-VERSION="3.6.0"
+VERSION="3.6.1"
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in

--- a/js/package.json
+++ b/js/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bugsnag/bugsnag-cli#readme",
   "dependencies": {
-    "proxy-agent": "^6.5.0",
+    "undici": "^6.23.0",
     "yaml": "^2.7.0"
   },
   "files": [

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/cli",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "BugSnag CLI",
   "main": "dist/bugsnag-cli-wrapper.js",
   "types": "dist/bugsnag-cli-wrapper.d.ts",

--- a/js/postinstall.js
+++ b/js/postinstall.js
@@ -4,7 +4,7 @@ const { createWriteStream } = require('fs')
 const path = require('path')
 const os = require('os')
 const YAML = require('yaml')
-const ProxyAgent = require('proxy-agent')
+const { ProxyAgent, fetch } = require('undici')
 const packageJson = require('./package.json')
 
 const supportedPlatformsConfig = fs.readFileSync(
@@ -58,11 +58,14 @@ const downloadBinaryFromGitHub = async (downloadUrl, outputPath) => {
             fs.mkdirSync(binDir, { recursive: true })
         }
 
-        const agent = new ProxyAgent()
+        const proxy =
+            process.env.HTTPS_PROXY ||
+            process.env.HTTP_PROXY ||
+            process.env.https_proxy ||
+            process.env.http_proxy
+        const options = proxy ? { dispatcher: new ProxyAgent(proxy) } : {}
 
-        const resp = await fetch(downloadUrl, {
-            dispatcher: agent
-        })
+        const resp = await fetch(downloadUrl, options)
 
         if (resp.ok && resp.body) {
             const writer = createWriteStream(outputPath)

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/bugsnag/bugsnag-cli/pkg/upload"
 )
 
-var package_version = "3.6.0"
+var package_version = "3.6.1"
 
 func main() {
 	commands := options.CLI{}

--- a/makefile
+++ b/makefile
@@ -51,7 +51,7 @@ unit-test:
 
 .PHONY: npm-lint
 npm-lint:
-	cd js && npm i && npm install -g npm-check && npm-check
+	cd js && npm i && npm install -g npm-check && npm-check --ignore=undici
 
 .PHONY: go-lint
 go-lint:


### PR DESCRIPTION
### Fixed

- Fix proxy support in the Node package by replacing proxy-agent with undici.ProxyAgent. [#254](https://github.com/bugsnag/bugsnag-cli/pull/254)
