### PR TITLE
fix: don't fail when AndroidManifest.xml is missing, if version info is provided via flags

### DIFF
--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -121,7 +121,11 @@ func ProcessReactNativeAndroid(globalOptions options.CLI, logger log.Logger) err
 		if androidOptions.Android.AppManifest == "" {
 			androidOptions.Android.AppManifest, err = android.FindAndroidManifest(appBuildPath, androidOptions.Android.Variant)
 			if err != nil {
-				return err
+				// Only fail if the values from manifest are not provided
+				if globalOptions.ApiKey == "" || androidOptions.ReactNative.VersionName == "" || androidOptions.Android.VersionCode == "" {
+					return err
+				}
+				logger.Debug(fmt.Sprintf("Could not find AndroidManifest.xml: %s", err.Error()))
 			}
 			if androidOptions.Android.AppManifest != "" {
 				logger.Debug(fmt.Sprintf("Found app manifest at: %s", androidOptions.Android.AppManifest))


### PR DESCRIPTION
## Goal
Possible fix for issue https://github.com/bugsnag/bugsnag-cli/issues/261, more details inside the issue.
`AndroidManifest.xml` is needed to populate values required for the `bugsnag-cli upload react-native-android`, the required values are:

- Version Name
- Version Code
- Bugsnag API key

If the user provides those three required values via flags:
```
--version-name="${APP_VERSION}"
--version-code="${BUILD_ID}"
--api-key="${BUGSNAG_API_KEY}"
```

Then the `AndroidManifest.xml` should no longer be needed or become optional.

## Design

Provide the ability to upload JS sourcemaps without performing full build of the app.

## Changeset

- Missing AndroidManifest.xml will now only error when these flags are not provided by the user: 
```
--version-name="${APP_VERSION}"
--version-code="${BUILD_ID}"
--api-key="${BUGSNAG_API_KEY}"
``` 

## Testing

Manual test step provided here: https://github.com/bugsnag/bugsnag-cli/issues/261