### PR TITLE
v3.8.0 Release

### DIFF
--- a/.buildkite/react-native/android.pipeline.yml
+++ b/.buildkite/react-native/android.pipeline.yml
@@ -14,7 +14,7 @@ steps:
     commands:
       - "chmod +x bin/arm64-macos-bugsnag-cli"
       - "bundle install"
-      - "bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) --document-server-port=$((MAZE_RUNNER_PORT + 1)) features/react-native/android.feature"
+      - "bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) features/react-native/android.feature"
     matrix:
       - "0.70"
       - "0.73"

--- a/.buildkite/react-native/ios.pipeline.yml
+++ b/.buildkite/react-native/ios.pipeline.yml
@@ -15,7 +15,7 @@ steps:
     commands:
       - "chmod +x bin/arm64-macos-bugsnag-cli"
       - "bundle install"
-      - "bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) --document-server-port=$((MAZE_RUNNER_PORT + 1)) features/react-native/ios.feature"
+      - "bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) features/react-native/ios.feature"
     matrix:
       - "0.70"
       - "0.73"

--- a/.buildkite/react-native/react-native.pipeline.yml
+++ b/.buildkite/react-native/react-native.pipeline.yml
@@ -9,7 +9,7 @@ steps:
     commands:
       - "chmod +x bin/arm64-macos-bugsnag-cli"
       - "bundle install"
-      - "bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) --document-server-port=$((MAZE_RUNNER_PORT + 1)) features/react-native/react-native.feature"
+      - "bundle exec maze-runner --port=$((MAZE_RUNNER_PORT)) features/react-native/react-native.feature"
     plugins:
       artifacts#v1.5.0:
         download:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Added
