### PR TITLE
Main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
-## [Unreleased]
+## [3.10.3] - 2026-06-22
 
 ### Fixed
+
 - Correctly handle capitalization in fallback AndroidManifest.xml search path (e.g., processStagingReleaseManifest) to support case-sensitive filesystems like Linux/Alpine. Previously, the search used incorrect capitalization, causing manifest detection to fail on some systems.
+- Fix a project root path related issue to upload dysm file.[#292](https://github.com/bugsnag/bugsnag-cli/pull/292)
+
 ## [3.10.2] - 2026-06-03
 
 ### Added

--- a/install.sh
+++ b/install.sh
@@ -107,7 +107,7 @@ display_help() {
 EOS
 }
 
-VERSION="3.10.2"
+VERSION="3.10.3"
 
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/cli",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "description": "BugSnag CLI",
   "main": "dist/bugsnag-cli-wrapper.js",
   "types": "dist/bugsnag-cli-wrapper.d.ts",

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/bugsnag/bugsnag-cli/pkg/upload"
 )
 
-var package_version = "3.10.2"
+var package_version = "3.10.3"
 
 func main() {
 	commands := options.CLI{}


### PR DESCRIPTION
### Fixed

- Correctly handle capitalization in fallback AndroidManifest.xml search path (e.g., processStagingReleaseManifest) to support case-sensitive filesystems like Linux/Alpine. Previously, the search used incorrect capitalization, causing manifest detection to fail on some systems.
- Fix a project root path related issue to upload dysm file.

