### PR TITLE
release v3.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
 # Changelog
 
+## [3.10.2] - 2026-06-03
+
+### Added
+
+- Support auto-discovery of hidden source maps (e.g., Vite with `sourcemaps: 'hidden'`) by falling back to `.map` suffix matching when no `sourceMappingURL` comment is found in bundle files. [#285](https://github.com/bugsnag/bugsnag-cli/issues/285)
+
+### Security
+
+- Bump esbuild to 0.25.0 to address CORS misconfiguration vulnerability in dev server.[#287](https://github.com/bugsnag/bugsnag-cli/pull/287)
+
 ## [3.10.1] - 2026-04-23
 
 ### Fixed
 
 - Resolve API key parsing issue in Android Manifest; when multiple meta-data entries exist. [#281](https://github.com/bugsnag/bugsnag-cli/pull/281)
-
 
 
 ## [3.10.0] - 2026-03-31

--- a/install.sh
+++ b/install.sh
@@ -107,7 +107,7 @@ display_help() {
 EOS
 }
 
-VERSION="3.10.1"
+VERSION="3.10.2"
 
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/cli",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "BugSnag CLI",
   "main": "dist/bugsnag-cli-wrapper.js",
   "types": "dist/bugsnag-cli-wrapper.d.ts",

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/bugsnag/bugsnag-cli/pkg/upload"
 )
 
-var package_version = "3.10.1"
+var package_version = "3.10.2"
 
 func main() {
 	commands := options.CLI{}


### PR DESCRIPTION

### Added

- Support auto-discovery of hidden source maps (e.g., Vite with `sourcemaps: 'hidden'`) by falling back to `.map` suffix matching when no `sourceMappingURL` comment is found in bundle files.

### Security

- Bump esbuild to 0.25.0 to address CORS misconfiguration vulnerability in dev server.
