### PR TITLE
Handle postinstall binary download error

### DIFF
--- a/js/postinstall.js
+++ b/js/postinstall.js
@@ -77,7 +77,7 @@ const downloadBinaryFromGitHub = async (downloadUrl, outputPath) => {
         fs.chmodSync(outputPath, 0o755)
         console.log('Binary downloaded successfully!')
     } catch (err) {
-        console.error('Error downloading binary:', err.message)
+        handleError(`Error downloading binary: ${err.message}`)
     }
 }
 


### PR DESCRIPTION
## Goal

A failure to fetch from GitHub should fail the postinstall rather than silently leaving the stub bin in place.

## Testing

Happy case covered by CI.