### PR TITLE
Release v3.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
-## [Unreleased]
+## [3.10.3] - 2026-06-22
 
 ### Fixed
+
 - Correctly handle capitalization in fallback AndroidManifest.xml search path (e.g., processStagingReleaseManifest) to support case-sensitive filesystems like Linux/Alpine. Previously, the search used incorrect capitalization, causing manifest detection to fail on some systems.
+- Fix a project root path related issue to upload dysm file.[#292](https://github.com/bugsnag/bugsnag-cli/pull/292)
+
 ## [3.10.2] - 2026-06-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Correctly handle capitalization in fallback AndroidManifest.xml search path (e.g., processStagingReleaseManifest) to support case-sensitive filesystems like Linux/Alpine. Previously, the search used incorrect capitalization, causing manifest detection to fail on some systems.
+
 ## [3.10.1] - 2026-04-23
 
 ### Fixed

--- a/features/react-native/scripts/react-native/ios-utils.js
+++ b/features/react-native/scripts/react-native/ios-utils.js
@@ -69,6 +69,12 @@ module.exports = {
       '-allowProvisioningUpdates',
       'archive'
     ]
+    // React Native 0.75+ introduced SCRIPT_PHASE_BASED_BUILD_OPTIMIZATION which can cause archive export failures
+    // Disable it for compatibility
+    const rnVersion = parseFloat(process.env.RN_VERSION || '0.70')
+    if (rnVersion >= 0.75) {
+      archiveArgs.push('SCRIPT_PHASE_BASED_BUILD_OPTIMIZATION=NO')
+    }
 
     if (exportArchive) {
       archiveArgs.splice(8, 0, '-archivePath', `${fixtureDir}/reactnative.xcarchive`)

--- a/features/react-native/scripts/react-native/ios-utils.js
+++ b/features/react-native/scripts/react-native/ios-utils.js
@@ -71,10 +71,10 @@ module.exports = {
     ]
     // React Native 0.75+ introduced SCRIPT_PHASE_BASED_BUILD_OPTIMIZATION which can cause archive export failures
     // Disable it for compatibility
-    const rnVersion = parseFloat(process.env.RN_VERSION || '0.70')
-    if (rnVersion >= 0.75) {
-      archiveArgs.push('SCRIPT_PHASE_BASED_BUILD_OPTIMIZATION=NO')
-    }
+    // const rnVersion = parseFloat(process.env.RN_VERSION || '0.70')
+    // if (rnVersion >= 0.75) {
+    //   archiveArgs.push('SCRIPT_PHASE_BASED_BUILD_OPTIMIZATION=NO')
+    // }
 
     if (exportArchive) {
       archiveArgs.splice(8, 0, '-archivePath', `${fixtureDir}/reactnative.xcarchive`)

--- a/features/react-native/scripts/react-native/ios-utils.js
+++ b/features/react-native/scripts/react-native/ios-utils.js
@@ -69,12 +69,6 @@ module.exports = {
       '-allowProvisioningUpdates',
       'archive'
     ]
-    // React Native 0.75+ introduced SCRIPT_PHASE_BASED_BUILD_OPTIMIZATION which can cause archive export failures
-    // Disable it for compatibility
-    const rnVersion = parseFloat(process.env.RN_VERSION || '0.70')
-    if (rnVersion >= 0.75) {
-      archiveArgs.push('SCRIPT_PHASE_BASED_BUILD_OPTIMIZATION=NO')
-    }
 
     if (exportArchive) {
       archiveArgs.splice(8, 0, '-archivePath', `${fixtureDir}/reactnative.xcarchive`)
@@ -94,6 +88,11 @@ module.exports = {
         '-exportOptionsPlist',
         'exportOptions.plist'
       ]
+
+      const rnVersion = parseFloat(process.env.RN_VERSION || '0.70')
+      if (rnVersion >= 0.75) {
+        exportArgs.push('SCRIPT_PHASE_BASED_BUILD_OPTIMIZATION=NO')
+      }
 
       execFileSync('xcrun', exportArgs, { cwd: fixtureDir, stdio: 'inherit' })
     }

--- a/features/react-native/scripts/react-native/ios-utils.js
+++ b/features/react-native/scripts/react-native/ios-utils.js
@@ -69,6 +69,12 @@ module.exports = {
       '-allowProvisioningUpdates',
       'archive'
     ]
+    // React Native 0.75+ introduced SCRIPT_PHASE_BASED_BUILD_OPTIMIZATION which can cause archive export failures
+    // Disable it for compatibility
+    const rnVersion = parseFloat(process.env.RN_VERSION || '0.70')
+    if (rnVersion >= 0.75) {
+      archiveArgs.push('SCRIPT_PHASE_BASED_BUILD_OPTIMIZATION=NO')
+    }
 
     if (exportArchive) {
       archiveArgs.splice(8, 0, '-archivePath', `${fixtureDir}/reactnative.xcarchive`)
@@ -88,11 +94,6 @@ module.exports = {
         '-exportOptionsPlist',
         'exportOptions.plist'
       ]
-
-      const rnVersion = parseFloat(process.env.RN_VERSION || '0.70')
-      if (rnVersion >= 0.75) {
-        exportArgs.push('SCRIPT_PHASE_BASED_BUILD_OPTIMIZATION=NO')
-      }
 
       execFileSync('xcrun', exportArgs, { cwd: fixtureDir, stdio: 'inherit' })
     }

--- a/features/react-native/scripts/react-native/ios-utils.js
+++ b/features/react-native/scripts/react-native/ios-utils.js
@@ -69,12 +69,6 @@ module.exports = {
       '-allowProvisioningUpdates',
       'archive'
     ]
-    // React Native 0.75+ introduced SCRIPT_PHASE_BASED_BUILD_OPTIMIZATION which can cause archive export failures
-    // Disable it for compatibility
-    // const rnVersion = parseFloat(process.env.RN_VERSION || '0.70')
-    // if (rnVersion >= 0.75) {
-    //   archiveArgs.push('SCRIPT_PHASE_BASED_BUILD_OPTIMIZATION=NO')
-    // }
 
     if (exportArchive) {
       archiveArgs.splice(8, 0, '-archivePath', `${fixtureDir}/reactnative.xcarchive`)

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -367,6 +367,9 @@ Before('@BuildRNAndroid') do
       ENV['BUNDLE_PATH'] = "#{base_path}/generated/assets/react/release/index.android.bundle"
     when 0.71
       ENV['BUNDLE_PATH'] = "#{base_path}/ASSETS/createBundleReleaseJsAndAssets/index.android.bundle"
+    when 0.73, 0.74
+      # RN 0.73 and 0.74 use the same path structure as 0.72+
+      ENV['BUNDLE_PATH'] = "#{base_path}/generated/assets/createBundleReleaseJsAndAssets/index.android.bundle"
     when 0.75
       ENV['APP_MANIFEST_PATH'] = "#{base_path}/intermediates/merged_manifests/release/processReleaseManifest/AndroidManifest.xml"
     end

--- a/features/steps/steps.rb
+++ b/features/steps/steps.rb
@@ -164,6 +164,13 @@ Then('the sourcemap payload field "minifiedFile" is not empty') do
   Maze.check.not_equal(Maze::Server.sourcemaps.current[:body]['minifiedFile'].length, 0)
 end
 
+Then('the sourcemap payload field {string} is an absolute path') do |field|
+  value = Maze::Server.sourcemaps.current[:body][field]
+  is_absolute = value.start_with?('/')
+  Maze.check.true(is_absolute,
+    "Expected sourcemap field '#{field}' to be an absolute path, but got '#{value}'")
+end
+
 Then('{string} should be used as {string}') do |value, field|
   Maze.check.include(run_output, "Using #{value} as #{field} from")
 end

--- a/features/unity/ios.feature
+++ b/features/unity/ios.feature
@@ -3,7 +3,7 @@ Feature: Unity iOS integration tests
     Given I build the Unity project for iOS
     And I wait for the build to succeed
 
-    When I run bugsnag-cli with upload unity-ios --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --no-upload-il2cpp-mapping platforms-examples/Unity/UnityExample/
+    When I run bugsnag-cli with upload unity-ios --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite --no-upload-il2cpp-mapping platforms-examples/Unity/
     Then I wait to receive 2 sourcemaps
     Then the sourcemap is valid for the dSYM Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
@@ -13,7 +13,7 @@ Feature: Unity iOS integration tests
     Given I build the Unity project for iOS
     And I wait for the build to succeed
 
-    When I run bugsnag-cli with upload unity-ios --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite platforms-examples/Unity/UnityExample/
+    When I run bugsnag-cli with upload unity-ios --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite platforms-examples/Unity/
     Then I wait to receive 3 sourcemaps
 
     Then the sourcemap is valid for the dSYM Build API
@@ -42,7 +42,7 @@ Feature: Unity iOS integration tests
     Given I build the Unity project for iOS
     And I wait for the build to succeed
 
-    When I run bugsnag-cli with upload unity-ios --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite platforms-examples/Unity/UnityExample/ --application-id=com.bugsnag.unity.test --bundle-version=999.99 --version-name=123.456
+    When I run bugsnag-cli with upload unity-ios --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --overwrite platforms-examples/Unity/ --application-id=com.bugsnag.unity.test --bundle-version=999.99 --version-name=123.456
     Then I wait to receive 3 sourcemaps
 
     Then the sourcemap is valid for the dSYM Build API

--- a/features/xcode/dsym.feature
+++ b/features/xcode/dsym.feature
@@ -14,3 +14,39 @@ Feature: dSYM Integration Tests
     Then the sourcemap is valid for the dSYM Build API
     Then the sourcemaps Content-Type header is valid multipart form-data
     And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
+
+  @PathNormalization @AutoDetect @BugFix1
+  Scenario: Upload dSYM with auto-detected project-root (omit flag - defaults to current directory)
+    When I run bugsnag-cli with upload dsym --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF features/base-fixtures/dsym/
+    And I wait to receive 1 sourcemaps
+    Then the sourcemap is valid for the dSYM Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
+    And the sourcemap payload field "projectRoot" is an absolute path
+
+  @PathNormalization @AbsolutePathWithSlash @BugFix2
+  Scenario: Upload dSYM with absolute project-root (WITH leading slash)
+    When I run bugsnag-cli with upload dsym --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=/Users/user_name/project/sub-project features/base-fixtures/dsym/
+    And I wait to receive 1 sourcemaps
+    Then the sourcemap is valid for the dSYM Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
+    And the sourcemap payload field "projectRoot" equals "/Users/user_name/project/sub-project"
+
+  @PathNormalization @RelativePathWithoutSlash @BugFix2
+  Scenario: Upload dSYM with relative project-root (WITHOUT leading slash - normalized to absolute)
+    When I run bugsnag-cli with upload dsym --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=Users/user_name/project/sub-project features/base-fixtures/dsym/
+    And I wait to receive 1 sourcemaps
+    Then the sourcemap is valid for the dSYM Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
+    And the sourcemap payload field "projectRoot" equals "/Users/user_name/project/sub-project"
+
+  @PathNormalization @RelativePathWithDot @BugFix2
+  Scenario: Upload dSYM with relative project-root starting with dot (normalized to absolute)
+    When I run bugsnag-cli with upload dsym --upload-api-root-url=http://localhost:$MAZE_RUNNER_PORT --api-key=1234567890ABCDEF1234567890ABCDEF --project-root=./features/base-fixtures features/base-fixtures/dsym/
+    And I wait to receive 1 sourcemaps
+    Then the sourcemap is valid for the dSYM Build API
+    Then the sourcemaps Content-Type header is valid multipart form-data
+    And the sourcemap payload field "apiKey" equals "1234567890ABCDEF1234567890ABCDEF"
+    And the sourcemap payload field "projectRoot" is an absolute path

--- a/install.sh
+++ b/install.sh
@@ -107,7 +107,7 @@ display_help() {
 EOS
 }
 
-VERSION="3.10.2"
+VERSION="3.10.3"
 
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do

--- a/js/package.json
+++ b/js/package.json
@@ -40,7 +40,7 @@
     "prepublish": "npm run build && cp bin/bugsnag-cli-placeholder bin/bugsnag-cli"
   },
   "devDependencies": {
-    "@types/node": "^25.0.3",
+    "@types/node": "^26.0.0",
     "typescript": "^6.0.2"
   }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/cli",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "description": "BugSnag CLI",
   "main": "dist/bugsnag-cli-wrapper.js",
   "types": "dist/bugsnag-cli-wrapper.d.ts",

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/bugsnag/bugsnag-cli/pkg/upload"
 )
 
-var package_version = "3.10.2"
+var package_version = "3.10.3"
 
 func main() {
 	commands := options.CLI{}

--- a/pkg/android/find-android-manifest.go
+++ b/pkg/android/find-android-manifest.go
@@ -1,12 +1,23 @@
 package android
 
+package android
+
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/bugsnag/bugsnag-cli/pkg/log"
 	"github.com/bugsnag/bugsnag-cli/pkg/utils"
 )
+
+// capitalizeFirstLetter returns the input string with the first letter capitalized.
+func capitalizeFirstLetter(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
 
 // FindAndroidManifest locates and returns the first existing AndroidManifest.xml
 // for a given build directory and variant.
@@ -39,7 +50,9 @@ func FindAndroidManifest(appBuildPath string, variant string, logger log.Logger)
 
 	primaryAppManifestPath := filepath.Join(mergedManifestPath, variant, "AndroidManifest.xml")
 
-	fallbackAppManifestPath := filepath.Join(mergedManifestPath, variant, "process"+variant+"Manifest", "AndroidManifest.xml")
+	// Fix: Capitalize first letter of variant for fallback path
+	capitalizedVariant := capitalizeFirstLetter(variant)
+	fallbackAppManifestPath := filepath.Join(mergedManifestPath, variant, "process"+capitalizedVariant+"Manifest", "AndroidManifest.xml")
 
 	paths := []string{primaryAppManifestPath, fallbackAppManifestPath}
 
@@ -55,3 +68,13 @@ func FindAndroidManifest(appBuildPath string, variant string, logger log.Logger)
 	logger.Info(fmt.Sprintf("No AndroidManifest.xml located for variant %s", variant))
 	return ""
 }
+
+		} else {
+			logger.Debug(fmt.Sprintf("AndroidManifest.xml not found at: %s", path))
+		}
+	}
+
+	logger.Info(fmt.Sprintf("No AndroidManifest.xml located for variant %s", variant))
+	return ""
+}
+

