### PR TITLE
Set default MR port and add testing docs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
-gem "bugsnag-maze-runner", "~> 10.11"
+gem "bugsnag-maze-runner", "~>11"
 gem 'cocoapods'

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,155 @@
+# Testing the BugSnag CLI
+
+## Initial setup
+
+Clone the repository and navigate to the project directory:
+
+```sh
+git clone git@github.com:bugsnag/bugsnag-cli.git
+cd bugsnag-cli
+```
+
+### Prerequisites
+
+- **Go** — Install via [Homebrew](https://brew.sh) or from [go.dev](https://go.dev/dl/):
+  ```sh
+  brew install golang
+  ```
+- **Ruby & Bundler** — Required for end-to-end tests:
+  ```sh
+  gem install bundler
+  bundle install
+  ```
+- **Node.js & npm** — Required for npm linting and JavaScript fixture builds.
+
+### Building the CLI
+
+Build for the host platform:
+
+```sh
+make build
+```
+
+Build for all platforms (Windows, Linux, macOS):
+
+```sh
+make build-all
+```
+
+## Unit tests
+
+Unit tests are written in Go and live under the `test/` directory, covering:
+
+- `android/` — AAB manifest parsing, DEX build IDs, NDK paths/versions, objcopy, variant listing
+- `endpoints/` — Endpoint configuration
+- `ios/` — Plist parsing
+- `options/` — Build metadata creation
+- `upload/` — Android manifest, Android NDK, Breakpad, Dart, and JS uploads
+- `utils/` — dSYM handling, file utilities, gzip compression
+
+Run all unit tests:
+
+```sh
+make unit-test
+```
+
+This executes `go test -race ./test/...` with output formatted via [gotestfmt](https://github.com/gotesttools/gotestfmt).
+
+## Linting
+
+### Go
+
+```sh
+make go-lint
+```
+
+Runs [golangci-lint](https://golangci-lint.run/) across the codebase.
+
+### Go formatting
+
+```sh
+make fmt
+```
+
+Applies `gofmt` to all Go source files.
+
+### npm
+
+```sh
+make npm-lint
+```
+
+Runs `npm-check` against the `js/` package to detect outdated or unused dependencies.
+
+## End-to-end tests
+
+End-to-end tests use [Bugsnag Maze Runner](https://github.com/bugsnag/maze-runner) with feature files under `features/`. Step definitions are in `features/steps/steps.rb`.
+
+### Test categories
+
+| Category | Feature files | Description |
+|---|---|---|
+| CLI | `features/cli/` | General CLI behaviour, `create-build`, `--exclude`, installation |
+| Android | `features/android/` | AAB, NDK, and ProGuard uploads |
+| Xcode / dSYM | `features/xcode/` | dSYM uploads, Xcode build/archive, Swift Package Manager |
+| JavaScript | `features/js/` | Source map uploads (Webpack 4 & 5, nested maps) |
+| Dart | `features/dart/` | Dart symbol uploads |
+| React Native | `features/react-native/` | Android & iOS React Native uploads |
+| Node.js | `features/node/` | Node.js source map uploads |
+| Unity | `features/unity/` | Android & iOS Unity uploads |
+| Breakpad | `features/breakpad/` | Breakpad symbol uploads |
+
+### Running end-to-end tests
+
+Ensure the CLI is built first (`make build`), then run a specific category:
+
+```sh
+bundle exec maze-runner features/<category>
+```
+
+For example:
+
+```sh
+bundle exec maze-runner features/cli
+bundle exec maze-runner features/xcode
+bundle exec maze-runner features/android
+```
+
+#### Maze Runner port
+
+The feature files reference `$MAZE_RUNNER_PORT` in upload/build API URLs. This defaults to `9339` if not set. To use a different port, export the variable before running tests:
+
+```sh
+export MAZE_RUNNER_PORT=9340
+bundle exec maze-runner features/cli
+```
+
+### Building test fixtures
+
+Some end-to-end tests require pre-built fixtures. Build them with:
+
+```sh
+make test-fixtures
+```
+
+Individual fixtures can also be built separately:
+
+```sh
+make features/base-fixtures/android       # Requires Android SDK / Gradle
+make features/base-fixtures/dart          # Requires Flutter SDK
+make features/base-fixtures/dsym          # Requires Xcode
+make features/base-fixtures/js-webpack4   # Requires Node.js
+make features/base-fixtures/js-webpack5   # Requires Node.js
+```
+
+## CI
+
+The project uses **Buildkite** for continuous integration. The pipeline (`.buildkite/pipeline.yml`) runs:
+
+1. License audit
+2. Build
+3. Go and npm linting
+4. Unit tests
+5. End-to-end tests across all categories
+
+CI runs on macOS agents. Unity tests use isolated macOS agents.

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,5 +1,6 @@
 BeforeAll do
   $api_key = '1234567890ABCDEF1234567890ABCDEF'
+  ENV['MAZE_RUNNER_PORT'] ||= '9339'
 end
 
 def run_output


### PR DESCRIPTION
## Goal

Improve developer onboarding and testing workflow by providing comprehensive testing documentation. The existing repository lacked clear guidance on how to run unit tests, end-to-end tests, linting, and build test fixtures, making it difficult for new contributors to understand the testing infrastructure.

## Design

Created a dedicated `TESTING.md` file that documents:
- Initial setup and prerequisites
- Building the CLI for different platforms
- Running unit tests across all test categories
- Running end-to-end tests with Maze Runner
- Building test fixtures for various platforms
- Linting and formatting commands
- CI pipeline overview

Updated `bugsnag-maze-runner` to v11 to ensure compatibility with the latest test framework features.

Added a default `MAZE_RUNNER_PORT` configuration to prevent port-related test failures when the environment variable is not explicitly set.

## Changeset

- **Added** `TESTING.md` — Complete testing documentation covering:
  - Prerequisites and setup instructions
  - Unit test structure and execution
  - End-to-end test categories and usage
  - Fixture building for Android, Dart, dSYM, JavaScript (Webpack 4 & 5)
  - Go and npm linting commands
  - CI pipeline description

- **Updated** `Gemfile` — Bumped `bugsnag-maze-runner` from `~> 10.11` to `~>11`

- **Updated** `features/support/env.rb` — Set default `MAZE_RUNNER_PORT` to `9339` if not already defined

## Testing

- Verified that all documented commands execute successfully
- Confirmed Maze Runner tests run with both default and custom `MAZE_RUNNER_PORT` values
- Validated that the Gemfile update does not break existing test suites
- Reviewed documentation for accuracy against the actual test infrastructure