### PR TITLE
Rebase v3.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.10.1] - 2026-04-23
+
+### Fixed
+
+- Resolve API key parsing issue in Android Manifest; when multiple meta-data entries exist. [#281](https://github.com/bugsnag/bugsnag-cli/pull/281)
+
+
+
 ## [3.10.0] - 2026-03-31
 
 ### Changed

--- a/install.sh
+++ b/install.sh
@@ -107,7 +107,7 @@ display_help() {
 EOS
 }
 
-VERSION="3.10.0"
+VERSION="3.10.1"
 
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/cli",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "BugSnag CLI",
   "main": "dist/bugsnag-cli-wrapper.js",
   "types": "dist/bugsnag-cli-wrapper.d.ts",

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/bugsnag/bugsnag-cli/pkg/upload"
 )
 
-var package_version = "3.10.0"
+var package_version = "3.10.1"
 
 func main() {
 	commands := options.CLI{}


### PR DESCRIPTION
### Fixed

- Resolve API key parsing issue in Android Manifest; when multiple meta-data entries exist. [#281](https://github.com/bugsnag/bugsnag-cli/pull/281)