--- a/pkg/android/find-android-manifest.go
+++ b/pkg/android/find-android-manifest.go
@@ -1,7 +1,5 @@
 package android
 
-package android
-
 import (
 	"fmt"
 	"path/filepath"
@@ -68,13 +66,3 @@ func FindAndroidManifest(appBuildPath string, variant string, logger log.Logger)
 	logger.Info(fmt.Sprintf("No AndroidManifest.xml located for variant %s", variant))
 	return ""
 }
-
-		} else {
-			logger.Debug(fmt.Sprintf("AndroidManifest.xml not found at: %s", path))
-		}
-	}
-
-	logger.Info(fmt.Sprintf("No AndroidManifest.xml located for variant %s", variant))
-	return ""
-}
-

--- a/pkg/ios/xcarchive.go
+++ b/pkg/ios/xcarchive.go
@@ -103,6 +103,7 @@ func GetLatestXcodeArchiveForScheme(scheme string) (string, error) {
 
 // FindXcarchivePath searches for an Xcode archive (.xcarchive) within the provided paths.
 // If a directory is given, it attempts to locate the latest archive associated with a scheme.
+// First checks the local build/ directory, then falls back to system archives.
 //
 // Parameters:
 // - options: CLI options containing upload paths and shared settings.
@@ -126,6 +127,21 @@ func FindXcarchivePath(options options.CLI, logger log.Logger) (string, error) {
 			// If the path is a directory, search for an Xcode archive inside it
 			logger.Info(fmt.Sprintf("Searching for an Xcode archive in %s", path))
 
+			// First check for archives in local build directory
+			localBuildPath := filepath.Join(path, "build")
+			if utils.IsDir(localBuildPath) {
+				entries, err := os.ReadDir(localBuildPath)
+				if err == nil {
+					for _, entry := range entries {
+						if entry.IsDir() && strings.HasSuffix(entry.Name(), ".xcarchive") {
+							xcarchivePath = filepath.Join(localBuildPath, entry.Name())
+							logger.Info(fmt.Sprintf("Found Xcode archive in local build directory: %s", xcarchivePath))
+							return xcarchivePath, nil
+						}
+					}
+				}
+			}
+
 			// Check if the directory contains an Xcode project or workspace
 			if IsPathAnXcodeProjectOrWorkspace(path) {
 				// Determine the scheme if it is not set
@@ -136,7 +152,7 @@ func FindXcarchivePath(options options.CLI, logger log.Logger) (string, error) {
 					}
 				}
 
-				// Retrieve the latest Xcode archive for the determined scheme
+				// Retrieve the latest Xcode archive for the determined scheme from system archives
 				xcarchivePath, _ = GetLatestXcodeArchiveForScheme(options.Upload.XcodeArchive.Shared.Scheme)
 			}
 		}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -85,7 +85,7 @@ type DsymShared struct {
 	IgnoreMissingDwarf bool       `help:"Throw warnings instead of errors when a dSYM with missing DWARF data is found"`
 	Configuration      string     `help:"The configuration used to build the application"`
 	Scheme             string     `help:"The name of the Xcode options.Scheme used to build the application"`
-	ProjectRoot        string     `help:"The path to strip from the beginning of source file names referenced in stacktraces on the BugSnag dashboard" type:"path"`
+	ProjectRoot        string     `help:"The path to strip from the beginning of source file names referenced in stacktraces on the BugSnag dashboard" default:"."`
 	Plist              utils.Path `help:"The path to a .plist file from which to obtain build information" type:"path"`
 	XcodeProject       utils.Path `help:"The path to an Xcode project, workspace or containing directory from which to obtain build information" type:"path"`
 }

