### PR TITLE
Fix: This change ensures that bugsnag-cli finds all dex files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Fixed
+
+- This change ensures that bugsnag-cli finds all dex files
+
 ## [3.10.2] - 2026-06-03
 
 ### Added

--- a/pkg/android/get-variant.go
+++ b/pkg/android/get-variant.go
@@ -57,7 +57,7 @@ func FindVariantDexFiles(mappingFilePath string, variant string) []string {
 	buildRoot := filepath.Join(filepath.Dir(mappingFilePath), "..", "..", "..", "intermediates", "dex", variant)
 
 	if utils.IsDir(buildRoot) {
-		matches, _ := filepath.Glob(filepath.Join(buildRoot, "*", "classes.dex"))
+		matches, _ := filepath.Glob(filepath.Join(buildRoot, "*", "classes*.dex"))
 		return matches
 	}
 


### PR DESCRIPTION
## Fixed

- This change ensures that bugsnag-cli finds all dex files