+
+- Add support for aarch64 in the install scripts [#260](https://github.com/bugsnag/bugsnag-cli/pull/260)
+
 ## [3.7.0] - 2026-01-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Changed
+
+- Changed AndroidManifest.xml handling for Android-related uploads (NDK, Proguard, and React Native Android) to log warnings instead of returning errors when the manifest file cannot be found or read. [#264](https://github.com/bugsnag/bugsnag-cli/pull/264)
+
 ## [3.7.0] - 2026-01-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Changed AndroidManifest.xml handling for Android-related uploads (NDK, Proguard, and React Native Android) to log warnings instead of returning errors when the manifest file cannot be found or read. [#264](https://github.com/bugsnag/bugsnag-cli/pull/264)
+- Changed AndroidManifest.xml handling for Android-related uploads (NDK, Proguard, and React Native Android) to not error when the manifest file cannot be found or read. [#264](https://github.com/bugsnag/bugsnag-cli/pull/264)
 
 - Add support for aarch64 in the install scripts [#260](https://github.com/bugsnag/bugsnag-cli/pull/260)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## unreleased
+## [3.8.0] - 2026-03-03
 
 ### Changed
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
-gem "bugsnag-maze-runner", "~> 9.36"
+gem "bugsnag-maze-runner", "~> 10.11"
 gem 'cocoapods'

--- a/features/android/android-ndk.feature
+++ b/features/android/android-ndk.feature
@@ -12,6 +12,18 @@ Feature: Android NDK Integration Test
       | versionName  | 2.0                                  |
       | overwrite    | true                                 |
 
+  Scenario: Upload a single Android NDK sourcemap using all CLI flags without AndroidManifest.xml
+    When I run bugsnag-cli with upload android-ndk --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --application-id="2.0" --variant=release --version-code=2 --version-name=2.0 features/android/fixtures/app/build/intermediates/merged_native_libs/release/out/lib/arm64-v8a/libbugsnag-ndk.so
+    And I wait to receive 1 sourcemaps
+    Then the sourcemaps are valid for the API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    Then the sourcemap payload fields should be:
+      | apiKey       | 1234567890ABCDEF1234567890ABCDEF     |
+      | appId        | 2.0                                  |
+      | versionCode  | 2                                    |
+      | versionName  | 2.0                                  |
+      | overwrite    | true                                 |
+
   Scenario: Upload a single Android NDK sourcemap providing the app-manifest CLI flag
     When I run bugsnag-cli with upload android-ndk --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --app-manifest=features/android/fixtures/app/build/intermediates/merged_manifests/release/AndroidManifest.xml features/android/fixtures/app/build/intermediates/merged_native_libs/release/out/lib/arm64-v8a/libbugsnag-ndk.so
     And I wait to receive 1 sourcemaps

--- a/features/android/android-proguard.feature
+++ b/features/android/android-proguard.feature
@@ -13,6 +13,19 @@ Feature: Android Proguard Integration Test
       | versionName  | 2.0                                   |
       | overwrite    | true                                  |
 
+  Scenario: Upload an Android Proguard mapping file using all CLI flags without AndroidManifest.xml 
+    When I run bugsnag-cli with upload android-proguard --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --application-id="com.exampleApp.android" --build-uuid=1234567890abcdefghijklmnopqrstuvwxyz --variant=release --version-code=2 --version-name=2.0 features/android/fixtures/app/build/outputs/mapping/release/mapping.txt
+    And I wait to receive 1 sourcemaps
+    Then the sourcemaps are valid for the API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    Then the sourcemap payload fields should be:
+      | apiKey       | 1234567890ABCDEF1234567890ABCDEF      |
+      | appId        | com.exampleApp.android                |
+      | buildUUID    | 1234567890abcdefghijklmnopqrstuvwxyz  |
+      | versionCode  | 2                                     |
+      | versionName  | 2.0                                   |
+      | overwrite    | true                                  |
+
   Scenario: Upload an Android Proguard mapping file providing the app-manifest CLI flag
     When I run bugsnag-cli with upload android-proguard --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --app-manifest=features/android/fixtures/app/build/intermediates/merged_manifests/release/AndroidManifest.xml features/android/fixtures/app/build/outputs/mapping/release/mapping.txt
     And I wait to receive 1 sourcemaps

--- a/install.sh
+++ b/install.sh
@@ -107,7 +107,7 @@ display_help() {
 EOS
 }
 
-VERSION="3.7.0"
+VERSION="3.8.0"
 
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do

--- a/install.sh
+++ b/install.sh
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
 
+# Bugsnag CLI installer
+# This script detects the current OS and CPU architecture,
+# downloads the appropriate prebuilt bugsnag-cli binary,
+# and installs it into a user-local prefix.
+
+# Fail fast on errors and broken pipelines
 set -o errexit
 set -o pipefail
 #set -o nounset
 #set -o xtrace
 
+# Print an error message to stderr and exit the script
 abort() {
   printf "%s\n" "$@" >&2
   exit 1
 }
 
+# Terminal formatting helpers (used for colored and styled output)
 # string formatters
 if [[ -t 1 ]]; then
   tty_escape() { printf "\033[%sm" "$1"; }
@@ -23,6 +31,7 @@ tty_red="$(tty_mkbold 31)"
 tty_bold="$(tty_mkbold 39)"
 tty_reset="$(tty_escape 0)"
 
+# Join command arguments for readable logging output
 shell_join() {
   local arg
   printf "%s" "$1"
@@ -33,10 +42,12 @@ shell_join() {
   done
 }
 
+# Remove a trailing newline from a string
 chomp() {
   printf "%s" "${1/"$'\n'"/}"
 }
 
+# Emit an audible bell when running in an interactive terminal
 ring_bell() {
   # Use the shell's audible bell.
   if [[ -t 1 ]]; then
@@ -44,10 +55,12 @@ ring_bell() {
   fi
 }
 
+# Check whether a path exists but is not readable, writable, and executable
 exists_but_not_writable() {
   [[ -e "$1" ]] && ! [[ -r "$1" && -w "$1" && -x "$1" ]]
 }
 
+# User-facing logging helpers
 ohai() {
   printf "${tty_blue}==>${tty_bold} %s${tty_reset}\n" "$(shell_join "$@")"
 }
@@ -56,12 +69,14 @@ warn() {
   printf "${tty_red}Warning${tty_reset}: %s\n" "$(chomp "$1")"
 }
 
+# Execute a command and abort with context if it fails
 execute() {
   if ! "$@"; then
     abort "$(printf "Failed during: %s" "$(shell_join "$@")")"
   fi
 }
 
+# File ownership and permission helpers
 STAT_PRINTF=("stat" "-f")
 
 get_owner() {
@@ -80,6 +95,7 @@ file_not_grpowned() {
   [[ " $(id -G "${USER}") " != *" $(get_group "$1") "* ]]
 }
 
+# Print usage and help information
 display_help() {
   echo ""
   cat <<EOS
@@ -93,6 +109,7 @@ EOS
 
 VERSION="3.7.0"
 
+# Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     --version=*)
@@ -111,13 +128,13 @@ while [[ "$#" -gt 0 ]]; do
   shift
 done
 
-# USER isn't always set so provide a fall back for the installer and subprocesses.
+# Ensure USER is set for ownership and permission operations
 if [[ -z "${USER-}" ]]; then
   USER="$(chomp "$(id -un)")"
   export USER
 fi
 
-# First check OS.
+# Detect supported operating systems (Linux and macOS only)
 OS="$(uname)"
 if [[ "${OS}" == "Linux" ]]; then
   BUGSNAG_CLI_ON_LINUX=1
@@ -131,12 +148,41 @@ else
   abort "This install script only works on Linux or Macos"
 fi
 
+# Normalize CPU architecture names to match release asset naming
 UNAME_MACHINE="$(uname -m)"
+
+case "$UNAME_MACHINE" in
+  aarch64|arm64)
+    ARCH="arm64"
+    ;;
+  x86_64|amd64)
+    ARCH="x86_64"
+    ;;
+  i386|i686)
+    UNAME_MACHINE="i386"
+    ;;
+  *)
+    abort "Unsupported architecture: $UNAME_MACHINE"
+    ;;
+esac
+
+# Map OS name to platform identifier used in download artifacts
+if [[ "$OS_NAME" == "linux" ]]; then
+  PLATFORM="linux"
+elif [[ "$OS_NAME" == "macos" ]]; then
+  PLATFORM="macos"
+else
+  abort "Unsupported OS: $OS_NAME"
+fi
+
+BIN_NAME="bugsnag-cli"
+DOWNLOAD_NAME="${ARCH}-${PLATFORM}-${BIN_NAME}"
 BUGSNAG_CLI_PREFIX="${HOME}/.local/bugsnag"
 
 ohai "This script will install:"
 echo "${BUGSNAG_CLI_PREFIX}/bin/bugsnag-cli"
 
+# Determine which directories need to be created under the install prefix
 directories=(
   bin
 )
@@ -154,6 +200,7 @@ if [[ "${#mkdirs[@]}" -gt 0 ]]; then
   printf "%s\n" "${mkdirs[@]}"
 fi
 
+# Create required directories with correct ownership and permissions
 if [[ "${#mkdirs[@]}" -gt 0 ]]; then
   execute "mkdir" "-p" "${mkdirs[@]}"
   execute "chmod" "ug=rwx" "${mkdirs[@]}"
@@ -161,6 +208,7 @@ if [[ "${#mkdirs[@]}" -gt 0 ]]; then
   execute "chgrp" "${GROUP}" "${mkdirs[@]}"
 fi
 
+# Download the appropriate bugsnag-cli binary and install it
 ohai "Downloading and installing Bugsnag CLI..."
 (
   cd "${BUGSNAG_CLI_PREFIX}" >/dev/null || return
@@ -175,14 +223,15 @@ ohai "Downloading and installing Bugsnag CLI..."
   elif [ "${http_status_code}" -ne 200 ]; then
       abort "The URL returned a non-404 error with status code ${http_status_code}."
   else
-      execute "curl" "-#" "-L" "$url/download/v${VERSION}/${UNAME_MACHINE}-${OS_NAME}-bugsnag-cli" "-o" "$output_file"
+      execute "curl" "-#" "-L" "$url/download/v${VERSION}/${DOWNLOAD_NAME}" "-o" "$output_file"
   fi
 
-  execute "chmod" "ug=rwx" "${BUGSNAG_CLI_PREFIX}/bin/bugsnag-cli"
+  execute "chmod" "ug=rwx" "${output_file}"
 
 ) ||
   exit 1
 
+# Warn the user if the install location is not on PATH
 if [[ ":${PATH}:" != *":${BUGSNAG_CLI_PREFIX}/bin:"* ]]; then
   warn "${BUGSNAG_CLI_PREFIX}/bin is not in your PATH.
   Instructions on how to configure your shell for Bugsnag CLI
@@ -194,6 +243,7 @@ echo
 
 ring_bell
 
+# Detect the user's shell profile for PATH modification instructions
 case "${SHELL}" in
 */bash*)
   if [[ -r "${HOME}/.bash_profile" ]]; then
@@ -210,7 +260,8 @@ case "${SHELL}" in
   ;;
 esac
 
-if [[ "$(which bugsnag-cli)" != "${BUGSNAG_CLI_PREFIX}/bin/bugsnag-cli" ]]; then
+# Print post-install instructions if bugsnag-cli is not yet discoverable
+if [[ "$(which bugsnag-cli)" != "${output_file}" ]]; then
   ohai "Next steps:"
 
   cat <<EOS

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/cli",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "BugSnag CLI",
   "main": "dist/bugsnag-cli-wrapper.js",
   "types": "dist/bugsnag-cli-wrapper.d.ts",

--- a/js/supported-platforms.yml
+++ b/js/supported-platforms.yml
@@ -17,7 +17,7 @@
   ARCHITECTURE: 'i386'
   ARTIFACT_NAME: 'i386-windows-bugsnag-cli.exe'
   BINARY_NAME: 'bugsnag-cli.exe'
-  
+
 - TYPE: 'Linux'
   ARCHITECTURE: 'x64'
   ARTIFACT_NAME: 'x86_64-linux-bugsnag-cli'
@@ -25,6 +25,11 @@
 
 - TYPE: 'Linux'
   ARCHITECTURE: 'arm64'
+  ARTIFACT_NAME: 'arm64-linux-bugsnag-cli'
+  BINARY_NAME: 'bugsnag-cli'
+
+- TYPE: 'Linux'
+  ARCHITECTURE: 'aarch64'
   ARTIFACT_NAME: 'arm64-linux-bugsnag-cli'
   BINARY_NAME: 'bugsnag-cli'
 

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/bugsnag/bugsnag-cli/pkg/upload"
 )
 
-var package_version = "3.7.0"
+var package_version = "3.8.0"
 
 func main() {
 	commands := options.CLI{}

--- a/pkg/android/find-android-manifest.go
+++ b/pkg/android/find-android-manifest.go
@@ -23,8 +23,7 @@ import (
 //
 // Returns:
 //   - string: The resolved manifest path if found, otherwise an empty string.
-//   - error: Non-nil if the manifest cannot be found.
-func FindAndroidManifest(appBuildPath string, variant string, logger log.Logger) (string, error) {
+func FindAndroidManifest(appBuildPath string, variant string, logger log.Logger) string {
 	var err error
 
 	mergedManifestPath := filepath.Join(appBuildPath, "intermediates", "merged_manifests")
@@ -34,7 +33,8 @@ func FindAndroidManifest(appBuildPath string, variant string, logger log.Logger)
 	}
 
 	if err != nil {
-		return "", err
+		logger.Info("No AndroidManifest.xml located: a single variant directory couldn't be found")
+		return ""
 	}
 
 	primaryAppManifestPath := filepath.Join(mergedManifestPath, variant, "AndroidManifest.xml")
@@ -45,11 +45,13 @@ func FindAndroidManifest(appBuildPath string, variant string, logger log.Logger)
 
 	for _, path := range paths {
 		if utils.FileExists(path) {
-			return path, nil
+			logger.Debug(fmt.Sprintf("AndroidManifest.xml located at: %s", path))
+			return path
+		} else {
+			logger.Debug(fmt.Sprintf("AndroidManifest.xml not found at: %s", path))
 		}
 	}
 
-	err = fmt.Errorf("unable to locate AndroidManifest.xml for variant %s", variant)
-	logger.Info(fmt.Sprintf("Unable to locate AndroidManifest.xml: %s", err.Error()))
-	return "", err
+	logger.Info(fmt.Sprintf("No AndroidManifest.xml located for variant %s", variant))
+	return ""
 }

--- a/pkg/android/find-android-manifest.go
+++ b/pkg/android/find-android-manifest.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/bugsnag/bugsnag-cli/pkg/log"
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
 )
 
@@ -18,11 +19,12 @@ import (
 //   - appBuildPath: The root build directory where Android build outputs are located.
 //   - variant: The build variant (e.g., "debug", "release") whose manifest paths
 //     should be searched.
+//   - logger: logger used to emit debug output when manifest is not found.
 //
 // Returns:
 //   - string: The resolved manifest path if found, otherwise an empty string.
 //   - error: Non-nil if the manifest cannot be found.
-func FindAndroidManifest(appBuildPath string, variant string) (string, error) {
+func FindAndroidManifest(appBuildPath string, variant string, logger log.Logger) (string, error) {
 	var err error
 
 	mergedManifestPath := filepath.Join(appBuildPath, "intermediates", "merged_manifests")
@@ -47,5 +49,7 @@ func FindAndroidManifest(appBuildPath string, variant string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("unable to locate AndroidManifest.xml for variant %s", variant)
+	err = fmt.Errorf("unable to locate AndroidManifest.xml for variant %s", variant)
+	logger.Info(fmt.Sprintf("Unable to locate AndroidManifest.xml: %s", err.Error()))
+	return "", err
 }

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -40,12 +40,7 @@ func resolveAppManifestIfNeeded(ndkOpts *options.AndroidNdkMapping, libPath stri
 		return
 	}
 	appBuildPath := filepath.Join(libPath, "..", "..")
-	manifestPath, err := android.FindAndroidManifest(appBuildPath, ndkOpts.Variant, logger)
-	if err != nil {
-		return
-	}
-	ndkOpts.AppManifest = manifestPath
-	logger.Debug(fmt.Sprintf("Found AndroidManifest.xml at %s", ndkOpts.AppManifest))
+	ndkOpts.AppManifest = android.FindAndroidManifest(appBuildPath, ndkOpts.Variant, logger)
 }
 
 // resolveProjectRootIfNeeded sets the project root directory in ndkOpts if it hasn't already been set.

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -29,23 +29,24 @@ func resolveMergedLibPath(input string) (string, error) {
 // resolveAppManifestIfNeeded sets the AndroidManifest.xml path in ndkOpts if it hasn't already been set.
 //
 // It infers the manifest location based on the provided native lib path and variant.
+// If the manifest cannot be found or read, a warning is logged instead of returning an error.
 //
 // Parameters:
 //   - ndkOpts: AndroidNdkMapping options struct (will be mutated).
 //   - libPath: resolved path to merged_native_libs.
 //   - logger: logger used to emit debug output.
-func resolveAppManifestIfNeeded(ndkOpts *options.AndroidNdkMapping, libPath string, logger log.Logger) error {
-	var err error
+func resolveAppManifestIfNeeded(ndkOpts *options.AndroidNdkMapping, libPath string, logger log.Logger) {
 	if ndkOpts.AppManifest != "" {
-		return nil
+		return
 	}
 	appBuildPath := filepath.Join(libPath, "..", "..")
-	ndkOpts.AppManifest, err = android.FindAndroidManifest(appBuildPath, ndkOpts.Variant)
+	manifestPath, err := android.FindAndroidManifest(appBuildPath, ndkOpts.Variant)
 	if err != nil {
-		return err
+		logger.Warn(fmt.Sprintf("Unable to locate AndroidManifest.xml: %s", err.Error()))
+		return
 	}
+	ndkOpts.AppManifest = manifestPath
 	logger.Debug(fmt.Sprintf("Found AndroidManifest.xml at %s", ndkOpts.AppManifest))
-	return nil
 }
 
 // resolveProjectRootIfNeeded sets the project root directory in ndkOpts if it hasn't already been set.
@@ -168,10 +169,7 @@ func ProcessAndroidNDK(opts options.CLI, logger log.Logger) error {
 					return err
 				}
 			}
-			err := resolveAppManifestIfNeeded(&ndkOpts, libPath, logger)
-			if err != nil {
-				return err
-			}
+			resolveAppManifestIfNeeded(&ndkOpts, libPath, logger)
 			resolveProjectRootIfNeeded(&ndkOpts, libPath)
 		}
 

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -42,7 +42,7 @@ func resolveAppManifestIfNeeded(ndkOpts *options.AndroidNdkMapping, libPath stri
 	appBuildPath := filepath.Join(libPath, "..", "..")
 	manifestPath, err := android.FindAndroidManifest(appBuildPath, ndkOpts.Variant)
 	if err != nil {
-		logger.Warn(fmt.Sprintf("Unable to locate AndroidManifest.xml: %s", err.Error()))
+		logger.Info(fmt.Sprintf("AndroidManifest.xml not located at: %s", err.Error()))
 		return
 	}
 	ndkOpts.AppManifest = manifestPath

--- a/pkg/upload/android-ndk.go
+++ b/pkg/upload/android-ndk.go
@@ -40,9 +40,8 @@ func resolveAppManifestIfNeeded(ndkOpts *options.AndroidNdkMapping, libPath stri
 		return
 	}
 	appBuildPath := filepath.Join(libPath, "..", "..")
-	manifestPath, err := android.FindAndroidManifest(appBuildPath, ndkOpts.Variant)
+	manifestPath, err := android.FindAndroidManifest(appBuildPath, ndkOpts.Variant, logger)
 	if err != nil {
-		logger.Info(fmt.Sprintf("AndroidManifest.xml not located at: %s", err.Error()))
 		return
 	}
 	ndkOpts.AppManifest = manifestPath

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -59,10 +59,7 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 				appBuildPath := filepath.Join(path, "app", "build")
 				proguardOptions.AppManifest, err = android.FindAndroidManifest(appBuildPath, proguardOptions.Variant)
 				if err != nil {
-					return err
-				}
-				if proguardOptions.AppManifest == "" {
-					logger.Info("Unable to locate AndroidManifest.xml for variant; proceeding without manifest path")
+					logger.Warn(fmt.Sprintf("Unable to locate AndroidManifest.xml: %s", err.Error()))
 				}
 			}
 
@@ -76,10 +73,7 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 				if filepath.Base(appBuildPath) == "build" {
 					proguardOptions.AppManifest, err = android.FindAndroidManifest(appBuildPath, proguardOptions.Variant)
 					if err != nil {
-						return err
-					}
-					if proguardOptions.AppManifest == "" {
-						logger.Info("Unable to locate AndroidManifest.xml for variant; proceeding without manifest path")
+						logger.Warn(fmt.Sprintf("Unable to locate AndroidManifest.xml: %s", err.Error()))
 					}
 				}
 			}
@@ -90,73 +84,73 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 			logger.Debug("Reading data from AndroidManifest.xml")
 			manifestData, err := android.ParseAndroidManifestXML(proguardOptions.AppManifest)
 			if err != nil {
-				return err
-			}
-
-			if options.ApiKey == "" {
-				for key, value := range manifestData.Application.MetaData.Name {
-					if value == "com.bugsnag.android.API_KEY" {
-						options.ApiKey = manifestData.Application.MetaData.Value[key]
+				logger.Warn(fmt.Sprintf("Unable to read AndroidManifest.xml: %s", err.Error()))
+			} else {
+				if options.ApiKey == "" {
+					for key, value := range manifestData.Application.MetaData.Name {
+						if value == "com.bugsnag.android.API_KEY" {
+							options.ApiKey = manifestData.Application.MetaData.Value[key]
+						}
 					}
-				}
-				if options.ApiKey != "" {
-					logger.Debug(fmt.Sprintf("Using %s as API key from AndroidManifest.xml", options.ApiKey))
-				}
-			}
-
-			if proguardOptions.ApplicationId == "" {
-				proguardOptions.ApplicationId = manifestData.ApplicationId
-				if proguardOptions.ApplicationId != "" {
-					logger.Debug(fmt.Sprintf("Using %s as application ID from AndroidManifest.xml", proguardOptions.ApplicationId))
-				}
-			}
-
-			if proguardOptions.NoBuildUuid {
-				proguardOptions.BuildUuid = ""
-				logger.Info("No build ID will be used")
-			} else if proguardOptions.BuildUuid == "" {
-				for i := range manifestData.Application.MetaData.Name {
-					if manifestData.Application.MetaData.Name[i] == "com.bugsnag.android.BUILD_UUID" {
-						proguardOptions.BuildUuid = manifestData.Application.MetaData.Value[i]
+					if options.ApiKey != "" {
+						logger.Debug(fmt.Sprintf("Using %s as API key from AndroidManifest.xml", options.ApiKey))
 					}
 				}
 
-				if len(proguardOptions.DexFiles) == 0 && proguardOptions.Variant != "" {
-					proguardOptions.DexFiles = android.FindVariantDexFiles(mappingFile, proguardOptions.Variant)
+				if proguardOptions.ApplicationId == "" {
+					proguardOptions.ApplicationId = manifestData.ApplicationId
+					if proguardOptions.ApplicationId != "" {
+						logger.Debug(fmt.Sprintf("Using %s as application ID from AndroidManifest.xml", proguardOptions.ApplicationId))
+					}
 				}
 
-				if proguardOptions.BuildUuid == "" && len(proguardOptions.DexFiles) > 0 {
-					safeDexFile, err := android.GetDexFiles(proguardOptions.DexFiles)
-					if err != nil {
-						return err
+				if proguardOptions.NoBuildUuid {
+					proguardOptions.BuildUuid = ""
+					logger.Info("No build ID will be used")
+				} else if proguardOptions.BuildUuid == "" {
+					for i := range manifestData.Application.MetaData.Name {
+						if manifestData.Application.MetaData.Name[i] == "com.bugsnag.android.BUILD_UUID" {
+							proguardOptions.BuildUuid = manifestData.Application.MetaData.Value[i]
+						}
 					}
 
-					signature, err := android.GetAppSignatureFromFiles(safeDexFile)
-					if err != nil {
-						return err
+					if len(proguardOptions.DexFiles) == 0 && proguardOptions.Variant != "" {
+						proguardOptions.DexFiles = android.FindVariantDexFiles(mappingFile, proguardOptions.Variant)
 					}
 
-					proguardOptions.BuildUuid = fmt.Sprintf("%x", signature)
+					if proguardOptions.BuildUuid == "" && len(proguardOptions.DexFiles) > 0 {
+						safeDexFile, err := android.GetDexFiles(proguardOptions.DexFiles)
+						if err != nil {
+							return err
+						}
 
-					if proguardOptions.BuildUuid != "" {
-						logger.Debug(fmt.Sprintf("Using %s as build ID from classes.dex", proguardOptions.BuildUuid))
+						signature, err := android.GetAppSignatureFromFiles(safeDexFile)
+						if err != nil {
+							return err
+						}
+
+						proguardOptions.BuildUuid = fmt.Sprintf("%x", signature)
+
+						if proguardOptions.BuildUuid != "" {
+							logger.Debug(fmt.Sprintf("Using %s as build ID from classes.dex", proguardOptions.BuildUuid))
+						}
+					} else {
+						logger.Debug(fmt.Sprintf("Using %s as build UUID from AndroidManifest.xml", proguardOptions.BuildUuid))
 					}
-				} else {
-					logger.Debug(fmt.Sprintf("Using %s as build UUID from AndroidManifest.xml", proguardOptions.BuildUuid))
 				}
-			}
 
-			if proguardOptions.VersionCode == "" {
-				proguardOptions.VersionCode = manifestData.VersionCode
-				if proguardOptions.VersionCode != "" {
-					logger.Debug(fmt.Sprintf("Using %s as version code from AndroidManifest.xml", proguardOptions.VersionCode))
+				if proguardOptions.VersionCode == "" {
+					proguardOptions.VersionCode = manifestData.VersionCode
+					if proguardOptions.VersionCode != "" {
+						logger.Debug(fmt.Sprintf("Using %s as version code from AndroidManifest.xml", proguardOptions.VersionCode))
+					}
 				}
-			}
 
-			if proguardOptions.VersionName == "" {
-				proguardOptions.VersionName = manifestData.VersionName
-				if proguardOptions.VersionName != "" {
-					logger.Debug(fmt.Sprintf("Using %s as version name from AndroidManifest.xml", proguardOptions.VersionName))
+				if proguardOptions.VersionName == "" {
+					proguardOptions.VersionName = manifestData.VersionName
+					if proguardOptions.VersionName != "" {
+						logger.Debug(fmt.Sprintf("Using %s as version name from AndroidManifest.xml", proguardOptions.VersionName))
+					}
 				}
 			}
 		}

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -57,10 +57,7 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 			// Attempt to locate AndroidManifest.xml for the variant if not set
 			if proguardOptions.AppManifest == "" {
 				appBuildPath := filepath.Join(path, "app", "build")
-				proguardOptions.AppManifest, err = android.FindAndroidManifest(appBuildPath, proguardOptions.Variant)
-				if err != nil {
-					logger.Warn(fmt.Sprintf("Unable to locate AndroidManifest.xml: %s", err.Error()))
-				}
+				proguardOptions.AppManifest, _ = android.FindAndroidManifest(appBuildPath, proguardOptions.Variant, logger)
 			}
 
 		} else {
@@ -71,10 +68,7 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 			if proguardOptions.AppManifest == "" && proguardOptions.Variant == "" {
 				appBuildPath := filepath.Join(path, "..", "..", "..", "..")
 				if filepath.Base(appBuildPath) == "build" {
-					proguardOptions.AppManifest, err = android.FindAndroidManifest(appBuildPath, proguardOptions.Variant)
-					if err != nil {
-						logger.Warn(fmt.Sprintf("Unable to locate AndroidManifest.xml: %s", err.Error()))
-					}
+					proguardOptions.AppManifest, _ = android.FindAndroidManifest(appBuildPath, proguardOptions.Variant, logger)
 				}
 			}
 		}

--- a/pkg/upload/android-proguard.go
+++ b/pkg/upload/android-proguard.go
@@ -57,7 +57,7 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 			// Attempt to locate AndroidManifest.xml for the variant if not set
 			if proguardOptions.AppManifest == "" {
 				appBuildPath := filepath.Join(path, "app", "build")
-				proguardOptions.AppManifest, _ = android.FindAndroidManifest(appBuildPath, proguardOptions.Variant, logger)
+				proguardOptions.AppManifest = android.FindAndroidManifest(appBuildPath, proguardOptions.Variant, logger)
 			}
 
 		} else {
@@ -68,7 +68,7 @@ func ProcessAndroidProguard(options options.CLI, logger log.Logger) error {
 			if proguardOptions.AppManifest == "" && proguardOptions.Variant == "" {
 				appBuildPath := filepath.Join(path, "..", "..", "..", "..")
 				if filepath.Base(appBuildPath) == "build" {
-					proguardOptions.AppManifest, _ = android.FindAndroidManifest(appBuildPath, proguardOptions.Variant, logger)
+					proguardOptions.AppManifest = android.FindAndroidManifest(appBuildPath, proguardOptions.Variant, logger)
 				}
 			}
 		}

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -118,10 +118,8 @@ func ProcessReactNativeAndroid(globalOptions options.CLI, logger log.Logger) err
 		}
 
 		if androidOptions.Android.AppManifest == "" {
-			androidOptions.Android.AppManifest, err = android.FindAndroidManifest(appBuildPath, androidOptions.Android.Variant)
-			if err != nil {
-				logger.Warn(fmt.Sprintf("Unable to locate AndroidManifest.xml: %s", err.Error()))
-			} else if androidOptions.Android.AppManifest != "" {
+			androidOptions.Android.AppManifest, err = android.FindAndroidManifest(appBuildPath, androidOptions.Android.Variant, logger)
+			if err == nil && androidOptions.Android.AppManifest != "" {
 				logger.Debug(fmt.Sprintf("Found app manifest at: %s", androidOptions.Android.AppManifest))
 			}
 		}

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -31,7 +31,6 @@ func ProcessReactNativeAndroid(globalOptions options.CLI, logger log.Logger) err
 	var variantDirName string
 	var bundleDirPath string
 	var variantFileFormat string
-	var appManifestPathExpected string
 
 	for _, path := range androidOptions.Path {
 
@@ -121,12 +120,9 @@ func ProcessReactNativeAndroid(globalOptions options.CLI, logger log.Logger) err
 		if androidOptions.Android.AppManifest == "" {
 			androidOptions.Android.AppManifest, err = android.FindAndroidManifest(appBuildPath, androidOptions.Android.Variant)
 			if err != nil {
-				return err
-			}
-			if androidOptions.Android.AppManifest != "" {
+				logger.Warn(fmt.Sprintf("Unable to locate AndroidManifest.xml: %s", err.Error()))
+			} else if androidOptions.Android.AppManifest != "" {
 				logger.Debug(fmt.Sprintf("Found app manifest at: %s", androidOptions.Android.AppManifest))
-			} else {
-				logger.Debug(fmt.Sprintf("No app manifest found at: %s", appManifestPathExpected))
 			}
 		}
 
@@ -135,28 +131,28 @@ func ProcessReactNativeAndroid(globalOptions options.CLI, logger log.Logger) err
 			manifestData, err := android.ParseAndroidManifestXML(androidOptions.Android.AppManifest)
 
 			if err != nil {
-				return err
-			}
-
-			if globalOptions.ApiKey == "" {
-				for key, value := range manifestData.Application.MetaData.Name {
-					if value == "com.bugsnag.android.API_KEY" {
-						globalOptions.ApiKey = manifestData.Application.MetaData.Value[key]
+				logger.Warn(fmt.Sprintf("Unable to read AndroidManifest.xml: %s", err.Error()))
+			} else {
+				if globalOptions.ApiKey == "" {
+					for key, value := range manifestData.Application.MetaData.Name {
+						if value == "com.bugsnag.android.API_KEY" {
+							globalOptions.ApiKey = manifestData.Application.MetaData.Value[key]
+						}
 					}
-				}
-				logger.Debug(fmt.Sprintf("Using %s as API key from AndroidManifest.xml", globalOptions.ApiKey))
-			}
-
-			// If we've not passed --code-bundle-id, proceed to populate versionName and versionCode from AndroidManifest.xml
-			if androidOptions.ReactNative.CodeBundleId == "" {
-				if androidOptions.ReactNative.VersionName == "" {
-					androidOptions.ReactNative.VersionName = manifestData.VersionName
-					logger.Debug(fmt.Sprintf("Using %s as version name from AndroidManifest.xml", androidOptions.ReactNative.VersionName))
+					logger.Debug(fmt.Sprintf("Using %s as API key from AndroidManifest.xml", globalOptions.ApiKey))
 				}
 
-				if androidOptions.Android.VersionCode == "" {
-					androidOptions.Android.VersionCode = manifestData.VersionCode
-					logger.Debug(fmt.Sprintf("Using %s as version code from AndroidManifest.xml", androidOptions.Android.VersionCode))
+				// If we've not passed --code-bundle-id, proceed to populate versionName and versionCode from AndroidManifest.xml
+				if androidOptions.ReactNative.CodeBundleId == "" {
+					if androidOptions.ReactNative.VersionName == "" {
+						androidOptions.ReactNative.VersionName = manifestData.VersionName
+						logger.Debug(fmt.Sprintf("Using %s as version name from AndroidManifest.xml", androidOptions.ReactNative.VersionName))
+					}
+
+					if androidOptions.Android.VersionCode == "" {
+						androidOptions.Android.VersionCode = manifestData.VersionCode
+						logger.Debug(fmt.Sprintf("Using %s as version code from AndroidManifest.xml", androidOptions.Android.VersionCode))
+					}
 				}
 			}
 		}

--- a/pkg/upload/react-native-android.go
+++ b/pkg/upload/react-native-android.go
@@ -118,10 +118,7 @@ func ProcessReactNativeAndroid(globalOptions options.CLI, logger log.Logger) err
 		}
 
 		if androidOptions.Android.AppManifest == "" {
-			androidOptions.Android.AppManifest, err = android.FindAndroidManifest(appBuildPath, androidOptions.Android.Variant, logger)
-			if err == nil && androidOptions.Android.AppManifest != "" {
-				logger.Debug(fmt.Sprintf("Found app manifest at: %s", androidOptions.Android.AppManifest))
-			}
+			androidOptions.Android.AppManifest = android.FindAndroidManifest(appBuildPath, androidOptions.Android.Variant, logger)
 		}
 
 		if androidOptions.Android.AppManifest != "" && (globalOptions.ApiKey == "" || androidOptions.ReactNative.VersionName == "" || androidOptions.Android.VersionCode == "") {

--- a/test/upload/android_manifest_test.go
+++ b/test/upload/android_manifest_test.go
@@ -1,0 +1,271 @@
+package upload_testing
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bugsnag/bugsnag-cli/pkg/options"
+	"github.com/bugsnag/bugsnag-cli/pkg/upload"
+	"github.com/stretchr/testify/assert"
+)
+
+// MockLogger implements the log.Logger interface for testing
+type MockLogger struct {
+	DebugMessages []string
+	InfoMessages  []string
+	WarnMessages  []string
+	ErrorMessages []string
+	FatalMessages []string
+}
+
+func NewMockLogger() *MockLogger {
+	return &MockLogger{
+		DebugMessages: []string{},
+		InfoMessages:  []string{},
+		WarnMessages:  []string{},
+		ErrorMessages: []string{},
+		FatalMessages: []string{},
+	}
+}
+
+func (m *MockLogger) Debug(msg string) {
+	m.DebugMessages = append(m.DebugMessages, msg)
+}
+
+func (m *MockLogger) Info(msg string) {
+	m.InfoMessages = append(m.InfoMessages, msg)
+}
+
+func (m *MockLogger) Warn(msg string) {
+	m.WarnMessages = append(m.WarnMessages, msg)
+}
+
+func (m *MockLogger) Error(msg string) {
+	m.ErrorMessages = append(m.ErrorMessages, msg)
+}
+
+func (m *MockLogger) Fatal(msg string) {
+	m.FatalMessages = append(m.FatalMessages, msg)
+}
+
+func (m *MockLogger) HasWarning(substring string) bool {
+	for _, msg := range m.WarnMessages {
+		if strings.Contains(msg, substring) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *MockLogger) HasDebug(substring string) bool {
+	for _, msg := range m.DebugMessages {
+		if strings.Contains(msg, substring) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *MockLogger) Reset() {
+	m.DebugMessages = []string{}
+	m.InfoMessages = []string{}
+	m.WarnMessages = []string{}
+	m.ErrorMessages = []string{}
+	m.FatalMessages = []string{}
+}
+
+// Test that ProcessAndroidProguard warns when AndroidManifest.xml cannot be found
+func TestProcessAndroidProguard_MissingManifest_Warns(t *testing.T) {
+	// Create a temporary directory structure without AndroidManifest.xml
+	tempDir := t.TempDir()
+	appDir := filepath.Join(tempDir, "app")
+	buildDir := filepath.Join(appDir, "build")
+	outputsDir := filepath.Join(buildDir, "outputs", "mapping", "release")
+
+	err := os.MkdirAll(outputsDir, 0755)
+	assert.NoError(t, err)
+
+	// Create a dummy mapping.txt file
+	mappingFile := filepath.Join(outputsDir, "mapping.txt")
+	err = os.WriteFile(mappingFile, []byte("# Proguard mapping file\n"), 0644)
+	assert.NoError(t, err)
+
+	logger := NewMockLogger()
+
+	opts := options.CLI{
+		Globals: options.Globals{
+			ApiKey: "test-api-key",
+		},
+		Upload: options.Upload{
+			AndroidProguard: options.AndroidProguardMapping{
+				Path:          []string{mappingFile},
+				Variant:       "release",
+				ApplicationId: "com.test.app",
+				VersionCode:   "1",
+				VersionName:   "1.0",
+			},
+		},
+	}
+
+	// This should not return an error, but should log a warning
+	err = upload.ProcessAndroidProguard(opts, logger)
+
+	// The function should complete without error even though manifest is missing
+	// Note: It may still fail due to actual upload but should not fail on manifest lookup
+	// For this test, we're primarily checking that warnings are logged
+	assert.True(t, len(logger.WarnMessages) > 0 || err != nil,
+		"Should either warn about missing manifest or fail for other reasons")
+}
+
+// Test that ProcessAndroidProguard warns when AndroidManifest.xml cannot be read
+func TestProcessAndroidProguard_UnreadableManifest_Warns(t *testing.T) {
+	// Create a temporary directory with an invalid manifest file
+	tempDir := t.TempDir()
+	appDir := filepath.Join(tempDir, "app")
+	buildDir := filepath.Join(appDir, "build")
+	outputsDir := filepath.Join(buildDir, "outputs", "mapping", "release")
+	manifestDir := filepath.Join(buildDir, "intermediates", "merged_manifests", "release")
+
+	err := os.MkdirAll(outputsDir, 0755)
+	assert.NoError(t, err)
+	err = os.MkdirAll(manifestDir, 0755)
+	assert.NoError(t, err)
+
+	// Create a dummy mapping.txt file
+	mappingFile := filepath.Join(outputsDir, "mapping.txt")
+	err = os.WriteFile(mappingFile, []byte("# Proguard mapping file\n"), 0644)
+	assert.NoError(t, err)
+
+	// Create an invalid manifest file
+	manifestFile := filepath.Join(manifestDir, "AndroidManifest.xml")
+	err = os.WriteFile(manifestFile, []byte("invalid xml content"), 0644)
+	assert.NoError(t, err)
+
+	logger := NewMockLogger()
+
+	opts := options.CLI{
+		Globals: options.Globals{
+			ApiKey: "test-api-key",
+		},
+		Upload: options.Upload{
+			AndroidProguard: options.AndroidProguardMapping{
+				Path:        []string{mappingFile},
+				Variant:     "release",
+				AppManifest: manifestFile,
+			},
+		},
+	}
+
+	// This should not return an error, but should log a warning about unable to read
+	err = upload.ProcessAndroidProguard(opts, logger)
+
+	// Check that a warning was logged about reading the manifest
+	// Note: Function may still fail for other reasons (like upload), but should warn about manifest
+	if err == nil {
+		assert.True(t, logger.HasWarning("Unable to read AndroidManifest.xml"),
+			"Should warn about unable to read manifest")
+	}
+}
+
+// Test that ProcessReactNativeAndroid warns when AndroidManifest.xml cannot be found
+func TestProcessReactNativeAndroid_MissingManifest_Warns(t *testing.T) {
+	tempDir := t.TempDir()
+	androidDir := filepath.Join(tempDir, "android")
+	appDir := filepath.Join(androidDir, "app")
+	buildDir := filepath.Join(appDir, "build")
+	assetsDir := filepath.Join(buildDir, "generated", "assets", "createBundleReleaseJsAndAssets")
+	sourcemapsDir := filepath.Join(buildDir, "generated", "sourcemaps", "react", "release")
+
+	err := os.MkdirAll(assetsDir, 0755)
+	assert.NoError(t, err)
+	err = os.MkdirAll(sourcemapsDir, 0755)
+	assert.NoError(t, err)
+
+	// Create dummy bundle and sourcemap files
+	bundleFile := filepath.Join(assetsDir, "index.android.bundle")
+	err = os.WriteFile(bundleFile, []byte("// bundle content"), 0644)
+	assert.NoError(t, err)
+
+	sourcemapFile := filepath.Join(sourcemapsDir, "index.android.bundle.map")
+	err = os.WriteFile(sourcemapFile, []byte("{}"), 0644)
+	assert.NoError(t, err)
+
+	logger := NewMockLogger()
+
+	opts := options.CLI{
+		Globals: options.Globals{
+			ApiKey: "test-api-key",
+		},
+		Upload: options.Upload{
+			ReactNativeAndroid: options.ReactNativeAndroid{
+				Path:        []string{tempDir},
+				ProjectRoot: tempDir,
+				Android: options.ReactNativeAndroidSpecific{
+					Variant:     "release",
+					VersionCode: "1",
+				},
+				ReactNative: options.ReactNativeShared{
+					Bundle:      bundleFile,
+					SourceMap:   sourcemapFile,
+					VersionName: "1.0",
+				},
+			},
+		},
+	}
+
+	// This should not return an error for missing manifest, but should log a warning
+	_ = upload.ProcessReactNativeAndroid(opts, logger)
+
+	// Check that a warning was logged about locating the manifest
+	hasManifestWarning := logger.HasWarning("Unable to locate AndroidManifest.xml")
+	if len(logger.WarnMessages) > 0 {
+		assert.True(t, hasManifestWarning,
+			"Should warn about unable to locate manifest if no API key provided")
+	}
+}
+
+// Test that logs debug message when manifest is successfully found
+func TestAndroidManifest_SuccessfulFind_LogsDebug(t *testing.T) {
+	// Use actual test fixtures if available
+	manifestPath := "../../features/android/fixtures/app/build/intermediates/merged_manifests/release/AndroidManifest.xml"
+
+	// Only run this test if the fixture exists
+	if _, err := os.Stat(manifestPath); os.IsNotExist(err) {
+		t.Skip("Test fixture not available")
+		return
+	}
+
+	logger := NewMockLogger()
+
+	// Test with a proguard upload that has a valid manifest
+	mappingPath := "../../features/android/fixtures/app/build/outputs/mapping/release/mapping.txt"
+	if _, err := os.Stat(mappingPath); os.IsNotExist(err) {
+		t.Skip("Test fixture not available")
+		return
+	}
+
+	opts := options.CLI{
+		Globals: options.Globals{
+			ApiKey: "test-api-key",
+		},
+		Upload: options.Upload{
+			AndroidProguard: options.AndroidProguardMapping{
+				Path:          []string{mappingPath},
+				Variant:       "release",
+				ApplicationId: "com.test.app",
+				VersionCode:   "1",
+				VersionName:   "1.0",
+			},
+		},
+	}
+
+	_ = upload.ProcessAndroidProguard(opts, logger)
+
+	// Should not have warnings about manifest issues
+	assert.False(t, logger.HasWarning("Unable to locate AndroidManifest.xml"),
+		"Should not warn when manifest can be found")
+	assert.False(t, logger.HasWarning("Unable to read AndroidManifest.xml"),
+		"Should not warn when manifest can be read")
+}

--- a/test/upload/android_ndk_test.go
+++ b/test/upload/android_ndk_test.go
@@ -1,0 +1,146 @@
+package upload_testing
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bugsnag/bugsnag-cli/pkg/options"
+	"github.com/bugsnag/bugsnag-cli/pkg/upload"
+	"github.com/stretchr/testify/assert"
+)
+
+// Note: The resolveAppManifestIfNeeded function is not exported, so we test it
+// indirectly through ProcessAndroidNdk
+
+func TestProcessAndroidNdk_MissingManifest_Warns(t *testing.T) {
+	// Create a temporary directory structure simulating merged_native_libs without manifest
+	tempDir := t.TempDir()
+	libPath := filepath.Join(tempDir, "app", "build", "intermediates", "merged_native_libs", "release", "out", "lib", "arm64-v8a")
+
+	err := os.MkdirAll(libPath, 0755)
+	assert.NoError(t, err)
+
+	// Create a dummy .so file
+	soFile := filepath.Join(libPath, "libnative.so")
+	err = os.WriteFile(soFile, []byte("dummy"), 0644)
+	assert.NoError(t, err)
+
+	logger := NewMockLogger()
+
+	opts := options.CLI{
+		Globals: options.Globals{
+			ApiKey: "test-api-key",
+		},
+		Upload: options.Upload{
+			AndroidNdk: options.AndroidNdkMapping{
+				Path:          []string{soFile},
+				Variant:       "release",
+				ApplicationId: "com.test.app",
+				VersionCode:   "1",
+				VersionName:   "1.0",
+			},
+		},
+	}
+
+	// Call ProcessAndroidNDK - it should warn about missing manifest but not error
+	_ = upload.ProcessAndroidNDK(opts, logger)
+
+	// Check that a warning was logged about missing manifest
+	hasWarning := logger.HasWarning("Unable to locate AndroidManifest.xml")
+	if !hasWarning {
+		// The test might fail for other reasons (e.g., invalid .so file)
+		// but we want to verify the warning behavior when it gets that far
+		t.Log("Warning about manifest may not have been reached due to earlier errors")
+		t.Log("Warnings:", logger.WarnMessages)
+	}
+}
+
+func TestProcessAndroidNdk_WithManifest_NoWarning(t *testing.T) {
+	// Use actual test fixture if available
+	fixturePath := "../../features/android/fixtures/app/build/intermediates/merged_native_libs/release/out/lib/arm64-v8a/libbugsnag-ndk.so"
+
+	if _, err := os.Stat(fixturePath); os.IsNotExist(err) {
+		t.Skip("Test fixture not available")
+		return
+	}
+
+	logger := NewMockLogger()
+
+	opts := options.CLI{
+		Globals: options.Globals{
+			ApiKey: "test-api-key",
+		},
+		Upload: options.Upload{
+			AndroidNdk: options.AndroidNdkMapping{
+				Path:          []string{fixturePath},
+				Variant:       "release",
+				ApplicationId: "com.test.app",
+				VersionCode:   "1",
+				VersionName:   "1.0",
+			},
+		},
+	}
+
+	_ = upload.ProcessAndroidNDK(opts, logger)
+
+	// Should not warn about manifest issues if manifest is found
+	// (though it may warn for other reasons)
+	hasManifestWarning := logger.HasWarning("Unable to locate AndroidManifest.xml") ||
+		logger.HasWarning("Unable to read AndroidManifest.xml")
+
+	if hasManifestWarning {
+		t.Errorf("Should not warn about manifest when it exists and is readable")
+		t.Log("Warnings:", logger.WarnMessages)
+	}
+}
+
+func TestProcessAndroidNdk_ManifestProvidedExplicitly_NoSearch(t *testing.T) {
+	// Create a temporary directory with a valid manifest
+	tempDir := t.TempDir()
+	libPath := filepath.Join(tempDir, "app", "build", "intermediates", "merged_native_libs", "release", "out", "lib", "arm64-v8a")
+	manifestPath := filepath.Join(tempDir, "AndroidManifest.xml")
+
+	err := os.MkdirAll(libPath, 0755)
+	assert.NoError(t, err)
+
+	// Create a minimal valid manifest
+	manifestContent := `<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.test.app"
+    android:versionCode="1"
+    android:versionName="1.0">
+</manifest>`
+
+	err = os.WriteFile(manifestPath, []byte(manifestContent), 0644)
+	assert.NoError(t, err)
+
+	// Create a dummy .so file
+	soFile := filepath.Join(libPath, "libnative.so")
+	err = os.WriteFile(soFile, []byte("dummy"), 0644)
+	assert.NoError(t, err)
+
+	logger := NewMockLogger()
+
+	opts := options.CLI{
+		Globals: options.Globals{
+			ApiKey: "test-api-key",
+		},
+		Upload: options.Upload{
+			AndroidNdk: options.AndroidNdkMapping{
+				Path:          []string{soFile},
+				AppManifest:   manifestPath,
+				Variant:       "release",
+				ApplicationId: "com.test.app",
+				VersionCode:   "1",
+				VersionName:   "1.0",
+			},
+		},
+	}
+
+	_ = upload.ProcessAndroidNDK(opts, logger)
+
+	// Should not warn about manifest since it was explicitly provided
+	assert.False(t, logger.HasWarning("Unable to locate AndroidManifest.xml"),
+		"Should not search for manifest when explicitly provided")
+}


### PR DESCRIPTION
### Changed

- Changed AndroidManifest.xml handling for Android-related uploads (NDK, Proguard, and React Native Android) to not error when the manifest file cannot be found or read. [#264](https://github.com/bugsnag/bugsnag-cli/pull/264)

- Add support for aarch64 in the install scripts [#260](https://github.com/bugsnag/bugsnag-cli/pull/260)
