### PR TITLE
Bump esbuild to 0.25.0

### DIFF
--- a/features/node/fixtures/package.json
+++ b/features/node/fixtures/package.json
@@ -2,7 +2,7 @@
   "name": "fixture",
   "private": true,
   "dependencies": {
-    "esbuild": "^0.21.0"
+    "esbuild": "0.25.0"
   },
   "scripts": {
     "clean": "rm -rf dist"


### PR DESCRIPTION
Update the esbuild dependency in features/node/fixtures/package.json from "^0.21.0" to "0.25.0" and remove the caret to pin the exact version. This updates the fixture to use the newer esbuild release.

## Goal

Address the reported security issue in esbuild’s dev server CORS behavior by ensuring our Node.js E2E fixture uses a patched esbuild version (0.25.0 or later). Pinning the exact version makes the fixture reproducible and avoids unintentionally pulling vulnerable/untested versions via a range.

## Design

Pin exact version ("0.25.0") instead of a caret range ("^0.21.0"):
Keeps CI and local runs deterministic (fixture builds won’t change based on whatever npm resolves at the time).
Ensures the fixture always uses the known patched version required by the remediation guidance.
Scope-limited change: update only the Node fixture dependency used by E2E tests, minimizing risk to the CLI itself.

## Changeset

Updated Node fixture dependency:
File: [package.json](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Change: esbuild from ^0.21.0 → 0.25.0
Also: removed the caret (^) to pin the dependency exactly.

## Testing

Run the following from the repo root:
1)Build the CLI (required before E2E):
make build
2)(Optional but recommended) Build test fixtures:
make test-fixtures
3)Install the Node fixture dependencies and build the fixture bundle:
cd features/node/fixtures
npm install
node build.js
4)Run Node E2E tests:
cd ../../..
bundle exec maze-runner features/node
5)Run Go unit tests to ensure no unrelated regressions:
make unit-test