--- a/pkg/utils/upload-options.go
+++ b/pkg/utils/upload-options.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"fmt"
+	"path/filepath"
+	"strings"
 )
 
 // BuildDartUploadOptions - Builds the upload options for processing dart files
@@ -73,9 +75,37 @@ func BuildAndroidProguardUploadOptions(applicationId string, versionName string,
 func BuildDsymUploadOptions(projectRoot string) (map[string]string, error) {
 	uploadOptions := make(map[string]string)
 
-	uploadOptions["projectRoot"] = projectRoot
+	// Normalize projectRoot to absolute path
+	normalizedRoot := normalizeProjectRoot(projectRoot)
+	if normalizedRoot != "" {
+		uploadOptions["projectRoot"] = normalizedRoot
+	}
 
 	return uploadOptions, nil
+}
+
+// normalizeProjectRoot converts a path to absolute, handling various input formats.
+// - If path starts with "/", it's already absolute, use as-is
+// - If path starts with ".", it's relative to CWD, convert to absolute
+// - Otherwise, treat as absolute path missing leading slash, prepend "/"
+func normalizeProjectRoot(projectRoot string) string {
+	if projectRoot == "" {
+		return ""
+	}
+
+	// Already absolute path (starts with /)
+	if strings.HasPrefix(projectRoot, "/") {
+		return projectRoot
+	}
+
+	// Relative path (starts with . or /) - convert to absolute
+	if strings.HasPrefix(projectRoot, ".") {
+		abs, _ := filepath.Abs(projectRoot)
+		return abs
+	}
+
+	// Path without leading slash - treat as absolute, prepend /
+	return "/" + projectRoot
 }
 
 func BuildJsUploadOptions(versionName string, codeBundleId string, bundleUrl string, projectRoot string, overwrite bool) (map[string]string, error) {


### PR DESCRIPTION
### Fixed

- Correctly handle capitalization in fallback AndroidManifest.xml search path (e.g., processStagingReleaseManifest) to support case-sensitive filesystems like Linux/Alpine. Previously, the search used incorrect capitalisation, causing manifest detection to fail on some systems.
- Fix a project root path related issue to upload dysm file.

