### PR TITLE
Do not error when we can't find an xcode archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Ensure that we only search for an Xcarchive when we need to extract information from it. [#276](https://github.com/bugsnag/bugsnag-cli/pull/276)
+- Log a DEBUG message rather than error when we can't find a Xcode archive for React Native iOS. [#276](https://github.com/bugsnag/bugsnag-cli/pull/276)
 
 ## [3.9.0] - 2026-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Fixed
+
+- Ensure that we only search for an Xcarchive when we need to extract information from it. [#276](https://github.com/bugsnag/bugsnag-cli/pull/276)
+
 ## [3.9.0] - 2026-03-11
 
 ### Added

--- a/js/package.json
+++ b/js/package.json
@@ -41,6 +41,6 @@
   },
   "devDependencies": {
     "@types/node": "^25.0.3",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.2"
   }
 }

--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -27,7 +27,7 @@
 
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */

--- a/pkg/upload/react-native-ios.go
+++ b/pkg/upload/react-native-ios.go
@@ -93,7 +93,7 @@ func ProcessReactNativeIos(globalOptions options.CLI, logger log.Logger) error {
 				xcodeArchivePath, err = ios.GetLatestXcodeArchiveForScheme(iosOptions.Ios.Scheme)
 
 				if err != nil {
-					return fmt.Errorf("error locating latest Xcode archive from Xcode project (scheme: %s), please specify the xcarchive path directly using --xcarchive-path: %w", iosOptions.Ios.Scheme, err)
+					logger.Debug(fmt.Sprintf("Latest Xcode archive from Xcode project (scheme: %s) not found: %s", iosOptions.Ios.Scheme, err.Error()))
 				}
 			}
 


### PR DESCRIPTION
## Goal
Log a DEBUG message when we can't find an Xcode archive for React Native iOS rather than an error.

## Testing
Covered by CI