### PR TITLE
Release v3.10.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ package-lock.json
 maze_output/
 maze-runner.log
 features/android/fixtures/app/build/outputs/mapping/release/mapping.txt.gz
+.pre-commit-config.yaml
+.gitleaks.toml
+.gitleaks-baseline.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.10.4] - 2026-07-22
+
+### Security
+
+- Bump Go toolchain version from 1.26.1 to 1.26.3.
+- Bump TypeScript version in the JS wrapper package from 6.0.2 to 7.0.2.
+
+
 ## [3.10.3] - 2026-06-22
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bugsnag/bugsnag-cli
 
-go 1.26.1
+go 1.26.3
 
 require (
 	github.com/alecthomas/kong v0.7.1

--- a/install.sh
+++ b/install.sh
@@ -107,7 +107,7 @@ display_help() {
 EOS
 }
 
-VERSION="3.10.3"
+VERSION="3.10.4"
 
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do

--- a/js/package.json
+++ b/js/package.json
@@ -41,6 +41,6 @@
   },
   "devDependencies": {
     "@types/node": "^26.0.0",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugsnag/cli",
-  "version": "3.10.3",
+  "version": "3.10.4",
   "description": "BugSnag CLI",
   "main": "dist/bugsnag-cli-wrapper.js",
   "types": "dist/bugsnag-cli-wrapper.d.ts",

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/bugsnag/bugsnag-cli/pkg/upload"
 )
 
-var package_version = "3.10.3"
+var package_version = "3.10.4"
 
 func main() {
 	commands := options.CLI{}


### PR DESCRIPTION
### Security

- Bump Go toolchain version from 1.26.1 to 1.26.3.
- Bump TypeScript version in the JS wrapper package from 6.0.2 to 7.0.2.